### PR TITLE
Restructure FeOs project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/target
+target
+docs/_build
+docs/api/generated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,8 @@ version = "0.2.1"
 dependencies = [
  "feos-core",
  "feos-dft",
- "feos-estimator",
+ "feos-estimator 0.1.0 (git+https://github.com/feos-org/feos-estimator?tag=v0.1.0)",
+ "feos-fcsaft",
  "feos-gc-pcsaft",
  "feos-pcsaft",
  "feos-pets",
@@ -196,6 +197,18 @@ dependencies = [
 [[package]]
 name = "feos-estimator"
 version = "0.1.0"
+dependencies = [
+ "feos-core",
+ "ndarray",
+ "numpy",
+ "pyo3",
+ "quantity",
+ "thiserror",
+]
+
+[[package]]
+name = "feos-estimator"
+version = "0.1.0"
 source = "git+https://github.com/feos-org/feos-estimator?tag=v0.1.0#db0d45050854e9014fbc984667c1fc6a6b54f6bb"
 dependencies = [
  "feos-core",
@@ -204,6 +217,23 @@ dependencies = [
  "pyo3",
  "quantity",
  "thiserror",
+]
+
+[[package]]
+name = "feos-fcsaft"
+version = "0.1.0"
+dependencies = [
+ "feos-core",
+ "feos-estimator 0.1.0",
+ "indexmap",
+ "ndarray",
+ "num-dual",
+ "numpy",
+ "petgraph",
+ "pyo3",
+ "quantity",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,41 @@ repository = "https://github.com/feos-org/feos"
 keywords = ["physics", "thermodynamics", "equations_of_state", "phase_equilibria", "density_functional_theory"]
 categories = ["science"]
 
+[workspace]
+members = ["feos-core", "feos-dft"]
+
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
 quantity = "0.5"
-feos-core = "0.2"
-feos-dft = "0.2"
-feos-pcsaft = { version = "0.2", features = ["python"] }
-feos-gc-pcsaft = { version = "0.1", features = ["python"] }
-feos-fcsaft = { path = "../feos-fcsaft", features = ["python"] }
-feos-pets = { version = "0.1", features = ["python"] }
-feos-uvtheory = { git = "https://github.com/feos-org/feos-uvtheory", features = ["python"], tag = "v0.1.0" }
-feos-estimator = { git = "https://github.com/feos-org/feos-estimator", features = ["python"], tag = "v0.1.0" }
-numpy = "0.16"
-ndarray = { version = "0.15", features=["approx"] }
+num-dual = "0.5"
+feos-core = { version = "0.2", path = "feos-core" }
+feos-dft = { version = "0.2", path = "feos-dft", optional = true }
+#feos-gc-pcsaft = { version = "0.1", features = ["python"] }
+#feos-fcsaft = { path = "../feos-fcsaft", features = ["python"] }
+#feos-pets = { version = "0.1", features = ["python"] }
+#feos-uvtheory = { git = "https://github.com/feos-org/feos-uvtheory", features = ["python"], tag = "v0.1.0" }
+numpy = { version = "0.16", optional = true }
+ndarray = { version = "0.15", features = ["approx"] }
 petgraph = "0.6"
+thiserror = "1.0"
+conv = "0.3"
+num-traits = "0.2"
+serde = "1.0"
+serde_json = "1.0"
 
 [dependencies.pyo3]
 version = "0.16"
 features = ["extension-module", "abi3", "abi3-py37"]
+optional = true
+
+[dev-dependencies]
+approx = "0.4"
+
+[features]
+default = ["fit", "pcsaft"]
+dft = ["feos-dft"]
+fit = []
+pcsaft = []
+python = ["pyo3", "numpy", "feos-core/python", "feos-dft?/python"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ feos-core = "0.2"
 feos-dft = "0.2"
 feos-pcsaft = { version = "0.2", features = ["python"] }
 feos-gc-pcsaft = { version = "0.1", features = ["python"] }
+feos-fcsaft = { path = "../feos-fcsaft", features = ["python"] }
 feos-pets = { version = "0.1", features = ["python"] }
 feos-uvtheory = { git = "https://github.com/feos-org/feos-uvtheory", features = ["python"], tag = "v0.1.0" }
 feos-estimator = { git = "https://github.com/feos-org/feos-estimator", features = ["python"], tag = "v0.1.0" }

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -1,0 +1,107 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+### Added
+- Added `pure_records` getter in the `impl_parameter` macro. [#54](https://github.com/feos-org/feos-core/pull/54)
+- Implemented `Deref` and `IntoIterator` for `StateVec` for additional vector functionalities of the `StateVec`. [#55](https://github.com/feos-org/feos-core/pull/55) 
+- Added `StateVec.__len__` and `StateVec.__getitem__` to allow indexing and iterating over `StateVec`s in Python. [#55](https://github.com/feos-org/feos-core/pull/55)
+- Added `SegmentCount` trait that allows the construction of parameter sets from arbitrary chemical records. [#56](https://github.com/feos-org/feos-core/pull/56)
+- Added `ParameterHetero` trait to generically provide utility functions for parameter sets of heterosegmented Helmholtz energy models. [#56](https://github.com/feos-org/feos-core/pull/56)
+
+### Changed
+- Changed datatype for binary parameters in interfaces of the `from_records` and `new_binary` methods for parameters to take either numpy arrays of `f64` or a list of `BinaryRecord` as input. [#54](https://github.com/feos-org/feos-core/pull/54)
+- Modified `PhaseDiagram.to_dict` function in Python to account for pure components and mixtures. [#55](https://github.com/feos-org/feos-core/pull/55)
+- Changed `StateVec` to a tuple struct. [#55](https://github.com/feos-org/feos-core/pull/55)
+- Made `cas` field of `Identifier` optional. [#56](https://github.com/feos-org/feos-core/pull/56)
+- Added type parameter to `FromSegments` and made its `from_segments` function fallible for more control over model limitations. [#56](https://github.com/feos-org/feos-core/pull/56)
+- Reverted `ChemicalRecord` back to a struct that only contains the structural information (and not segment and bond counts). [#56](https://github.com/feos-org/feos-core/pull/56)
+- Made `IdentifierOption` directly usable in Python using `PyO3`'s new `#[pyclass]` for fieldless enums feature. [#58](https://github.com/feos-org/feos-core/pull/58)
+
+## [0.2.0] - 2022-04-12
+### Added
+- Added conversions between `ParameterError` and `EosError` to improve the error messages in some cases. [#40](https://github.com/feos-org/feos-core/pull/40)
+- Added new struct `StateVec`, that gives easy access to properties of lists of states, e.g. in phase diagrams. [#48](https://github.com/feos-org/feos-core/pull/48)
+- Added `ln_symmetric_activity_coefficient` and `ln_phi_pure` to the list of state properties that can be calculated. [#50](https://github.com/feos-org/feos-core/pull/50)
+
+### Changed
+- Removed `State` from `EntropyScaling` trait and adjusted associated methods to use temperature, volume and moles instead of state. [#36](https://github.com/feos-org/feos-core/pull/36)
+- Replaced the outer loop iterations for the critical point of binary systems with dedicated algorithms. [#34](https://github.com/feos-org/feos-core/pull/34)
+- Renamed `VLEOptions` to `SolverOptions`. [#38](https://github.com/feos-org/feos-core/pull/38)
+- Renamed methods of `StateBuilder` and the parameters in the `State` constructor in python to `molar_enthalpy`, `molar_entropy`, and `molar_internal_energy`.  [#35](https://github.com/feos-org/feos-core/pull/35)
+- Removed `PyContributions` and `PyVerbosity` in favor of a simpler implementation using `PyO3`'s new `#[pyclass]` for fieldless enums feature. [#41](https://github.com/feos-org/feos-core/pull/41)
+- Renamed `Contributions::Residual` to `Contributions::ResidualNvt` and `Contributions::ResidualP` to `Contributions::ResidualNpt`. [#43](https://github.com/feos-org/feos-core/pull/43)
+- Renamed macro `impl_vle_state!` to `impl_phase_equilibrium!`. [#48](https://github.com/feos-org/feos-core/pull/48)
+- Removed `_t` and `_p` functions in favor of simpler interfaces. The kind of specification (temperature or pressure) is determined from the unit of the argument. [#48](https://github.com/feos-org/feos-core/pull/48)
+  - `PhaseEquilibrium::pure_t`, `PhaseEquilibrium::pure_p` -> `PhaseEquilibrium::pure`
+  - `PhaseEquilibrium::vle_pure_comps_t`, `PhaseEquilibrium::vle_pure_comps_p` -> `PhaseEquilibrium::vle_pure_comps`\
+  The `PhaseEquilibria` returned by this function now have the same number of components as the (mixture) eos, that it is called with.
+  - `PhaseEquilibrium::bubble_point_tx`, `PhaseEquilibrium::bubble_point_px` -> `PhaseEquilibrium::bubble_point`
+  - `PhaseEquilibrium::dew_point_tx`, `PhaseEquilibrium::dew_point_px` -> `PhaseEquilibrium::dew_point`
+  - `PhaseEquilibrium::heteroazeotrope_t`, `PhaseEquilibrium::heteroazeotrope_p` -> `PhaseEquilibrium::heteroazeotrope`
+  - `State::critical_point_binary_t`, `State::critical_point_binary_p` -> `State::crititcal_point_binary`
+- Combined `PhaseDiagramPure` and `PhaseDiagramBinary` into a single struct `PhaseDiagram` and renamed its constructors.  Properties of the phase diagram are available from the `vapor` and `liquid` getters, that return `StateVec`s. [#48](https://github.com/feos-org/feos-core/pull/48)
+  - `PhaseDiagramPure::new` -> `PhaseDiagram::pure`
+  - `PhaseDiagramBinary::new_txy`, `PhaseDiagramBinary::new_pxy` -> `PhaseDiagram::binary_vle`
+  - `PhaseDiagramBinary::new_txy_lle`, `PhaseDiagramBinary::new_pxy_lle` -> `PhaseDiagram::lle`
+  - `PhaseDiagramHetero::new_txy`, `PhaseDiagramHetero::new_pxy` -> `PhaseDiagram::binary_vlle`\
+  which still returns an instance of `PhaseDiagramHetero`
+- Changed the internal implementation of the Peng-Robinson equation of state to use contributions like the more complex equations of state and removed the suggestion to overwrite the `evaluate_residual` function of `EquationOfState`. [#51](https://github.com/feos-org/feos-core/pull/51)
+- Moved the creation of the python module to the `build_wheel` auxilliary crate, so that only the relevant structs and macros are available for the dependents. [#47](https://github.com/feos-org/feos-core/pull/47)
+
+### Removed
+- Removed the `utils` module containing `DataSet` and `Estimator` in favor of a separate crate. [#47](https://github.com/feos-org/feos-core/pull/47)
+
+### Packaging
+- Updated `pyo3` and `numpy` dependencies to 0.16.
+- Updated `num-dual` dependency to 0.5.
+- Updated `quantity` dependency to 0.5.
+
+## [0.1.5] - 2022-02-21
+### Fixed
+- Fixed bug in `predict` of `Estimator`. [#30](https://github.com/feos-org/feos-core/pull/30)
+
+### Added
+- Add `pyproject.toml`. [#29](https://github.com/feos-org/feos-core/pull/29)
+
+## [0.1.4] - 2022-02-18
+### Fixed
+- Fix state constructor for `T`, `p`, `V`, `x_i` specification. [#26](https://github.com/feos-org/feos-core/pull/26)
+
+### Added
+- Added method `predict` to `Estimator`. [#27](https://github.com/feos-org/feos-core/pull/27)
+
+### Changed
+- Changed method for vapor pressure in `DataSet` to `vapor_pressure` (was `pressure` of VLE liquid phase). [#27](https://github.com/feos-org/feos-core/pull/27)
+
+## [0.1.3] - 2022-01-21
+### Added
+- Added the following properties to `State`: [#21](https://github.com/feos-org/feos-core/pull/21)
+  - `dp_drho` partial derivative of pressure w.r.t. density
+  - `d2p_drho2` second partial derivative of pressure w.r.t. density
+  - `isothermal_compressibility` the isothermal compressibility
+- Read a list of segment records directly from a JSON file. [#22](https://github.com/feos-org/feos-core/pull/22)
+
+
+## [0.1.2] - 2022-01-10
+### Changed
+- Changed `ChemicalRecord` to an enum that can hold either the full structural information of a molecule or only segment and bond counts and added an `Identifier`. [#19](https://github.com/feos-org/feos-core/pull/19)
+- Removed the `chemical_record` field from `PureRecord` and made `model_record` non-optional. [#19](https://github.com/feos-org/feos-core/pull/19)
+
+## [0.1.1] - 2021-12-22
+### Added
+- Added `from_multiple_json` function to `Parameter` trait that is able to read parameters from separate JSON files. [#15](https://github.com/feos-org/feos-core/pull/15)
+
+### Packaging
+- Updated `pyo3` and `numpy` dependencies to 0.15.
+- Updated `quantity` dependency to 0.4.
+- Updated `num-dual` dependency to 0.4.
+- Removed `ndarray-linalg` and `ndarray-stats` dependencies.
+- Removed obsolete features for the selection of the BLAS/LAPACK library.
+
+## [0.1.0] - 2021-12-02
+### Added
+- Initial release

--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "feos-core"
+version = "0.2.0"
+authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
+           "Philipp Rehner <prehner@ethz.ch"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "Core traits and functionalities for the `feos` project."
+homepage = "https://github.com/feos-org"
+readme = "README.md"
+repository = "https://github.com/feos-org/feos-core"
+keywords = ["physics", "thermodynamics", "equations_of_state", "phase_equilibria"]
+categories = ["science"]
+exclude = ["/.github/*", "*.ipynb", "/docs"]
+workspace = ".."
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "./docs-header.html" ]
+
+[dependencies]
+quantity = "0.5"
+approx = "0.4"
+num-dual = { version = "0.5", features = ["linalg"] }
+ndarray = { version = "0.15", features = ["serde"] }
+num-traits = "0.2"
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+indexmap = "1.7"
+conv = "0.3"
+numpy = { version = "0.16", optional = true }
+pyo3 = { version = "0.16", optional = true }
+
+[features]
+default = []
+python = ["pyo3", "numpy", "quantity/python", "num-dual/python"]

--- a/feos-core/README.md
+++ b/feos-core/README.md
@@ -1,0 +1,32 @@
+# FeOs - A Framework for Equations of State
+
+[![crate](https://img.shields.io/crates/v/feos-core.svg)](https://crates.io/crates/feos-core)
+[![documentation](https://docs.rs/feos-core/badge.svg)](https://docs.rs/feos-core)
+
+Core traits and functionalities for the `feos` project.
+
+The crate makes use of [generalized (hyper-) dual numbers](https://github.com/itt-ustutt/num-dual) to generically calculate exact partial derivatives from Helmholtz energy equations of state. The derivatives are used to calculate
+- **properties**,
+- **critical points**,
+- and **phase equilibria**.
+
+In addition to that, utilities are provided to assist in the handling of **parameters** for both molecular equations of state and (homosegmented) group contribution methods. Mainly as a simple test case, a **cubic** equation of state is published as part of this crate. Implementations of more sophisticated models are meant to be contained in individual crates. A list of currently available implementations can be found in the [feos](https://github.com/feos-org/feos) repository.
+
+For information on how to implement your own equation of state, check out the [documentation](https://feos-org.github.io/feos/rustguide/index.html).
+
+## Installation
+
+Add this to your `Cargo.toml`
+
+```toml
+[dependencies]
+feos-core = "0.2"
+```
+
+## Test building python wheel
+
+From within a Python virtual environment with `maturin` installed, type
+
+```
+maturin build --release --out dist --no-sdist -m build_wheel/Cargo.toml
+```

--- a/feos-core/docs-header.html
+++ b/feos-core/docs-header.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js"                  integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js"    integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "\\(", right: "\\)", display: false},
+                {left: "$", right: "$", display: false},
+                {left: "\\[", right: "\\]", display: true}
+            ]
+        });
+    });
+</script>

--- a/feos-core/license-apache
+++ b/feos-core/license-apache
@@ -1,0 +1,1 @@
+license-apache

--- a/feos-core/license-mit
+++ b/feos-core/license-mit
@@ -1,0 +1,1 @@
+license-mit

--- a/feos-core/src/cubic.rs
+++ b/feos-core/src/cubic.rs
@@ -1,0 +1,332 @@
+//! Implementation of the Peng-Robinson equation of state.
+//!
+//! This module acts as a reference on how a simple equation
+//! of state - with a single contribution to the Helmholtz energy - can be implemented.
+//! The implementation closely follows the form of the equations given in
+//! [this wikipedia article](https://en.wikipedia.org/wiki/Cubic_equations_of_state#Peng%E2%80%93Robinson_equation_of_state).
+use crate::equation_of_state::{
+    EquationOfState, HelmholtzEnergy, HelmholtzEnergyDual, IdealGasContribution,
+};
+use crate::joback::{Joback, JobackRecord};
+use crate::parameter::{Identifier, Parameter, ParameterError, PureRecord};
+use crate::si::{GRAM, MOL};
+use crate::state::StateHD;
+use crate::MolarWeight;
+use ndarray::{Array1, Array2};
+use num_dual::DualNum;
+use quantity::si::{SIArray1, SIUnit};
+use serde::{Deserialize, Serialize};
+use std::f64::consts::SQRT_2;
+use std::fmt;
+use std::rc::Rc;
+
+const KB_A3: f64 = 13806490.0;
+
+/// Peng-Robinson parameters for a single substance.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PengRobinsonRecord {
+    /// critical temperature in Kelvin
+    tc: f64,
+    /// critical pressure in Pascal
+    pc: f64,
+    /// acentric factor
+    acentric_factor: f64,
+}
+
+impl PengRobinsonRecord {
+    /// Create a new pure substance record for the Peng-Robinson equation of state.
+    pub fn new(tc: f64, pc: f64, acentric_factor: f64) -> Self {
+        Self {
+            tc,
+            pc,
+            acentric_factor,
+        }
+    }
+}
+
+impl std::fmt::Display for PengRobinsonRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PengRobinsonRecord(tc={} K", self.tc)?;
+        write!(f, ", pc={} Pa", self.pc)?;
+        write!(f, ", acentric factor={}", self.acentric_factor)
+    }
+}
+
+/// Peng-Robinson parameters for one ore more substances.
+pub struct PengRobinsonParameters {
+    /// Critical temperature in Kelvin
+    tc: Array1<f64>,
+    a: Array1<f64>,
+    b: Array1<f64>,
+    /// Binary interaction parameter
+    k_ij: Array2<f64>,
+    kappa: Array1<f64>,
+    /// Molar weight in units of g/mol
+    molarweight: Array1<f64>,
+    /// List of pure component records
+    pure_records: Vec<PureRecord<PengRobinsonRecord, JobackRecord>>,
+    /// List of ideal gas Joback records
+    joback_records: Option<Vec<JobackRecord>>,
+}
+
+impl std::fmt::Display for PengRobinsonParameters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.pure_records
+            .iter()
+            .try_for_each(|pr| writeln!(f, "{}", pr))?;
+        writeln!(f, "\nk_ij:\n{}", self.k_ij)
+    }
+}
+
+impl PengRobinsonParameters {
+    /// Build a simple parameter set without binary interaction parameters.
+    pub fn new_simple(
+        tc: &[f64],
+        pc: &[f64],
+        acentric_factor: &[f64],
+        molarweight: &[f64],
+    ) -> Result<Self, crate::parameter::ParameterError> {
+        if [pc.len(), acentric_factor.len(), molarweight.len()]
+            .iter()
+            .any(|&l| l != tc.len())
+        {
+            return Err(ParameterError::IncompatibleParameters(String::from(
+                "each component has to have parameters.",
+            )));
+        }
+        let records = (0..tc.len())
+            .map(|i| {
+                let record = PengRobinsonRecord {
+                    tc: tc[i],
+                    pc: pc[i],
+                    acentric_factor: acentric_factor[i],
+                };
+                let id = Identifier::default();
+                PureRecord::new(id, molarweight[i], record, None)
+            })
+            .collect();
+        Ok(PengRobinsonParameters::from_records(
+            records,
+            Array2::zeros([pc.len(); 2]),
+        ))
+    }
+}
+
+impl Parameter for PengRobinsonParameters {
+    type Pure = PengRobinsonRecord;
+    type IdealGas = JobackRecord;
+    type Binary = f64;
+
+    /// Creates parameters from pure component records.
+    fn from_records(
+        pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
+        binary_records: Array2<Self::Binary>,
+    ) -> Self {
+        let n = pure_records.len();
+
+        let mut tc = Array1::zeros(n);
+        let mut a = Array1::zeros(n);
+        let mut b = Array1::zeros(n);
+        let mut molarweight = Array1::zeros(n);
+        let mut kappa = Array1::zeros(n);
+
+        for (i, record) in pure_records.iter().enumerate() {
+            molarweight[i] = record.molarweight;
+            let r = &record.model_record;
+            tc[i] = r.tc;
+            a[i] = 0.45724 * r.tc.powi(2) * KB_A3 / r.pc;
+            b[i] = 0.07780 * r.tc * KB_A3 / r.pc;
+            kappa[i] = 0.37464 + (1.54226 - 0.26992 * r.acentric_factor) * r.acentric_factor;
+        }
+
+        let joback_records = pure_records
+            .iter()
+            .map(|r| r.ideal_gas_record.clone())
+            .collect();
+
+        Self {
+            tc,
+            a,
+            b,
+            k_ij: binary_records,
+            kappa,
+            molarweight,
+            pure_records,
+            joback_records,
+        }
+    }
+
+    fn records(
+        &self,
+    ) -> (
+        &[PureRecord<PengRobinsonRecord, JobackRecord>],
+        &Array2<f64>,
+    ) {
+        (&self.pure_records, &self.k_ij)
+    }
+}
+
+struct PengRobinsonContribution {
+    parameters: Rc<PengRobinsonParameters>,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for PengRobinsonContribution {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        // temperature dependent a parameter
+        let p = &self.parameters;
+        let x = &state.molefracs;
+        let ak = (&p.tc.mapv(|tc| (D::one() - (state.temperature / tc).sqrt())) * &p.kappa + 1.0)
+            .mapv(|x| x.powi(2))
+            * &p.a;
+
+        // Mixing rules
+        let mut ak_mix = D::zero();
+        for i in 0..ak.len() {
+            for j in 0..ak.len() {
+                ak_mix += (ak[i] * ak[j]).sqrt() * (x[i] * x[j] * (1.0 - p.k_ij[(i, j)]));
+            }
+        }
+        let b = (x * &p.b).sum();
+
+        // Helmholtz energy
+        let n = state.moles.sum();
+        let v = state.volume;
+        n * ((v / (v - b * n)).ln()
+            - ak_mix / (b * SQRT_2 * 2.0 * state.temperature)
+                * ((v * (SQRT_2 - 1.0) + b * n) / (v * (SQRT_2 + 1.0) - b * n)).ln())
+    }
+}
+
+impl fmt::Display for PengRobinsonContribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Peng Robinson")
+    }
+}
+
+/// A simple version of the Peng-Robinson equation of state.
+pub struct PengRobinson {
+    /// Parameters
+    parameters: Rc<PengRobinsonParameters>,
+    /// Ideal gas contributions to the Helmholtz energy
+    ideal_gas: Joback,
+    /// Non-ideal contributions to the Helmholtz energy
+    contributions: Vec<Box<dyn HelmholtzEnergy>>,
+}
+
+impl PengRobinson {
+    /// Create a new equation of state from a set of parameters.
+    pub fn new(parameters: Rc<PengRobinsonParameters>) -> Self {
+        let ideal_gas = parameters.joback_records.as_ref().map_or_else(
+            || Joback::default(parameters.tc.len()),
+            |j| Joback::new(j.clone()),
+        );
+        let contributions: Vec<Box<dyn HelmholtzEnergy>> =
+            vec![Box::new(PengRobinsonContribution {
+                parameters: parameters.clone(),
+            })];
+        Self {
+            parameters,
+            ideal_gas,
+            contributions,
+        }
+    }
+}
+
+impl EquationOfState for PengRobinson {
+    fn components(&self) -> usize {
+        self.parameters.b.len()
+    }
+
+    fn subset(&self, component_list: &[usize]) -> Self {
+        Self::new(Rc::new(self.parameters.subset(component_list)))
+    }
+
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
+        let b = (moles * &self.parameters.b).sum() / moles.sum();
+        0.9 / b
+    }
+
+    fn residual(&self) -> &[Box<dyn HelmholtzEnergy>] {
+        &self.contributions
+    }
+
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        &self.ideal_gas
+    }
+}
+
+impl MolarWeight<SIUnit> for PengRobinson {
+    fn molar_weight(&self) -> SIArray1 {
+        self.parameters.molarweight.clone() * GRAM / MOL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::phase_equilibria::SolverOptions;
+    use crate::state::State;
+    use crate::Contributions;
+    use crate::{EosResult, Verbosity};
+    use approx::*;
+    use quantity::si::*;
+    use std::rc::Rc;
+
+    fn pure_record_vec() -> Vec<PureRecord<PengRobinsonRecord, JobackRecord>> {
+        let records = r#"[
+            {
+                "identifier": {
+                    "cas": "74-98-6",
+                    "name": "propane",
+                    "iupac_name": "propane",
+                    "smiles": "CCC",
+                    "inchi": "InChI=1/C3H8/c1-3-2/h3H2,1-2H3",
+                    "formula": "C3H8"
+                },
+                "model_record": {
+                    "tc": 369.96,
+                    "pc": 4250000.0,
+                    "acentric_factor": 0.153
+                },
+                "molarweight": 44.0962
+            },
+            {
+                "identifier": {
+                    "cas": "106-97-8",
+                    "name": "butane",
+                    "iupac_name": "butane",
+                    "smiles": "CCCC",
+                    "inchi": "InChI=1/C4H10/c1-3-4-2/h3-4H2,1-2H3",
+                    "formula": "C4H10"
+                },
+                "model_record": {
+                    "tc": 425.2,
+                    "pc": 3800000.0,
+                    "acentric_factor": 0.199
+                },
+                "molarweight": 58.123
+            }
+        ]"#;
+        serde_json::from_str(records).expect("Unable to parse json.")
+    }
+
+    #[test]
+    fn peng_robinson() -> EosResult<()> {
+        let mixture = pure_record_vec();
+        let propane = mixture[0].clone();
+        let tc = propane.model_record.tc;
+        let pc = propane.model_record.pc;
+        let parameters = PengRobinsonParameters::from_records(vec![propane], Array2::zeros((1, 1)));
+        let pr = Rc::new(PengRobinson::new(Rc::new(parameters)));
+        let options = SolverOptions::new().verbosity(Verbosity::Iter);
+        let cp = State::critical_point(&pr, None, None, options)?;
+        println!("{} {}", cp.temperature, cp.pressure(Contributions::Total));
+        assert_relative_eq!(cp.temperature, tc * KELVIN, max_relative = 1e-4);
+        assert_relative_eq!(
+            cp.pressure(Contributions::Total),
+            pc * PASCAL,
+            max_relative = 1e-4
+        );
+        Ok(())
+    }
+}

--- a/feos-core/src/density_iteration.rs
+++ b/feos-core/src/density_iteration.rs
@@ -1,0 +1,197 @@
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::state::State;
+use crate::EosUnit;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::rc::Rc;
+
+pub struct SpinodalPoint<U: EosUnit> {
+    pub p: QuantityScalar<U>,
+    pub dp_drho: QuantityScalar<U>,
+    pub rho: QuantityScalar<U>,
+}
+
+pub fn density_iteration<U: EosUnit, E: EquationOfState>(
+    eos: &Rc<E>,
+    temperature: QuantityScalar<U>,
+    pressure: QuantityScalar<U>,
+    moles: &QuantityArray1<U>,
+    initial_density: QuantityScalar<U>,
+) -> EosResult<State<U, E>> {
+    let maxdensity = eos.max_density(Some(moles))?;
+    let (abstol, reltol) = (1e-12, 1e-14);
+    let n = moles.sum();
+
+    let mut rho = initial_density;
+    if rho <= 0.0 * U::reference_density() {
+        return Err(EosError::InvalidState(
+            String::from("density iteration"),
+            String::from("density"),
+            rho.to_reduced(U::reference_density())?,
+        ));
+    }
+
+    let maxiter = 50;
+    let mut iterations = 0;
+    'iteration: for k in 0..maxiter {
+        iterations += 1;
+        let (mut p, mut dp_drho) = State::new_nvt(eos, temperature, n / rho, moles)?.p_dpdrho();
+
+        // attempt to correct for poor initial density rho_init
+        if dp_drho.is_sign_negative() && k == 0 {
+            rho = if initial_density <= 0.15 * maxdensity {
+                0.05 * initial_density
+            } else {
+                (1.1 * initial_density).min(maxdensity)?
+            };
+            let p_ = State::new_nvt(eos, temperature, n / rho, moles)?.p_dpdrho();
+            p = p_.0;
+            dp_drho = p_.1;
+        }
+
+        let mut error = p - pressure;
+
+        let mut delta_rho = -error / dp_drho;
+        if delta_rho.abs() > 0.075 * maxdensity {
+            delta_rho = 0.075 * maxdensity * delta_rho.signum();
+        };
+        delta_rho = delta_rho.max(-0.95 * rho)?; // prevent stepping to rho < 0.0
+
+        // correction for instable region
+        if dp_drho.is_sign_negative() && k < maxiter {
+            let d2pdrho2 = State::new_nvt(eos, temperature, n / rho, moles)?
+                .d2pdrho2()
+                .2;
+
+            if rho > 0.85 * maxdensity {
+                let sp = pressure_spinodal(eos, temperature, initial_density, moles)?;
+                rho = sp.rho;
+                error = sp.p - pressure;
+                if rho > 0.85 * maxdensity {
+                    if error.is_sign_negative() {
+                        return Err(EosError::IterationFailed(String::from("density_iteration")));
+                    } else {
+                        rho = rho * 0.98
+                    }
+                } else if error.is_sign_positive() {
+                    rho = 0.001 * maxdensity
+                } else {
+                    rho = (rho * 1.1).min(maxdensity)?
+                }
+            } else if error.is_sign_positive() && d2pdrho2.is_sign_positive() {
+                let sp = pressure_spinodal(eos, temperature, initial_density, moles)?;
+                rho = sp.rho;
+                error = sp.p - pressure;
+                if error.is_sign_positive() {
+                    rho = 0.001 * maxdensity
+                } else {
+                    rho = (rho * 1.1).min(maxdensity)?
+                }
+            } else if error.is_sign_negative() && d2pdrho2.is_sign_negative() {
+                let sp = pressure_spinodal(eos, temperature, initial_density, moles)?;
+                rho = sp.rho;
+                error = sp.p - pressure;
+                if error.is_sign_negative() {
+                    rho = 0.8 * maxdensity
+                } else {
+                    rho = rho * 0.8
+                }
+            } else if error.is_sign_negative() && d2pdrho2.is_sign_positive() {
+                let sp_l = pressure_spinodal(eos, temperature, 0.8 * maxdensity, moles)?;
+                let rho_l = sp_l.rho;
+                let sp_v = pressure_spinodal(eos, temperature, 0.001 * maxdensity, moles)?;
+                let rho_v = sp_v.rho;
+                error = sp_v.p - pressure;
+                if error.is_sign_positive()
+                    && (initial_density - rho_v).abs() < (initial_density - rho_l).abs()
+                {
+                    rho = 0.8 * rho_v
+                } else {
+                    rho = (rho_l * 1.1).min(maxdensity)?
+                }
+            } else if error.is_sign_positive() && d2pdrho2.is_sign_negative() {
+                let sp_l = pressure_spinodal(eos, temperature, 0.8 * maxdensity, moles)?;
+                let rho_l = sp_l.rho;
+                let sp_v = pressure_spinodal(eos, temperature, 0.001 * maxdensity, moles)?;
+                let rho_v = sp_v.rho;
+                error = sp_v.p - pressure;
+                if error.is_sign_negative()
+                    && (initial_density - rho_v).abs() > (initial_density - rho_l).abs()
+                {
+                    rho = (rho_l * 1.1).min(maxdensity)?
+                } else {
+                    rho = 0.8 * rho_v
+                }
+            } else {
+                rho = (rho + initial_density) * 0.5;
+                if (rho - initial_density)
+                    .to_reduced(U::reference_density())?
+                    .abs()
+                    < 1e-8
+                {
+                    rho = (rho + 0.1 * maxdensity).min(maxdensity)?
+                }
+            }
+            continue 'iteration;
+        }
+        // Newton step
+        rho += delta_rho;
+        if error.to_reduced(U::reference_pressure())?.abs()
+            < f64::max(abstol, (rho * reltol).to_reduced(U::reference_density())?)
+        {
+            break 'iteration;
+        }
+    }
+    if iterations == maxiter + 1 {
+        Err(EosError::NotConverged("density_iteration".to_owned()))
+    } else {
+        Ok(State::new_nvt(eos, temperature, n / rho, moles)?)
+    }
+}
+
+pub fn pressure_spinodal<U: EosUnit, E: EquationOfState>(
+    eos: &Rc<E>,
+    temperature: QuantityScalar<U>,
+    rho_init: QuantityScalar<U>,
+    moles: &QuantityArray1<U>,
+) -> EosResult<SpinodalPoint<U>> {
+    let maxiter = 30;
+    let abstol = 1e-8;
+
+    let maxdensity = eos.max_density(Some(moles))?;
+    let n = moles.sum();
+    let mut rho = rho_init;
+
+    if rho <= 0.0 * U::reference_density() {
+        return Err(EosError::InvalidState(
+            String::from("pressure spinodal"),
+            String::from("density"),
+            rho.to_reduced(U::reference_density())?,
+        ));
+    }
+
+    for _ in 0..maxiter {
+        let (p, dpdrho, d2pdrho2) = State::new_nvt(eos, temperature, n / rho, moles)?.d2pdrho2();
+
+        let mut delta_rho = -dpdrho / d2pdrho2;
+        if delta_rho.abs() > 0.05 * maxdensity {
+            delta_rho = 0.05 * maxdensity * delta_rho.signum()
+        }
+        delta_rho = delta_rho.max(-rho * 0.95)?; // prevent stepping to rho < 0.0
+        delta_rho = delta_rho.min(maxdensity - rho)?; // prevent stepping to rho > maxdensity
+        rho += delta_rho;
+
+        if dpdrho
+            .to_reduced(U::reference_pressure() / U::reference_density())?
+            .abs()
+            < abstol
+        {
+            return Ok(SpinodalPoint {
+                p,
+                dp_drho: dpdrho,
+                rho,
+            });
+        }
+    }
+    Err(EosError::NotConverged("pressure_spinodal".to_owned()))
+}

--- a/feos-core/src/equation_of_state.rs
+++ b/feos-core/src/equation_of_state.rs
@@ -1,0 +1,334 @@
+use crate::errors::{EosError, EosResult};
+use crate::state::StateHD;
+use crate::EosUnit;
+use ndarray::prelude::*;
+use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualNum, DualVec64, HyperDual, HyperDual64};
+use num_traits::{One, Zero};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::fmt;
+
+/// Individual Helmholtz energy contribution that can
+/// be evaluated using generalized (hyper) dual numbers.
+///
+/// This trait needs to be implemented generically or for
+/// the specific types in the supertraits of [HelmholtzEnergy]
+/// so that the implementor can be used as a Helmholtz energy
+/// contribution in the equation of state.
+pub trait HelmholtzEnergyDual<D: DualNum<f64>> {
+    /// The Helmholtz energy contribution $\beta A$ of a given state in reduced units.
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D;
+}
+
+/// Object safe version of the [HelmholtzEnergyDual] trait.
+///
+/// The trait is implemented automatically for every struct that implements
+/// the supertraits.
+pub trait HelmholtzEnergy:
+    HelmholtzEnergyDual<f64>
+    + HelmholtzEnergyDual<Dual64>
+    + HelmholtzEnergyDual<Dual<DualVec64<3>, f64>>
+    + HelmholtzEnergyDual<HyperDual64>
+    + HelmholtzEnergyDual<Dual3_64>
+    + HelmholtzEnergyDual<HyperDual<Dual64, f64>>
+    + HelmholtzEnergyDual<HyperDual<DualVec64<2>, f64>>
+    + HelmholtzEnergyDual<HyperDual<DualVec64<3>, f64>>
+    + HelmholtzEnergyDual<Dual3<Dual64, f64>>
+    + HelmholtzEnergyDual<Dual3<DualVec64<2>, f64>>
+    + HelmholtzEnergyDual<Dual3<DualVec64<3>, f64>>
+    + fmt::Display
+{
+}
+
+impl<T> HelmholtzEnergy for T where
+    T: HelmholtzEnergyDual<f64>
+        + HelmholtzEnergyDual<Dual64>
+        + HelmholtzEnergyDual<Dual<DualVec64<3>, f64>>
+        + HelmholtzEnergyDual<HyperDual64>
+        + HelmholtzEnergyDual<Dual3_64>
+        + HelmholtzEnergyDual<HyperDual<Dual64, f64>>
+        + HelmholtzEnergyDual<HyperDual<DualVec64<2>, f64>>
+        + HelmholtzEnergyDual<HyperDual<DualVec64<3>, f64>>
+        + HelmholtzEnergyDual<Dual3<Dual64, f64>>
+        + HelmholtzEnergyDual<Dual3<DualVec64<2>, f64>>
+        + HelmholtzEnergyDual<Dual3<DualVec64<3>, f64>>
+        + fmt::Display
+{
+}
+
+/// Ideal gas Helmholtz energy contribution that can
+/// be evaluated using generalized (hyper) dual numbers.
+///
+/// This trait needs to be implemented generically or for
+/// the specific types in the supertraits of [IdealGasContribution]
+/// so that the implementor can be used as an ideal gas
+/// contribution in the equation of state.
+pub trait IdealGasContributionDual<D: DualNum<f64>> {
+    /// The thermal de Broglie wavelength of each component in the form $\ln\left(\frac{\Lambda^3}{\AA^3}\right)$
+    fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D>;
+
+    /// Evaluate the ideal gas contribution for a given state.
+    ///
+    /// In some cases it could be advantageous to overwrite this
+    /// implementation instead of implementing the de Broglie
+    /// wavelength.
+    fn evaluate(&self, state: &StateHD<D>) -> D {
+        let lambda = self.de_broglie_wavelength(state.temperature, state.moles.len());
+        ((lambda
+            + state.partial_density.mapv(|x| {
+                if x.re() == 0.0 {
+                    D::from(0.0)
+                } else {
+                    x.ln() - 1.0
+                }
+            }))
+            * &state.moles)
+            .sum()
+    }
+}
+
+/// Object safe version of the [IdealGasContributionDual] trait.
+///
+/// The trait is implemented automatically for every struct that implements
+/// the supertraits.
+pub trait IdealGasContribution:
+    IdealGasContributionDual<f64>
+    + IdealGasContributionDual<Dual64>
+    + IdealGasContributionDual<Dual<DualVec64<3>, f64>>
+    + IdealGasContributionDual<HyperDual64>
+    + IdealGasContributionDual<Dual3_64>
+    + IdealGasContributionDual<HyperDual<Dual64, f64>>
+    + IdealGasContributionDual<HyperDual<DualVec64<2>, f64>>
+    + IdealGasContributionDual<HyperDual<DualVec64<3>, f64>>
+    + IdealGasContributionDual<Dual3<Dual64, f64>>
+    + IdealGasContributionDual<Dual3<DualVec64<2>, f64>>
+    + IdealGasContributionDual<Dual3<DualVec64<3>, f64>>
+    + fmt::Display
+{
+}
+
+impl<T> IdealGasContribution for T where
+    T: IdealGasContributionDual<f64>
+        + IdealGasContributionDual<Dual64>
+        + IdealGasContributionDual<Dual<DualVec64<3>, f64>>
+        + IdealGasContributionDual<HyperDual64>
+        + IdealGasContributionDual<Dual3_64>
+        + IdealGasContributionDual<HyperDual<Dual64, f64>>
+        + IdealGasContributionDual<HyperDual<DualVec64<2>, f64>>
+        + IdealGasContributionDual<HyperDual<DualVec64<3>, f64>>
+        + IdealGasContributionDual<Dual3<Dual64, f64>>
+        + IdealGasContributionDual<Dual3<DualVec64<2>, f64>>
+        + IdealGasContributionDual<Dual3<DualVec64<3>, f64>>
+        + fmt::Display
+{
+}
+
+struct DefaultIdealGasContribution;
+impl<D: DualNum<f64>> IdealGasContributionDual<D> for DefaultIdealGasContribution {
+    fn de_broglie_wavelength(&self, _: D, components: usize) -> Array1<D> {
+        Array1::zeros(components)
+    }
+}
+
+impl fmt::Display for DefaultIdealGasContribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ideal gas (default)")
+    }
+}
+
+/// Molar weight of all components.
+///
+/// The trait is required to be able to calculate (mass)
+/// specific properties.
+pub trait MolarWeight<U: EosUnit> {
+    fn molar_weight(&self) -> QuantityArray1<U>;
+}
+
+/// A general equation of state.
+pub trait EquationOfState {
+    /// Return the number of components of the equation of state.
+    fn components(&self) -> usize;
+
+    /// Return an equation of state consisting of the components
+    /// contained in component_list.
+    fn subset(&self, component_list: &[usize]) -> Self;
+
+    /// Return the maximum density in Angstrom^-3.
+    ///
+    /// This value is used as an estimate for a liquid phase for phase
+    /// equilibria and other iterations. It is not explicitly meant to
+    /// be a mathematical limit for the density (if those exist in the
+    /// equation of state anyways).
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64;
+
+    /// Return a slice of the individual contributions (excluding the ideal gas)
+    /// of the equation of state.
+    fn residual(&self) -> &[Box<dyn HelmholtzEnergy>];
+
+    /// Evaluate the residual reduced Helmholtz energy $\beta A^\mathrm{res}$.
+    fn evaluate_residual<D: DualNum<f64>>(&self, state: &StateHD<D>) -> D
+    where
+        dyn HelmholtzEnergy: HelmholtzEnergyDual<D>,
+    {
+        self.residual()
+            .iter()
+            .map(|c| c.helmholtz_energy(state))
+            .sum()
+    }
+
+    /// Evaluate the reduced Helmholtz energy of each individual contribution
+    /// and return them together with a string representation of the contribution.
+    fn evaluate_residual_contributions<D: DualNum<f64>>(
+        &self,
+        state: &StateHD<D>,
+    ) -> Vec<(String, D)>
+    where
+        dyn HelmholtzEnergy: HelmholtzEnergyDual<D>,
+    {
+        self.residual()
+            .iter()
+            .map(|c| (c.to_string(), c.helmholtz_energy(state)))
+            .collect()
+    }
+
+    /// Return the ideal gas contribution.
+    ///
+    /// Per default this function returns an ideal gas contribution
+    /// in which the de Broglie wavelength is 1 for every component.
+    /// Therefore, the correct ideal gas pressure is obtained even
+    /// with no explicit ideal gas term. If a more detailed model is
+    /// required (e.g. for the calculation of enthalpies) this function
+    /// has to be overwritten.
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        &DefaultIdealGasContribution
+    }
+
+    /// Check if the provided optional mole number is consistent with the
+    /// equation of state.
+    ///
+    /// In general, the number of elements in `moles` needs to match the number
+    /// of components of the equation of state. For a pure component, however,
+    /// no moles need to be provided. In that case, it is set to the constant
+    /// reference value.
+    fn validate_moles<U: EosUnit>(
+        &self,
+        moles: Option<&QuantityArray1<U>>,
+    ) -> EosResult<QuantityArray1<U>> {
+        let l = moles.map_or(1, |m| m.len());
+        if self.components() == l {
+            match moles {
+                Some(m) => Ok(m.to_owned()),
+                None => Ok(Array::ones(1) * U::reference_moles()),
+            }
+        } else {
+            Err(EosError::IncompatibleComponents(self.components(), l))
+        }
+    }
+
+    /// Calculate the maximum density.
+    ///
+    /// This value is used as an estimate for a liquid phase for phase
+    /// equilibria and other iterations. It is not explicitly meant to
+    /// be a mathematical limit for the density (if those exist in the
+    /// equation of state anyways).
+    fn max_density<U: EosUnit>(
+        &self,
+        moles: Option<&QuantityArray1<U>>,
+    ) -> EosResult<QuantityScalar<U>> {
+        let mr = self
+            .validate_moles(moles)?
+            .to_reduced(U::reference_moles())?;
+        Ok(self.compute_max_density(&mr) * U::reference_density())
+    }
+
+    /// Calculate the second virial coefficient $B(T)$
+    fn second_virial_coefficient<U: EosUnit>(
+        &self,
+        temperature: QuantityScalar<U>,
+        moles: Option<&QuantityArray1<U>>,
+    ) -> EosResult<QuantityScalar<U>> {
+        let mr = self.validate_moles(moles)?;
+        let x = mr.to_reduced(mr.sum())?;
+        let mut rho = HyperDual64::zero();
+        rho.eps1[0] = 1.0;
+        rho.eps2[0] = 1.0;
+        let t = HyperDual64::from(temperature.to_reduced(U::reference_temperature())?);
+        let s = StateHD::new_virial(t, rho, x);
+        Ok(self.evaluate_residual(&s).eps1eps2[(0, 0)] * 0.5 / U::reference_density())
+    }
+
+    /// Calculate the third virial coefficient $C(T)$
+    fn third_virial_coefficient<U: EosUnit>(
+        &self,
+        temperature: QuantityScalar<U>,
+        moles: Option<&QuantityArray1<U>>,
+    ) -> EosResult<QuantityScalar<U>> {
+        let mr = self.validate_moles(moles)?;
+        let x = mr.to_reduced(mr.sum())?;
+        let rho = Dual3_64::zero().derive();
+        let t = Dual3_64::from(temperature.to_reduced(U::reference_temperature())?);
+        let s = StateHD::new_virial(t, rho, x);
+        Ok(self.evaluate_residual(&s).v3 / 3.0 / U::reference_density().powi(2))
+    }
+
+    /// Calculate the temperature derivative of the second virial coefficient $B'(T)$
+    fn second_virial_coefficient_temperature_derivative<U: EosUnit>(
+        &self,
+        temperature: QuantityScalar<U>,
+        moles: Option<&QuantityArray1<U>>,
+    ) -> EosResult<QuantityScalar<U>> {
+        let mr = self.validate_moles(moles)?;
+        let x = mr.to_reduced(mr.sum())?;
+        let mut rho = HyperDual::zero();
+        rho.eps1[0] = Dual64::one();
+        rho.eps2[0] = Dual64::one();
+        let t = HyperDual::from_re(
+            Dual64::from(temperature.to_reduced(U::reference_temperature())?).derive(),
+        );
+        let s = StateHD::new_virial(t, rho, x);
+        Ok(self.evaluate_residual(&s).eps1eps2[(0, 0)].eps[0] * 0.5
+            / (U::reference_density() * U::reference_temperature()))
+    }
+
+    /// Calculate the temperature derivative of the third virial coefficient $C'(T)$
+    fn third_virial_coefficient_temperature_derivative<U: EosUnit>(
+        &self,
+        temperature: QuantityScalar<U>,
+        moles: Option<&QuantityArray1<U>>,
+    ) -> EosResult<QuantityScalar<U>> {
+        let mr = self.validate_moles(moles)?;
+        let x = mr.to_reduced(mr.sum())?;
+        let rho = Dual3::zero().derive();
+        let t = Dual3::from_re(
+            Dual64::from(temperature.to_reduced(U::reference_temperature())?).derive(),
+        );
+        let s = StateHD::new_virial(t, rho, x);
+        Ok(self.evaluate_residual(&s).v3.eps[0]
+            / 3.0
+            / (U::reference_density().powi(2) * U::reference_temperature()))
+    }
+}
+
+/// Reference values and residual entropy correlations for entropy scaling.
+pub trait EntropyScaling<U: EosUnit> {
+    fn viscosity_reference(
+        &self,
+        temperature: QuantityScalar<U>,
+        volume: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+    ) -> EosResult<QuantityScalar<U>>;
+    fn viscosity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64>;
+    fn diffusion_reference(
+        &self,
+        temperature: QuantityScalar<U>,
+        volume: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+    ) -> EosResult<QuantityScalar<U>>;
+    fn diffusion_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64>;
+    fn thermal_conductivity_reference(
+        &self,
+        temperature: QuantityScalar<U>,
+        volume: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+    ) -> EosResult<QuantityScalar<U>>;
+    fn thermal_conductivity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64>;
+}

--- a/feos-core/src/errors.rs
+++ b/feos-core/src/errors.rs
@@ -1,0 +1,36 @@
+use crate::parameter::ParameterError;
+use num_dual::linalg::LinAlgError;
+use quantity::QuantityError;
+use thiserror::Error;
+
+/// Error type for improperly defined states and convergence problems.
+#[derive(Error, Debug)]
+pub enum EosError {
+    #[error("`{0}` did not converge within the maximum number of iterations.")]
+    NotConverged(String),
+    #[error("`{0}` encountered illegal values during the iteration.")]
+    IterationFailed(String),
+    #[error("Iteration resulted in trivial solution.")]
+    TrivialSolution,
+    #[error("Equation of state is initialized for {0} components while the input specifies {1} components.")]
+    IncompatibleComponents(usize, usize),
+    #[error("Invalid state in {0}: {1} = {2}.")]
+    InvalidState(String, String, f64),
+    #[error("Undetermined state: {0}.")]
+    UndeterminedState(String),
+    #[error("System is supercritical.")]
+    SuperCritical,
+    #[error("No phase split according to stability analysis.")]
+    NoPhaseSplit,
+    #[error("Wrong input units. Expected {0}, got {1}")]
+    WrongUnits(String, String),
+    #[error(transparent)]
+    QuantityError(#[from] QuantityError),
+    #[error(transparent)]
+    ParameterError(#[from] ParameterError),
+    #[error(transparent)]
+    LinAlgError(#[from] LinAlgError),
+}
+
+/// Convenience type for `Result<T, EosError>`.
+pub type EosResult<T> = Result<T, EosError>;

--- a/feos-core/src/joback.rs
+++ b/feos-core/src/joback.rs
@@ -1,0 +1,305 @@
+//! Implementation of the ideal gas heat capacity (de Broglie wavelength)
+//! of [Joback and Reid, 1987](https://doi.org/10.1080/00986448708960487).
+
+use crate::parameter::*;
+use crate::{
+    EosResult, EosUnit, EquationOfState, HelmholtzEnergy, IdealGasContribution,
+    IdealGasContributionDual,
+};
+use conv::ValueInto;
+use ndarray::Array1;
+use num_dual::*;
+use quantity::QuantityScalar;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Coefficients used in the Joback model.
+///
+/// Contains an additional fourth order polynomial coefficient `e`
+/// which is not used in the original publication but is used in
+/// parametrization for additional molecules in other publications.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct JobackRecord {
+    a: f64,
+    b: f64,
+    c: f64,
+    d: f64,
+    e: f64,
+}
+
+impl JobackRecord {
+    /// Creates a new `JobackRecord`
+    pub fn new(a: f64, b: f64, c: f64, d: f64, e: f64) -> Self {
+        Self { a, b, c, d, e }
+    }
+}
+
+impl fmt::Display for JobackRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "JobackRecord(a={}, b={}, c={}, d={}, e={})",
+            self.a, self.b, self.c, self.d, self.e
+        )
+    }
+}
+
+/// Implementation of the combining rules as described in
+/// [Joback and Reid, 1987](https://doi.org/10.1080/00986448708960487).
+impl<T: Copy + ValueInto<f64>> FromSegments<T> for JobackRecord {
+    fn from_segments(segments: &[(Self, T)]) -> Result<Self, ParameterError> {
+        let mut a = -37.93;
+        let mut b = 0.21;
+        let mut c = -3.91e-4;
+        let mut d = 2.06e-7;
+        let mut e = 0.0;
+        segments.iter().for_each(|(s, n)| {
+            let n = (*n).value_into().unwrap();
+            a += s.a * n;
+            b += s.b * n;
+            c += s.c * n;
+            d += s.d * n;
+            e += s.e * n;
+        });
+        Ok(Self { a, b, c, d, e })
+    }
+}
+
+/// The ideal gas contribution according to
+/// [Joback and Reid, 1987](https://doi.org/10.1080/00986448708960487).
+#[derive(Debug, Clone)]
+pub struct Joback {
+    pub records: Vec<JobackRecord>,
+}
+
+impl Joback {
+    /// Creates a new Joback contribution.
+    pub fn new(records: Vec<JobackRecord>) -> Self {
+        Self { records }
+    }
+
+    /// Creates a default ($c_p^\mathrm{ig}=0$) ideal gas contribution for the
+    /// given number of components.
+    pub fn default(components: usize) -> Self {
+        Self::new(vec![JobackRecord::default(); components])
+    }
+
+    /// Directly calculates the ideal gas heat capacity from the Joback model.
+    pub fn c_p<U: EosUnit>(
+        &self,
+        temperature: QuantityScalar<U>,
+        molefracs: &Array1<f64>,
+    ) -> EosResult<QuantityScalar<U>> {
+        let t = temperature.to_reduced(U::reference_temperature())?;
+        let mut c_p = 0.0;
+        for (j, &x) in self.records.iter().zip(molefracs.iter()) {
+            c_p += x * (j.a + j.b * t + j.c * t.powi(2) + j.d * t.powi(3) + j.e * t.powi(4));
+        }
+        Ok(c_p / RGAS * U::gas_constant())
+    }
+}
+
+impl fmt::Display for Joback {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ideal gas (Joback)")
+    }
+}
+
+const RGAS: f64 = 6.022140857 * 1.38064852;
+const T0: f64 = 298.15;
+const P0: f64 = 1.0e5;
+const A3: f64 = 1e-30;
+const KB: f64 = 1.38064852e-23;
+
+impl<D: DualNum<f64>> IdealGasContributionDual<D> for Joback {
+    fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D> {
+        let t = temperature;
+        let t2 = t * t;
+        let f = (temperature * KB / (P0 * A3)).ln();
+        Array1::from_shape_fn(components, |i| {
+            let j = &self.records[i];
+            let h = (t2 - T0 * T0) * 0.5 * j.b
+                + (t * t2 - T0.powi(3)) * j.c / 3.0
+                + (t2 * t2 - T0.powi(4)) * j.d / 4.0
+                + (t2 * t2 * t - T0.powi(5)) * j.e / 5.0
+                + (t - T0) * j.a;
+            let s = (t - T0) * j.b
+                + (t2 - T0.powi(2)) * 0.5 * j.c
+                + (t2 * t - T0.powi(3)) * j.d / 3.0
+                + (t2 * t2 - T0.powi(4)) * j.e / 4.0
+                + (t / T0).ln() * j.a;
+            (h - t * s) / (t * RGAS) + f
+        })
+    }
+}
+
+impl EquationOfState for Joback {
+    fn components(&self) -> usize {
+        self.records.len()
+    }
+
+    fn subset(&self, component_list: &[usize]) -> Self {
+        let records = component_list
+            .iter()
+            .map(|&i| self.records[i].clone())
+            .collect();
+        Self::new(records)
+    }
+
+    fn compute_max_density(&self, _moles: &Array1<f64>) -> f64 {
+        1.0
+    }
+
+    fn residual(&self) -> &[Box<dyn HelmholtzEnergy>] {
+        &[]
+    }
+
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Contributions, State, StateBuilder};
+    use approx::assert_relative_eq;
+    use ndarray::arr1;
+    use quantity::si::*;
+    use std::rc::Rc;
+
+    use super::*;
+
+    #[derive(Deserialize, Clone, Debug)]
+    struct ModelRecord;
+
+    #[test]
+    fn paper_example() -> EosResult<()> {
+        let segments_json = r#"[
+        {
+          "identifier": "-Cl",
+          "model_record": null,
+          "ideal_gas_record": {
+            "a": 33.3,
+            "b": -0.0963,
+            "c": 0.000187,
+            "d": -9.96e-8,
+            "e": 0.0
+          },
+          "molarweight": 35.453
+        },
+        {
+          "identifier": "-CH=(ring)",
+          "model_record": null,
+          "ideal_gas_record": {
+            "a": -2.14,
+            "b": 5.74e-2,
+            "c": -1.64e-6,
+            "d": -1.59e-8,
+            "e": 0.0
+          },
+          "molarweight": 13.01864
+        },
+        {
+          "identifier": "=CH<(ring)",
+          "model_record": null,
+          "ideal_gas_record": {
+            "a": -8.25,
+            "b": 1.01e-1,
+            "c": -1.42e-4,
+            "d": 6.78e-8,
+            "e": 0.0
+          },
+          "molarweight": 13.01864
+        }
+        ]"#;
+        let segment_records: Vec<SegmentRecord<ModelRecord, JobackRecord>> =
+            serde_json::from_str(segments_json).expect("Unable to parse json.");
+        let segments = ChemicalRecord::new(
+            Identifier::default(),
+            vec![
+                String::from("-Cl"),
+                String::from("-Cl"),
+                String::from("-CH=(ring)"),
+                String::from("-CH=(ring)"),
+                String::from("-CH=(ring)"),
+                String::from("-CH=(ring)"),
+                String::from("=CH<(ring)"),
+                String::from("=CH<(ring)"),
+            ],
+            None,
+        )
+        .segment_map(&segment_records)?;
+        assert_eq!(segments.get(&segment_records[0]), Some(&2));
+        assert_eq!(segments.get(&segment_records[1]), Some(&4));
+        assert_eq!(segments.get(&segment_records[2]), Some(&2));
+        let joback_segments: Vec<_> = segments
+            .iter()
+            .map(|(s, &n)| (s.ideal_gas_record.clone().unwrap(), n))
+            .collect();
+        let jr = JobackRecord::from_segments(&joback_segments)?;
+        assert_relative_eq!(
+            jr.a,
+            33.3 * 2.0 - 2.14 * 4.0 - 8.25 * 2.0 - 37.93,
+            epsilon = 1e-10
+        );
+        assert_relative_eq!(
+            jr.b,
+            -0.0963 * 2.0 + 5.74e-2 * 4.0 + 1.01e-1 * 2.0 + 0.21,
+            epsilon = 1e-10
+        );
+        assert_relative_eq!(
+            jr.c,
+            0.000187 * 2.0 - 1.64e-6 * 4.0 - 1.42e-4 * 2.0 - 3.91e-4,
+            epsilon = 1e-10
+        );
+        assert_relative_eq!(
+            jr.d,
+            -9.96e-8 * 2.0 - 1.59e-8 * 4.0 + 6.78e-8 * 2.0 + 2.06e-7,
+            epsilon = 1e-10
+        );
+        assert_relative_eq!(jr.e, 0.0);
+
+        let eos = Rc::new(Joback::new(vec![jr]));
+        let state = State::new_nvt(
+            &eos,
+            1000.0 * KELVIN,
+            1.0 * ANGSTROM.powi(3),
+            &(arr1(&[1.0]) * MOL),
+        )?;
+        assert!(
+            (state
+                .c_p(Contributions::IdealGas)
+                .to_reduced(JOULE / MOL / KELVIN)?
+                - 224.6)
+                .abs()
+                < 1.0
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn c_p_comparison() -> EosResult<()> {
+        let record1 = JobackRecord::new(1.0, 0.2, 0.03, 0.004, 0.005);
+        let record2 = JobackRecord::new(-5.0, 0.4, 0.03, 0.002, 0.001);
+        let joback = Rc::new(Joback::new(vec![record1, record2]));
+        let temperature = 300.0 * KELVIN;
+        let volume = METER.powi(3);
+        let moles = arr1(&[1.0, 3.0]) * MOL;
+        let state = StateBuilder::new(&joback)
+            .temperature(temperature)
+            .volume(volume)
+            .moles(&moles)
+            .build()?;
+        println!(
+            "{} {}",
+            joback.c_p(temperature, &state.molefracs)?,
+            state.c_p(Contributions::IdealGas)
+        );
+        assert_relative_eq!(
+            joback.c_p(temperature, &state.molefracs)?,
+            state.c_p(Contributions::IdealGas),
+            max_relative = 1e-10
+        );
+        Ok(())
+    }
+}

--- a/feos-core/src/lib.rs
+++ b/feos-core/src/lib.rs
@@ -1,0 +1,121 @@
+#![warn(clippy::all)]
+#![allow(clippy::reversed_empty_ranges)]
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::too_many_arguments)]
+
+use quantity::si::*;
+use quantity::*;
+
+/// Print messages with level `Verbosity::Iter` or higher.
+#[macro_export]
+macro_rules! log_iter {
+    ($verbosity:expr, $($arg:tt)*) => {
+        if $verbosity >= Verbosity::Iter {
+            println!($($arg)*);
+        }
+    }
+}
+
+/// Print messages with level `Verbosity::Result` or higher.
+#[macro_export]
+macro_rules! log_result {
+    ($verbosity:expr, $($arg:tt)*) => {
+        if $verbosity >= Verbosity::Result {
+            println!($($arg)*);
+        }
+    }
+}
+
+pub mod cubic;
+mod density_iteration;
+mod equation_of_state;
+mod errors;
+pub mod joback;
+pub mod parameter;
+mod phase_equilibria;
+mod state;
+pub use equation_of_state::{
+    EntropyScaling, EquationOfState, HelmholtzEnergy, HelmholtzEnergyDual, IdealGasContribution,
+    IdealGasContributionDual, MolarWeight,
+};
+pub use errors::{EosError, EosResult};
+pub use phase_equilibria::{
+    PhaseDiagram, PhaseDiagramHetero, PhaseEquilibrium, SolverOptions, Verbosity,
+};
+pub use state::{Contributions, DensityInitialization, State, StateBuilder, StateHD, StateVec};
+
+#[cfg(feature = "python")]
+pub mod python;
+
+/// Consistent conversions between quantities and reduced properties.
+pub trait EosUnit: Unit {
+    fn reference_temperature() -> QuantityScalar<Self>;
+    fn reference_length() -> QuantityScalar<Self>;
+    fn reference_density() -> QuantityScalar<Self>;
+    fn reference_time() -> QuantityScalar<Self>;
+    fn gas_constant() -> QuantityScalar<Self>;
+    fn reference_volume() -> QuantityScalar<Self> {
+        Self::reference_length().powi(3)
+    }
+    fn reference_velocity() -> QuantityScalar<Self> {
+        Self::reference_length() / Self::reference_time()
+    }
+    fn reference_moles() -> QuantityScalar<Self> {
+        Self::reference_density() * Self::reference_volume()
+    }
+    fn reference_mass() -> QuantityScalar<Self> {
+        Self::reference_energy() * Self::reference_velocity().powi(-2)
+    }
+    fn reference_energy() -> QuantityScalar<Self> {
+        Self::gas_constant() * Self::reference_temperature() * Self::reference_moles()
+    }
+    fn reference_pressure() -> QuantityScalar<Self> {
+        Self::reference_energy() / Self::reference_volume()
+    }
+    fn reference_entropy() -> QuantityScalar<Self> {
+        Self::reference_energy() / Self::reference_temperature()
+    }
+    fn reference_molar_energy() -> QuantityScalar<Self> {
+        Self::reference_energy() / Self::reference_moles()
+    }
+    fn reference_molar_entropy() -> QuantityScalar<Self> {
+        Self::reference_entropy() / Self::reference_moles()
+    }
+    fn reference_surface_tension() -> QuantityScalar<Self> {
+        Self::reference_pressure() * Self::reference_length()
+    }
+    fn reference_influence_parameter() -> QuantityScalar<Self> {
+        Self::reference_temperature() * Self::gas_constant() * Self::reference_length().powi(2)
+            / Self::reference_density()
+    }
+    fn reference_molar_mass() -> QuantityScalar<Self> {
+        Self::reference_mass() / Self::reference_moles()
+    }
+    fn reference_viscosity() -> QuantityScalar<Self> {
+        Self::reference_pressure() * Self::reference_time()
+    }
+    fn reference_diffusion() -> QuantityScalar<Self> {
+        Self::reference_length().powi(2) / Self::reference_time()
+    }
+    fn reference_momentum() -> QuantityScalar<Self> {
+        Self::reference_molar_mass() * Self::reference_density() * Self::reference_velocity()
+    }
+}
+
+impl EosUnit for SIUnit {
+    fn reference_temperature() -> SINumber {
+        KELVIN
+    }
+    fn reference_length() -> SINumber {
+        ANGSTROM
+    }
+    fn reference_density() -> SINumber {
+        ANGSTROM.powi(-3) / NAV
+    }
+    fn reference_time() -> SINumber {
+        PICO * SECOND
+    }
+    fn gas_constant() -> SINumber {
+        RGAS
+    }
+}

--- a/feos-core/src/parameter/chemical_record.rs
+++ b/feos-core/src/parameter/chemical_record.rs
@@ -1,0 +1,156 @@
+use super::identifier::Identifier;
+use super::segment::SegmentRecord;
+use super::ParameterError;
+use conv::ValueInto;
+use num_traits::NumAssign;
+use serde::{Deserialize, Serialize};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
+
+// Auxiliary structure used to deserialize chemical records without explicit bond information.
+#[derive(Serialize, Deserialize)]
+struct ChemicalRecordJSON {
+    identifier: Identifier,
+    segments: Vec<String>,
+    bonds: Option<Vec<[usize; 2]>>,
+}
+
+/// Chemical information of a substance.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(from = "ChemicalRecordJSON")]
+#[serde(into = "ChemicalRecordJSON")]
+pub struct ChemicalRecord {
+    pub identifier: Identifier,
+    pub segments: Vec<String>,
+    pub bonds: Vec<[usize; 2]>,
+}
+
+impl From<ChemicalRecordJSON> for ChemicalRecord {
+    fn from(record: ChemicalRecordJSON) -> Self {
+        Self::new(record.identifier, record.segments, record.bonds)
+    }
+}
+
+impl From<ChemicalRecord> for ChemicalRecordJSON {
+    fn from(record: ChemicalRecord) -> Self {
+        Self {
+            identifier: record.identifier,
+            segments: record.segments,
+            bonds: Some(record.bonds),
+        }
+    }
+}
+
+impl ChemicalRecord {
+    /// Create a new `ChemicalRecord`.
+    ///
+    /// If no bonds are given, the molecule is assumed to be linear.
+    pub fn new(
+        identifier: Identifier,
+        segments: Vec<String>,
+        bonds: Option<Vec<[usize; 2]>>,
+    ) -> ChemicalRecord {
+        let bonds = bonds.unwrap_or_else(|| {
+            (0..segments.len() - 1)
+                .zip(1..segments.len())
+                .map(|x| [x.0, x.1])
+                .collect()
+        });
+        Self {
+            identifier,
+            segments,
+            bonds,
+        }
+    }
+
+    /// Count the number of occurences of each individual segment identifier in the
+    /// chemical record.
+    ///
+    /// The map contains the segment identifier as key and the count as value.
+    pub fn segment_count<T: NumAssign>(&self) -> HashMap<String, T> {
+        let mut counts = HashMap::with_capacity(self.segments.len());
+        for si in &self.segments {
+            let entry = counts.entry(si.clone()).or_insert_with(|| T::zero());
+            *entry += T::one();
+        }
+        counts
+    }
+
+    /// Count the number of occurences of bonds between each pair of segment identifiers
+    /// in the chemical record.
+    ///
+    /// The map contains the segment identifiers as key and the count as value.
+    pub fn bond_count<T: NumAssign>(&self) -> HashMap<[String; 2], T> {
+        let mut bond_counts = HashMap::new();
+        for b in &self.bonds {
+            let s1 = self.segments[b[0]].clone();
+            let s2 = self.segments[b[1]].clone();
+            let indices = if s1 > s2 { [s2, s1] } else { [s1, s2] };
+            let entry = bond_counts.entry(indices).or_insert_with(|| T::zero());
+            *entry += T::one();
+        }
+        bond_counts
+    }
+}
+
+impl std::fmt::Display for ChemicalRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChemicalRecord(")?;
+        write!(f, "\n\tidentifier={},", self.identifier)?;
+        write!(f, "\n\tsegments={:?},", self.segments)?;
+        write!(f, "\n\tbonds={:?}\n)", self.bonds)
+    }
+}
+
+/// Trait that enables parameter generation from generic molecular representations.
+pub trait SegmentCount {
+    type Count: Copy + ValueInto<f64>;
+
+    fn identifier(&self) -> Cow<Identifier>;
+
+    /// Count the number of occurences of each individual segment identifier in the
+    /// molecule.
+    ///
+    /// The map contains the segment identifier as key and the count as value.
+    fn segment_count(&self) -> Cow<HashMap<String, Self::Count>>;
+
+    /// Count the number of occurences of each individual segment in the
+    /// molecule.
+    ///
+    /// The map contains the segment record as key and the count as value.
+    fn segment_map<M: Clone, I: Clone>(
+        &self,
+        segment_records: &[SegmentRecord<M, I>],
+    ) -> Result<HashMap<SegmentRecord<M, I>, Self::Count>, ParameterError> {
+        let count = self.segment_count();
+        let queried: HashSet<_> = count.keys().cloned().collect();
+        let mut segments: HashMap<String, SegmentRecord<M, I>> = segment_records
+            .iter()
+            .map(|r| (r.identifier.clone(), r.clone()))
+            .collect();
+        let available = segments.keys().cloned().collect();
+        if !queried.is_subset(&available) {
+            let missing: Vec<String> = queried.difference(&available).cloned().collect();
+            let msg = format!("{:?}", missing);
+            return Err(ParameterError::ComponentsNotFound(msg));
+        };
+        Ok(count
+            .iter()
+            .map(|(s, c)| (segments.remove(s).unwrap(), *c))
+            .collect())
+    }
+}
+
+impl SegmentCount for ChemicalRecord {
+    type Count = usize;
+
+    fn identifier(&self) -> Cow<Identifier> {
+        Cow::Borrowed(&self.identifier)
+    }
+
+    fn segment_count(&self) -> Cow<HashMap<String, usize>> {
+        Cow::Owned(self.segment_count())
+    }
+}

--- a/feos-core/src/parameter/identifier.rs
+++ b/feos-core/src/parameter/identifier.rs
@@ -1,0 +1,137 @@
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+
+/// Possible variants to identify a substance.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub enum IdentifierOption {
+    Cas,
+    Name,
+    IupacName,
+    Smiles,
+    Inchi,
+    Formula,
+}
+
+/// A collection of identifiers for a chemical structure or substance.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct Identifier {
+    /// CAS number
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cas: Option<String>,
+    /// Commonly used english name
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// IUPAC name
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iupac_name: Option<String>,
+    /// SMILES key
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smiles: Option<String>,
+    /// InchI key
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inchi: Option<String>,
+    /// Chemical formula
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub formula: Option<String>,
+}
+
+impl Identifier {
+    /// Create a new identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use feos_core::parameter::Identifier;
+    /// let methanol = Identifier::new(
+    ///     Some("67-56-1"),
+    ///     Some("methanol"),
+    ///     Some("methanol"),
+    ///     Some("CO"),
+    ///     Some("InChI=1S/CH4O/c1-2/h2H,1H3"),
+    ///     Some("CH4O")
+    /// );
+    pub fn new(
+        cas: Option<&str>,
+        name: Option<&str>,
+        iupac_name: Option<&str>,
+        smiles: Option<&str>,
+        inchi: Option<&str>,
+        formula: Option<&str>,
+    ) -> Identifier {
+        Identifier {
+            cas: cas.map(Into::into),
+            name: name.map(Into::into),
+            iupac_name: iupac_name.map(Into::into),
+            smiles: smiles.map(Into::into),
+            inchi: inchi.map(Into::into),
+            formula: formula.map(Into::into),
+        }
+    }
+
+    pub fn as_string(&self, option: IdentifierOption) -> Option<String> {
+        match option {
+            IdentifierOption::Cas => self.cas.clone(),
+            IdentifierOption::Name => self.name.clone(),
+            IdentifierOption::IupacName => self.iupac_name.clone(),
+            IdentifierOption::Smiles => self.smiles.clone(),
+            IdentifierOption::Inchi => self.inchi.clone(),
+            IdentifierOption::Formula => self.formula.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut ids = Vec::new();
+        if let Some(n) = &self.cas {
+            ids.push(format!("cas={}", n));
+        }
+        if let Some(n) = &self.name {
+            ids.push(format!("name={}", n));
+        }
+        if let Some(n) = &self.iupac_name {
+            ids.push(format!("iupac_name={}", n));
+        }
+        if let Some(n) = &self.smiles {
+            ids.push(format!("smiles={}", n));
+        }
+        if let Some(n) = &self.inchi {
+            ids.push(format!("inchi={}", n));
+        }
+        if let Some(n) = &self.formula {
+            ids.push(format!("formula={}", n));
+        }
+        write!(f, "Identifier({})", ids.join(", "))
+    }
+}
+
+impl PartialEq for Identifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.cas == other.cas
+    }
+}
+impl Eq for Identifier {}
+
+impl Hash for Identifier {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.cas.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_fmt() {
+        let id = Identifier::new(None, Some("acetone"), None, Some("CC(=O)C"), None, None);
+        assert_eq!(id.to_string(), "Identifier(name=acetone, smiles=CC(=O)C)");
+    }
+}

--- a/feos-core/src/parameter/mod.rs
+++ b/feos-core/src/parameter/mod.rs
@@ -1,0 +1,685 @@
+//! Structures and traits that can be used to build model parameters for equations of state.
+
+use indexmap::{IndexMap, IndexSet};
+use ndarray::Array2;
+use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io;
+use std::io::BufReader;
+use std::path::Path;
+use thiserror::Error;
+
+mod chemical_record;
+mod identifier;
+mod model_record;
+mod segment;
+
+pub use chemical_record::{ChemicalRecord, SegmentCount};
+pub use identifier::{Identifier, IdentifierOption};
+pub use model_record::{BinaryRecord, FromSegments, FromSegmentsBinary, PureRecord};
+pub use segment::SegmentRecord;
+
+/// Constructor methods for parameters.
+///
+/// By implementing `Parameter` for a type, you define how parameters
+/// of an equation of state can be constructed from a sequence of
+/// single substance records and possibly binary interaction parameters.
+pub trait Parameter
+where
+    Self: Sized,
+{
+    type Pure: Clone + DeserializeOwned;
+    type IdealGas: Clone + DeserializeOwned;
+    type Binary: Clone + DeserializeOwned + Default;
+
+    /// Creates parameters from records for pure substances and possibly binary parameters.
+    fn from_records(
+        pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
+        binary_records: Array2<Self::Binary>,
+    ) -> Self;
+
+    /// Creates parameters for a pure component from a pure record.
+    fn new_pure(pure_record: PureRecord<Self::Pure, Self::IdealGas>) -> Self {
+        let binary_record = Array2::from_elem([1, 1], Self::Binary::default());
+        Self::from_records(vec![pure_record], binary_record)
+    }
+
+    /// Creates parameters for a binary system from pure records and an optional
+    /// binary interaction parameter.
+    fn new_binary(
+        pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
+        binary_record: Option<Self::Binary>,
+    ) -> Self {
+        let binary_record = Array2::from_shape_fn([2, 2], |(i, j)| {
+            if i == j {
+                Self::Binary::default()
+            } else {
+                binary_record.clone().unwrap_or_default()
+            }
+        });
+        Self::from_records(pure_records, binary_record)
+    }
+
+    /// Return the original pure and binary records that were used to construct the parameters.
+    #[allow(clippy::type_complexity)]
+    fn records(
+        &self,
+    ) -> (
+        &[PureRecord<Self::Pure, Self::IdealGas>],
+        &Array2<Self::Binary>,
+    );
+
+    /// Helper function to build matrix from list of records in correct order.
+    ///
+    /// If the identifiers in `binary_records` are not a subset of those in
+    /// `pure_records`, the `Default` implementation of Self::Binary is used.
+    fn binary_matrix_from_records(
+        pure_records: &Vec<PureRecord<Self::Pure, Self::IdealGas>>,
+        binary_records: &[BinaryRecord<Identifier, Self::Binary>],
+        search_option: IdentifierOption,
+    ) -> Array2<Self::Binary> {
+        // Build Hashmap (id, id) -> BinaryRecord
+        let binary_map: HashMap<(String, String), Self::Binary> = {
+            binary_records
+                .iter()
+                .filter_map(|br| {
+                    let id1 = br.id1.as_string(search_option);
+                    let id2 = br.id2.as_string(search_option);
+                    id1.and_then(|id1| id2.map(|id2| ((id1, id2), br.model_record.clone())))
+                })
+                .collect()
+        };
+        let n = pure_records.len();
+        Array2::from_shape_fn([n, n], |(i, j)| {
+            let id1 = pure_records[i].identifier.as_string(search_option).unwrap();
+            let id2 = pure_records[j].identifier.as_string(search_option).unwrap();
+            binary_map
+                .get(&(id1.clone(), id2.clone()))
+                .or_else(|| binary_map.get(&(id2, id1)))
+                .cloned()
+                .unwrap_or_default()
+        })
+    }
+
+    /// Creates parameters from substance information stored in json files.
+    fn from_json<P>(
+        substances: Vec<&str>,
+        file_pure: P,
+        file_binary: Option<P>,
+        search_option: IdentifierOption,
+    ) -> Result<Self, ParameterError>
+    where
+        P: AsRef<Path>,
+    {
+        Self::from_multiple_json(&[(substances, file_pure)], file_binary, search_option)
+    }
+
+    /// Creates parameters from substance information stored in multiple json files.
+    fn from_multiple_json<P>(
+        input: &[(Vec<&str>, P)],
+        file_binary: Option<P>,
+        search_option: IdentifierOption,
+    ) -> Result<Self, ParameterError>
+    where
+        P: AsRef<Path>,
+    {
+        let mut queried: IndexSet<String> = IndexSet::new();
+        let mut record_map: HashMap<String, PureRecord<Self::Pure, Self::IdealGas>> =
+            HashMap::new();
+
+        for (substances, file) in input {
+            substances.iter().try_for_each(|identifier| {
+                match queried.insert(identifier.to_string()) {
+                    true => Ok(()),
+                    false => Err(ParameterError::IncompatibleParameters(format!(
+                        "tried to add substance '{}' to system but it is already present.",
+                        identifier
+                    ))),
+                }
+            })?;
+            let f = File::open(file)?;
+            let reader = BufReader::new(f);
+
+            let pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>> =
+                serde_json::from_reader(reader)?;
+
+            pure_records
+                .into_iter()
+                .filter_map(|record| {
+                    record
+                        .identifier
+                        .as_string(search_option)
+                        .map(|i| (i, record))
+                })
+                .for_each(|(i, r)| {
+                    let _ = record_map.insert(i, r);
+                });
+        }
+
+        // Compare queried components and available components
+        let available: IndexSet<String> = record_map
+            .keys()
+            .map(|identifier| identifier.to_string())
+            .collect();
+        if !queried.is_subset(&available) {
+            let missing: Vec<String> = queried.difference(&available).cloned().collect();
+            let msg = format!("{:?}", missing);
+            return Err(ParameterError::ComponentsNotFound(msg));
+        };
+        let p = queried
+            .iter()
+            .filter_map(|identifier| record_map.remove(&identifier.clone()))
+            .collect();
+
+        let binary_records = if let Some(path) = file_binary {
+            let file = File::open(path)?;
+            let reader = BufReader::new(file);
+            serde_json::from_reader(reader)?
+        } else {
+            Vec::new()
+        };
+        let record_matrix = Self::binary_matrix_from_records(&p, &binary_records, search_option);
+        Ok(Self::from_records(p, record_matrix))
+    }
+
+    /// Creates parameters from the molecular structure and segment information.
+    ///
+    /// The [FromSegments] trait needs to be implemented for both the model record
+    /// and the ideal gas record.
+    fn from_segments<C: SegmentCount>(
+        chemical_records: Vec<C>,
+        segment_records: Vec<SegmentRecord<Self::Pure, Self::IdealGas>>,
+        binary_segment_records: Option<Vec<BinaryRecord<String, Self::Binary>>>,
+    ) -> Result<Self, ParameterError>
+    where
+        Self::Pure: FromSegments<C::Count>,
+        Self::IdealGas: FromSegments<C::Count>,
+        Self::Binary: FromSegmentsBinary<C::Count>,
+    {
+        // update the pure records with model and ideal gas records
+        // calculated from the gc method
+        let pure_records = chemical_records
+            .iter()
+            .map(|cr| {
+                cr.segment_map(&segment_records).and_then(|segments| {
+                    PureRecord::from_segments(cr.identifier().into_owned(), segments)
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Map: (id1, id2) -> model_record
+        // empty, if no binary segment records are provided
+        let binary_map: HashMap<_, _> = binary_segment_records
+            .into_iter()
+            .flat_map(|seg| seg.into_iter())
+            .map(|br| ((br.id1, br.id2), br.model_record))
+            .collect();
+
+        // For every component:  map: id -> count
+        let segment_counts: Vec<_> = chemical_records
+            .iter()
+            .map(|cr| cr.segment_count())
+            .collect();
+
+        // full matrix of binary records from the gc method.
+        // If a specific segment-segment interaction is not in the binary map,
+        // the default value is used.
+        let n = pure_records.len();
+        let mut binary_records = Array2::default([n, n]);
+        for i in 0..n {
+            for j in 0..n {
+                let mut vec = Vec::new();
+                for (id1, &n1) in segment_counts[i].iter() {
+                    for (id2, &n2) in segment_counts[j].iter() {
+                        let binary = binary_map
+                            .get(&(id1.clone(), id2.clone()))
+                            .or_else(|| binary_map.get(&(id2.clone(), id1.clone())))
+                            .cloned()
+                            .unwrap_or_default();
+                        vec.push((binary, n1, n2));
+                    }
+                }
+                binary_records[(i, j)] = Self::Binary::from_segments_binary(&vec)?
+            }
+        }
+
+        Ok(Self::from_records(pure_records, binary_records))
+    }
+
+    /// Creates parameters from segment information stored in json files.
+    ///
+    /// The [FromSegments] trait needs to be implemented for both the model record
+    /// and the ideal gas record.
+    fn from_json_segments<P>(
+        substances: &[&str],
+        file_pure: P,
+        file_segments: P,
+        file_binary: Option<P>,
+        search_option: IdentifierOption,
+    ) -> Result<Self, ParameterError>
+    where
+        P: AsRef<Path>,
+        Self::Pure: FromSegments<usize>,
+        Self::IdealGas: FromSegments<usize>,
+        Self::Binary: FromSegmentsBinary<usize>,
+    {
+        let queried: IndexSet<String> = substances
+            .iter()
+            .map(|identifier| identifier.to_string())
+            .collect();
+
+        let file = File::open(file_pure)?;
+        let reader = BufReader::new(file);
+        let chemical_records: Vec<ChemicalRecord> = serde_json::from_reader(reader)?;
+        let mut record_map: HashMap<_, _> = chemical_records
+            .into_iter()
+            .filter_map(|record| {
+                record
+                    .identifier
+                    .as_string(search_option)
+                    .map(|i| (i, record))
+            })
+            .collect();
+
+        // Compare queried components and available components
+        let available: IndexSet<String> = record_map
+            .keys()
+            .map(|identifier| identifier.to_string())
+            .collect();
+        if !queried.is_subset(&available) {
+            let missing: Vec<String> = queried.difference(&available).cloned().collect();
+            let msg = format!("{:?}", missing);
+            return Err(ParameterError::ComponentsNotFound(msg));
+        };
+
+        // collect all pure records that were queried
+        let chemical_records: Vec<_> = queried
+            .iter()
+            .filter_map(|identifier| record_map.remove(&identifier.clone()))
+            .collect();
+
+        // Read segment records
+        let segment_records: Vec<SegmentRecord<Self::Pure, Self::IdealGas>> =
+            SegmentRecord::from_json(file_segments)?;
+
+        // Read binary records
+        let binary_records = file_binary
+            .map(|file_binary| {
+                let reader = BufReader::new(File::open(file_binary)?);
+                let binary_records: Result<
+                    Vec<BinaryRecord<String, Self::Binary>>,
+                    ParameterError,
+                > = Ok(serde_json::from_reader(reader)?);
+                binary_records
+            })
+            .transpose()?;
+
+        Self::from_segments(chemical_records, segment_records, binary_records)
+    }
+
+    /// Return a parameter set containing the subset of components specified in `component_list`.
+    fn subset(&self, component_list: &[usize]) -> Self {
+        let (pure_records, binary_records) = self.records();
+        let pure_records = component_list
+            .iter()
+            .map(|&i| pure_records[i].clone())
+            .collect();
+        let n = component_list.len();
+        let binary_records = Array2::from_shape_fn([n, n], |(i, j)| {
+            binary_records[(component_list[i], component_list[j])].clone()
+        });
+
+        Self::from_records(pure_records, binary_records)
+    }
+}
+
+/// Constructor methods for parameters for heterosegmented models.
+pub trait ParameterHetero: Sized {
+    type Chemical: Clone;
+    type Pure: Clone + DeserializeOwned;
+    type IdealGas: Clone + DeserializeOwned;
+    type Binary: Clone + DeserializeOwned;
+
+    /// Creates parameters from the molecular structure and segment information.
+    fn from_segments<C: Clone + Into<Self::Chemical>>(
+        chemical_records: Vec<C>,
+        segment_records: Vec<SegmentRecord<Self::Pure, Self::IdealGas>>,
+        binary_segment_records: Option<Vec<BinaryRecord<String, Self::Binary>>>,
+    ) -> Result<Self, ParameterError>;
+
+    /// Return the original records that were used to construct the parameters.
+    #[allow(clippy::type_complexity)]
+    fn records(
+        &self,
+    ) -> (
+        &[Self::Chemical],
+        &[SegmentRecord<Self::Pure, Self::IdealGas>],
+        &Option<Vec<BinaryRecord<String, Self::Binary>>>,
+    );
+
+    /// Creates parameters from segment information stored in json files.
+    fn from_json_segments<P>(
+        substances: &[&str],
+        file_pure: P,
+        file_segments: P,
+        file_binary: Option<P>,
+        search_option: IdentifierOption,
+    ) -> Result<Self, ParameterError>
+    where
+        P: AsRef<Path>,
+        ChemicalRecord: Into<Self::Chemical>,
+    {
+        let queried: IndexSet<String> = substances
+            .iter()
+            .map(|identifier| identifier.to_string())
+            .collect();
+
+        let reader = BufReader::new(File::open(file_pure)?);
+        let chemical_records: Vec<ChemicalRecord> = serde_json::from_reader(reader)?;
+        let mut record_map: IndexMap<_, _> = chemical_records
+            .into_iter()
+            .filter_map(|record| {
+                record
+                    .identifier
+                    .as_string(search_option)
+                    .map(|i| (i, record))
+            })
+            .collect();
+
+        // Compare queried components and available components
+        let available: IndexSet<String> = record_map
+            .keys()
+            .map(|identifier| identifier.to_string())
+            .collect();
+        if !queried.is_subset(&available) {
+            let missing: Vec<String> = queried.difference(&available).cloned().collect();
+            return Err(ParameterError::ComponentsNotFound(format!("{:?}", missing)));
+        };
+
+        // Collect all pure records that were queried
+        let chemical_records: Vec<_> = queried
+            .iter()
+            .filter_map(|identifier| record_map.remove(&identifier.clone()))
+            .collect();
+
+        // Read segment records
+        let segment_records: Vec<SegmentRecord<Self::Pure, Self::IdealGas>> =
+            SegmentRecord::from_json(file_segments)?;
+
+        // Read binary records
+        let binary_records = file_binary
+            .map(|file_binary| {
+                let reader = BufReader::new(File::open(file_binary)?);
+                let binary_records: Result<
+                    Vec<BinaryRecord<String, Self::Binary>>,
+                    ParameterError,
+                > = Ok(serde_json::from_reader(reader)?);
+                binary_records
+            })
+            .transpose()?;
+
+        Self::from_segments(chemical_records, segment_records, binary_records)
+    }
+
+    /// Return a parameter set containing the subset of components specified in `component_list`.
+    fn subset(&self, component_list: &[usize]) -> Self {
+        let (chemical_records, segment_records, binary_segment_records) = self.records();
+        let chemical_records: Vec<_> = component_list
+            .iter()
+            .map(|&i| chemical_records[i].clone())
+            .collect();
+        Self::from_segments(
+            chemical_records,
+            segment_records.to_vec(),
+            binary_segment_records.clone(),
+        )
+        .unwrap()
+    }
+}
+
+/// Error type for incomplete parameter information and IO problems.
+#[derive(Error, Debug)]
+pub enum ParameterError {
+    #[error(transparent)]
+    FileIO(#[from] io::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error("The following component(s) were not found: {0}")]
+    ComponentsNotFound(String),
+    #[error("The identifier '{0}' is not known. ['cas', 'name', 'iupacname', 'smiles', inchi', 'formula']")]
+    IdentifierNotFound(String),
+    #[error("Information missing.")]
+    InsufficientInformation,
+    #[error("Incompatible parameters: {0}")]
+    IncompatibleParameters(String),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::joback::JobackRecord;
+    use serde::{Deserialize, Serialize};
+    use std::convert::TryFrom;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+    struct MyPureModel {
+        a: f64,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+    struct MyBinaryModel {
+        b: f64,
+    }
+
+    impl TryFrom<f64> for MyBinaryModel {
+        type Error = &'static str;
+        fn try_from(f: f64) -> Result<Self, Self::Error> {
+            Ok(Self { b: f })
+        }
+    }
+
+    struct MyParameter {
+        pure_records: Vec<PureRecord<MyPureModel, JobackRecord>>,
+        binary_records: Array2<MyBinaryModel>,
+    }
+
+    impl Parameter for MyParameter {
+        type Pure = MyPureModel;
+        type IdealGas = JobackRecord;
+        type Binary = MyBinaryModel;
+        fn from_records(
+            pure_records: Vec<PureRecord<MyPureModel, JobackRecord>>,
+            binary_records: Array2<MyBinaryModel>,
+        ) -> Self {
+            Self {
+                pure_records,
+                binary_records,
+            }
+        }
+
+        fn records(
+            &self,
+        ) -> (
+            &[PureRecord<MyPureModel, JobackRecord>],
+            &Array2<MyBinaryModel>,
+        ) {
+            (&self.pure_records, &self.binary_records)
+        }
+    }
+
+    #[test]
+    fn from_records() {
+        let pr_json = r#"
+        [
+            {
+                "identifier": {
+                    "cas": "123-4-5"
+                },
+                "molarweight": 16.0426,
+                "model_record": {
+                    "a": 0.1
+                }
+            },
+            {
+                "identifier": {
+                    "cas": "678-9-1"
+                },
+                "molarweight": 32.08412,
+                "model_record": {
+                    "a": 0.2
+                }
+            }
+        ]
+        "#;
+        let br_json = r#"
+        [
+            {
+                "id1": {
+                    "cas": "123-4-5"
+                },
+                "id2": {
+                    "cas": "678-9-1"
+                },
+                "model_record": {
+                    "b": 12.0
+                }
+            }
+        ]
+        "#;
+        let pure_records = serde_json::from_str(pr_json).expect("Unable to parse json.");
+        let binary_records: Vec<_> = serde_json::from_str(br_json).expect("Unable to parse json.");
+        let binary_matrix = MyParameter::binary_matrix_from_records(
+            &pure_records,
+            &binary_records,
+            IdentifierOption::Cas,
+        );
+        let p = MyParameter::from_records(pure_records, binary_matrix);
+
+        assert_eq!(p.pure_records[0].identifier.cas, Some("123-4-5".into()));
+        assert_eq!(p.pure_records[1].identifier.cas, Some("678-9-1".into()));
+        assert_eq!(p.binary_records[[0, 1]].b, 12.0)
+    }
+
+    #[test]
+    fn from_records_missing_binary() {
+        let pr_json = r#"
+        [
+            {
+                "identifier": {
+                    "cas": "123-4-5"
+                },
+                "molarweight": 16.0426,
+                "model_record": {
+                    "a": 0.1
+                }
+            },
+            {
+                "identifier": {
+                    "cas": "678-9-1"
+                },
+                "molarweight": 32.08412,
+                "model_record": {
+                    "a": 0.2
+                }
+            }
+        ]
+        "#;
+        let br_json = r#"
+        [
+            {
+                "id1": {
+                    "cas": "123-4-5"
+                },
+                "id2": {
+                    "cas": "000-00-0"
+                },
+                "model_record": {
+                    "b": 12.0
+                }
+            }
+        ]
+        "#;
+        let pure_records = serde_json::from_str(pr_json).expect("Unable to parse json.");
+        let binary_records: Vec<_> = serde_json::from_str(br_json).expect("Unable to parse json.");
+        let binary_matrix = MyParameter::binary_matrix_from_records(
+            &pure_records,
+            &binary_records,
+            IdentifierOption::Cas,
+        );
+        let p = MyParameter::from_records(pure_records, binary_matrix);
+
+        assert_eq!(p.pure_records[0].identifier.cas, Some("123-4-5".into()));
+        assert_eq!(p.pure_records[1].identifier.cas, Some("678-9-1".into()));
+        assert_eq!(p.binary_records[[0, 1]], MyBinaryModel::default());
+        assert_eq!(p.binary_records[[0, 1]].b, 0.0)
+    }
+
+    #[test]
+    fn from_records_correct_binary_order() {
+        let pr_json = r#"
+        [
+            {
+                "identifier": {
+                    "cas": "000-0-0"
+                },
+                "molarweight": 32.08412,
+                "model_record": {
+                    "a": 0.2
+                }
+            },
+            {
+                "identifier": {
+                    "cas": "123-4-5"
+                },
+                "molarweight": 16.0426,
+                "model_record": {
+                    "a": 0.1
+                }
+            },
+            {
+                "identifier": {
+                    "cas": "678-9-1"
+                },
+                "molarweight": 32.08412,
+                "model_record": {
+                    "a": 0.2
+                }
+            }
+        ]
+        "#;
+        let br_json = r#"
+        [
+            {
+                "id1": {
+                    "cas": "123-4-5"
+                },
+                "id2": {
+                    "cas": "678-9-1"
+                },
+                "model_record": {
+                    "b": 12.0
+                }
+            }
+        ]
+        "#;
+        let pure_records = serde_json::from_str(pr_json).expect("Unable to parse json.");
+        let binary_records: Vec<_> = serde_json::from_str(br_json).expect("Unable to parse json.");
+        let binary_matrix = MyParameter::binary_matrix_from_records(
+            &pure_records,
+            &binary_records,
+            IdentifierOption::Cas,
+        );
+        let p = MyParameter::from_records(pure_records, binary_matrix);
+
+        assert_eq!(p.pure_records[0].identifier.cas, Some("000-0-0".into()));
+        assert_eq!(p.pure_records[1].identifier.cas, Some("123-4-5".into()));
+        assert_eq!(p.pure_records[2].identifier.cas, Some("678-9-1".into()));
+        assert_eq!(p.binary_records[[0, 1]], MyBinaryModel::default());
+        assert_eq!(p.binary_records[[1, 0]], MyBinaryModel::default());
+        assert_eq!(p.binary_records[[0, 2]], MyBinaryModel::default());
+        assert_eq!(p.binary_records[[2, 0]], MyBinaryModel::default());
+        assert_eq!(p.binary_records[[2, 1]].b, 12.0);
+        assert_eq!(p.binary_records[[1, 2]].b, 12.0);
+    }
+}

--- a/feos-core/src/parameter/model_record.rs
+++ b/feos-core/src/parameter/model_record.rs
@@ -1,0 +1,196 @@
+use super::identifier::Identifier;
+use super::segment::SegmentRecord;
+use super::ParameterError;
+use conv::ValueInto;
+use serde::{Deserialize, Serialize};
+
+/// A collection of parameters of a pure substance.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PureRecord<M, I> {
+    pub identifier: Identifier,
+    pub molarweight: f64,
+    pub model_record: M,
+    #[serde(default = "Default::default")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ideal_gas_record: Option<I>,
+}
+
+impl<M, I> PureRecord<M, I> {
+    /// Create a new `PureRecord`.
+    pub fn new(
+        identifier: Identifier,
+        molarweight: f64,
+        model_record: M,
+        ideal_gas_record: Option<I>,
+    ) -> Self {
+        Self {
+            identifier,
+            molarweight,
+            model_record,
+            ideal_gas_record,
+        }
+    }
+
+    /// Update the `PureRecord` from segment counts.
+    ///
+    /// The [FromSegments] trait needs to be implemented for both the model record
+    /// and the ideal gas record.
+    pub fn from_segments<S, T>(identifier: Identifier, segments: S) -> Result<Self, ParameterError>
+    where
+        T: Copy + ValueInto<f64>,
+        M: FromSegments<T>,
+        I: FromSegments<T>,
+        S: IntoIterator<Item = (SegmentRecord<M, I>, T)>,
+    {
+        let mut molarweight = 0.0;
+        let mut model_segments = Vec::new();
+        let mut ideal_gas_segments = Vec::new();
+        for (s, n) in segments {
+            molarweight += s.molarweight * n.value_into().unwrap();
+            model_segments.push((s.model_record, n));
+            ideal_gas_segments.push(s.ideal_gas_record.map(|ig| (ig, n)));
+        }
+        let model_record = M::from_segments(&model_segments)?;
+
+        let ideal_gas_segments: Option<Vec<_>> = ideal_gas_segments.into_iter().collect();
+        let ideal_gas_record = ideal_gas_segments
+            .as_deref()
+            .map(I::from_segments)
+            .transpose()?;
+
+        Ok(Self::new(
+            identifier,
+            molarweight,
+            model_record,
+            ideal_gas_record,
+        ))
+    }
+}
+
+impl<M, I> std::fmt::Display for PureRecord<M, I>
+where
+    M: std::fmt::Display,
+    I: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PureRecord(")?;
+        write!(f, "\n\tidentifier={},", self.identifier)?;
+        write!(f, "\n\tmolarweight={},", self.molarweight)?;
+        write!(f, "\n\tmodel_record={},", self.model_record)?;
+        if let Some(i) = self.ideal_gas_record.as_ref() {
+            write!(f, "\n\tideal_gas_record={},", i)?;
+        }
+        write!(f, "\n)")
+    }
+}
+
+/// Trait for models that implement a homosegmented group contribution
+/// method
+pub trait FromSegments<T>: Clone {
+    /// Constructs the record from a list of segment records with their
+    /// number of occurences.
+    fn from_segments(segments: &[(Self, T)]) -> Result<Self, ParameterError>;
+}
+
+/// Trait for models that implement a homosegmented group contribution
+/// method and have a combining rule for binary interaction parameters.
+pub trait FromSegmentsBinary<T>: Clone {
+    /// Constructs the binary record from a list of segment records with
+    /// their number of occurences.
+    fn from_segments_binary(segments: &[(Self, T, T)]) -> Result<Self, ParameterError>;
+}
+
+/// A collection of parameters that model interactions between two
+/// substances or segments.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BinaryRecord<I, B> {
+    /// Identifier of the first component
+    pub id1: I,
+    /// Identifier of the second component
+    pub id2: I,
+    /// Binary interaction parameter(s)
+    pub model_record: B,
+}
+
+impl<I, B> BinaryRecord<I, B> {
+    /// Crates a new `BinaryRecord`.
+    pub fn new(id1: I, id2: I, model_record: B) -> Self {
+        Self {
+            id1,
+            id2,
+            model_record,
+        }
+    }
+}
+
+impl<I, B> std::fmt::Display for BinaryRecord<I, B>
+where
+    I: std::fmt::Display,
+    B: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BinaryRecord(")?;
+        write!(f, "\n\tid1={},", self.id1)?;
+        write!(f, "\n\tid2={},", self.id2)?;
+        write!(f, "\n\tmodel_record={},", self.model_record)?;
+        write!(f, "\n)")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::joback::JobackRecord;
+
+    #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+    struct TestModelRecordSegments {
+        a: f64,
+    }
+
+    #[test]
+    fn deserialize() {
+        let r = r#"
+        {
+            "identifier": {
+                "cas": "123-4-5"
+            },
+            "molarweight": 16.0426,
+            "model_record": {
+                "a": 0.1
+            }
+        }
+        "#;
+        let record: PureRecord<TestModelRecordSegments, JobackRecord> =
+            serde_json::from_str(r).expect("Unable to parse json.");
+        assert_eq!(record.identifier.cas, Some("123-4-5".into()))
+    }
+
+    #[test]
+    fn deserialize_list() {
+        let r = r#"
+        [
+            {
+                "identifier": {
+                    "cas": "1"
+                },
+                "molarweight": 1.0,
+                "model_record": {
+                    "a": 1.0
+                }
+            },
+            {
+                "identifier": {
+                    "cas": "2"
+                },
+                "molarweight": 2.0,
+                "model_record": {
+                    "a": 2.0
+                }
+            }
+        ]"#;
+        let records: Vec<PureRecord<TestModelRecordSegments, JobackRecord>> =
+            serde_json::from_str(r).expect("Unable to parse json.");
+        assert_eq!(records[0].identifier.cas, Some("1".into()));
+        assert_eq!(records[1].identifier.cas, Some("2".into()))
+    }
+}

--- a/feos-core/src/parameter/segment.rs
+++ b/feos-core/src/parameter/segment.rs
@@ -1,0 +1,67 @@
+use super::ParameterError;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::hash::{Hash, Hasher};
+use std::io::BufReader;
+use std::path::Path;
+
+/// Parameters describing an individual segment of a molecule.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SegmentRecord<M, I> {
+    pub identifier: String,
+    pub molarweight: f64,
+    pub model_record: M,
+    pub ideal_gas_record: Option<I>,
+}
+
+impl<M, I> SegmentRecord<M, I> {
+    /// Creates a new `SegmentRecord`.
+    pub fn new(
+        identifier: String,
+        molarweight: f64,
+        model_record: M,
+        ideal_gas_record: Option<I>,
+    ) -> Self {
+        Self {
+            identifier,
+            molarweight,
+            model_record,
+            ideal_gas_record,
+        }
+    }
+
+    /// Read a list of `SegmentRecord`s from a JSON file.
+    pub fn from_json<P: AsRef<Path>>(file: P) -> Result<Vec<Self>, ParameterError>
+    where
+        I: DeserializeOwned,
+        M: DeserializeOwned,
+    {
+        Ok(serde_json::from_reader(BufReader::new(File::open(file)?))?)
+    }
+}
+
+impl<M, I> Hash for SegmentRecord<M, I> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.identifier.hash(state);
+    }
+}
+
+impl<M, I> PartialEq for SegmentRecord<M, I> {
+    fn eq(&self, other: &Self) -> bool {
+        self.identifier == other.identifier
+    }
+}
+impl<M, I> Eq for SegmentRecord<M, I> {}
+
+impl<M: std::fmt::Display, I: std::fmt::Display> std::fmt::Display for SegmentRecord<M, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SegmentRecord(\n\tidentifier={}", self.identifier)?;
+        write!(f, "\n\tmolarweight={}", self.molarweight)?;
+        write!(f, "\n\tmodel_record={}", self.model_record)?;
+        if let Some(i) = self.ideal_gas_record.as_ref() {
+            write!(f, "\n\tideal_gas_record={},", i)?;
+        }
+        write!(f, "\n)")
+    }
+}

--- a/feos-core/src/phase_equilibria/bubble_dew.rs
+++ b/feos-core/src/phase_equilibria/bubble_dew.rs
@@ -1,0 +1,619 @@
+use super::{PhaseEquilibrium, SolverOptions, Verbosity};
+use crate::errors::{EosError, EosResult};
+use crate::state::{
+    Contributions,
+    DensityInitialization::{InitialDensity, Liquid, Vapor},
+    State, StateBuilder, TPSpec,
+};
+use crate::{equation_of_state::EquationOfState, EosUnit};
+use ndarray::*;
+use num_dual::linalg::{norm, LU};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::convert::TryFrom;
+use std::rc::Rc;
+
+const MAX_ITER_INNER: usize = 5;
+const TOL_INNER: f64 = 1e-9;
+const MAX_ITER_OUTER: usize = 400;
+const TOL_OUTER: f64 = 1e-10;
+
+const MAX_TSTEP: f64 = 20.0;
+const MAX_LNPSTEP: f64 = 0.1;
+const PROMISING_F: f64 = 1.0;
+const P_START: f64 = 1.0 / 138.0649; // equivalent to 1 bar in SI units
+const T_START: f64 = 400.0;
+const NEWTON_TOL: f64 = 1e-3;
+
+impl<U: EosUnit> TPSpec<U> {
+    fn starting_value(&self) -> QuantityScalar<U> {
+        match self {
+            Self::Temperature(_) => P_START * U::reference_pressure(),
+            Self::Pressure(_) => T_START * U::reference_temperature(),
+        }
+    }
+
+    pub(super) fn temperature_pressure(
+        &self,
+        tp_init: QuantityScalar<U>,
+    ) -> (Self, QuantityScalar<U>, QuantityScalar<U>) {
+        match self {
+            Self::Temperature(t) => (Self::Pressure(tp_init), *t, tp_init),
+            Self::Pressure(p) => (Self::Temperature(tp_init), tp_init, *p),
+        }
+    }
+
+    fn identifier(&self) -> &str {
+        match self {
+            Self::Temperature(_) => "temperature",
+            Self::Pressure(_) => "pressure",
+        }
+    }
+}
+
+impl<U: EosUnit> std::fmt::Display for TPSpec<U>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Temperature(t) => {
+                write!(f, " ")?;
+                t.fmt(f)?;
+                write!(f, " ")
+            }
+            Self::Pressure(p) => p.fmt(f),
+        }
+    }
+}
+
+/// # Bubble and dew point calculations
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    /// Calculate a phase equilibrium for a given temperature
+    /// or pressure and composition of the liquid phase.
+    pub fn bubble_point(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        liquid_molefracs: &Array1<f64>,
+        tp_init: Option<QuantityScalar<U>>,
+        vapor_molefracs: Option<&Array1<f64>>,
+        options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        Self::bubble_dew_point_with_options(
+            eos,
+            TPSpec::try_from(temperature_or_pressure)?,
+            tp_init,
+            liquid_molefracs,
+            vapor_molefracs,
+            true,
+            options,
+        )
+    }
+
+    /// Calculate a phase equilibrium for a given temperature
+    /// or pressure and composition of the vapor phase.
+    pub fn dew_point(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        vapor_molefracs: &Array1<f64>,
+        tp_init: Option<QuantityScalar<U>>,
+        liquid_molefracs: Option<&Array1<f64>>,
+        options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        Self::bubble_dew_point_with_options(
+            eos,
+            TPSpec::try_from(temperature_or_pressure)?,
+            tp_init,
+            vapor_molefracs,
+            liquid_molefracs,
+            false,
+            options,
+        )
+    }
+
+    pub(super) fn bubble_dew_point_with_options(
+        eos: &Rc<E>,
+        tp_spec: TPSpec<U>,
+        tp_init: Option<QuantityScalar<U>>,
+        molefracs_spec: &Array1<f64>,
+        molefracs_init: Option<&Array1<f64>>,
+        bubble: bool,
+        options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        let tp_init = tp_init.unwrap_or_else(|| tp_spec.starting_value());
+        let (var, t, p) = tp_spec.temperature_pressure(tp_init);
+        let (state1, state2) = if bubble {
+            starting_x2_bubble(eos, t, p, molefracs_spec, molefracs_init)
+        } else {
+            starting_x2_dew(eos, t, p, molefracs_spec, molefracs_init)
+        }?;
+        bubble_dew(tp_spec, var, state1, state2, options)
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn starting_x2_bubble<U: EosUnit, E: EquationOfState>(
+    eos: &Rc<E>,
+    temperature: QuantityScalar<U>,
+    pressure: QuantityScalar<U>,
+    liquid_molefracs: &Array1<f64>,
+    vapor_molefracs: Option<&Array1<f64>>,
+) -> EosResult<(State<U, E>, State<U, E>)> {
+    let liquid_state = State::new_npt(
+        eos,
+        temperature,
+        pressure,
+        &(liquid_molefracs.clone() * U::reference_moles()),
+        Liquid,
+    )?;
+    let xv = match vapor_molefracs {
+        Some(xv) => xv.clone(),
+        None => liquid_state.ln_phi().mapv(f64::exp) * liquid_molefracs,
+    };
+    let vapor_state = State::new_npt(
+        eos,
+        temperature,
+        pressure,
+        &(xv * U::reference_moles()),
+        Vapor,
+    )?;
+    Ok((liquid_state, vapor_state))
+}
+
+#[allow(clippy::type_complexity)]
+fn starting_x2_dew<U: EosUnit, E: EquationOfState>(
+    eos: &Rc<E>,
+    temperature: QuantityScalar<U>,
+    pressure: QuantityScalar<U>,
+    vapor_molefracs: &Array1<f64>,
+    liquid_molefracs: Option<&Array1<f64>>,
+) -> EosResult<(State<U, E>, State<U, E>)> {
+    let vapor_state = State::new_npt(
+        eos,
+        temperature,
+        pressure,
+        &(vapor_molefracs.clone() * U::reference_moles()),
+        Vapor,
+    )?;
+    let xl = match liquid_molefracs {
+        Some(xl) => xl.clone(),
+        None => {
+            let xl = vapor_state.ln_phi().mapv(f64::exp) * vapor_molefracs;
+            let liquid_state = State::new_npt(
+                eos,
+                temperature,
+                pressure,
+                &(xl * U::reference_moles()),
+                Liquid,
+            )?;
+            (vapor_state.ln_phi() - liquid_state.ln_phi()).mapv(f64::exp) * vapor_molefracs
+        }
+    };
+    let liquid_state = State::new_npt(
+        eos,
+        temperature,
+        pressure,
+        &(xl * U::reference_moles()),
+        Liquid,
+    )?;
+    Ok((vapor_state, liquid_state))
+}
+
+fn bubble_dew<U: EosUnit, E: EquationOfState>(
+    tp_spec: TPSpec<U>,
+    mut var_tp: TPSpec<U>,
+    mut state1: State<U, E>,
+    mut state2: State<U, E>,
+    options: (SolverOptions, SolverOptions),
+) -> EosResult<PhaseEquilibrium<U, E, 2>>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    let (options_inner, options_outer) = options;
+
+    // initialize variables
+    let mut err_out = 1.0;
+    let mut k_out = 0;
+
+    // If the starting values are insufficient find better ones
+    if !promising_values(&state1, &state2) {
+        log_iter!(options_outer.verbosity, "Trivial solution encountered!");
+        // find_starting_values(&mut var_tp, &mut state1, bubble)?;
+    }
+
+    log_iter!(
+        options_outer.verbosity,
+        "res outer loop | res inner loop | {:^16} | molefracs second phase",
+        var_tp.identifier()
+    );
+    log_iter!(options_outer.verbosity, "{:-<85}", "");
+
+    // Outer loop for finding x2
+    for ko in 0..options_outer.max_iter.unwrap_or(MAX_ITER_OUTER) {
+        // Iso-Fugacity equation
+        err_out = if err_out > NEWTON_TOL {
+            // Inner loop for finding T or p
+            for _ in 0..options_inner.max_iter.unwrap_or(MAX_ITER_INNER) {
+                // Newton step
+                if adjust_t_p(
+                    &mut var_tp,
+                    &mut state1,
+                    &mut state2,
+                    options_inner.verbosity,
+                )? < options_inner.tol.unwrap_or(TOL_INNER)
+                {
+                    break;
+                }
+            }
+            adjust_x2(&state1, &mut state2, options_outer.verbosity)
+        } else {
+            newton_step(
+                tp_spec,
+                &mut var_tp,
+                &mut state1,
+                &mut state2,
+                options_outer.verbosity,
+            )
+        }?;
+
+        // if a trivial solution is encountered, reinitialize T or p
+        if PhaseEquilibrium::is_trivial_solution(&state1, &state2) {
+            log_iter!(options_outer.verbosity, "Trivial solution encountered!");
+            // find_starting_values(iterate_t, bubble, &mut itervars)?;
+        }
+
+        if err_out < options_outer.tol.unwrap_or(TOL_OUTER) {
+            k_out = ko + 1;
+            break;
+        }
+    }
+
+    if err_out < options_outer.tol.unwrap_or(TOL_OUTER) {
+        log_result!(
+            options_outer.verbosity,
+            "Bubble/dew point: calculation converged in {} step(s)\n",
+            k_out
+        );
+        Ok(PhaseEquilibrium::from_states(state1, state2))
+    } else {
+        // not converged, return EosError
+        Err(EosError::NotConverged(String::from("bubble-dew-iteration")))
+    }
+}
+
+fn adjust_t_p<U: EosUnit, E: EquationOfState>(
+    var: &mut TPSpec<U>,
+    state1: &mut State<U, E>,
+    state2: &mut State<U, E>,
+    verbosity: Verbosity,
+) -> EosResult<f64>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    // calculate K = phi_1/phi_2 = x_2/x_1
+    let ln_phi_1 = state1.ln_phi();
+    let ln_phi_2 = state2.ln_phi();
+    let k = (&ln_phi_1 - &ln_phi_2).mapv(f64::exp);
+
+    // calculate residual
+    let f = (&state1.molefracs * &k).sum() - 1.0;
+
+    match var {
+        TPSpec::Temperature(t) => {
+            // Derivative w.r.t. temperature
+            let ln_phi_1_dt = state1.dln_phi_dt();
+            let ln_phi_2_dt = state2.dln_phi_dt();
+            let df = ((ln_phi_1_dt - ln_phi_2_dt) * &state1.molefracs * &k).sum();
+            let mut tstep = -f / df;
+
+            // catch too big t-steps
+            if tstep < -MAX_TSTEP * U::reference_temperature() {
+                tstep = -MAX_TSTEP * U::reference_temperature();
+            } else if tstep > MAX_TSTEP * U::reference_temperature() {
+                tstep = MAX_TSTEP * U::reference_temperature();
+            }
+
+            // Update t
+            *t += tstep;
+        }
+        TPSpec::Pressure(p) => {
+            // Derivative w.r.t. ln(pressure)
+            let ln_phi_1_dp = state1.dln_phi_dp();
+            let ln_phi_2_dp = state2.dln_phi_dp();
+            let df = ((ln_phi_1_dp - ln_phi_2_dp) * *p * &state1.molefracs * &k)
+                .sum()
+                .into_value()?;
+            let mut lnpstep = -f / df;
+
+            // catch too big p-steps
+            if lnpstep < -MAX_LNPSTEP {
+                lnpstep = -MAX_LNPSTEP;
+            } else if lnpstep > MAX_LNPSTEP {
+                lnpstep = MAX_LNPSTEP;
+            }
+
+            // Update p
+            *p = *p * lnpstep.exp();
+        }
+    };
+
+    // update states with new temperature/pressure
+    adjust_states(&*var, state1, state2, None)?;
+
+    // log
+    log_iter!(
+        verbosity,
+        "{:14} | {:<14.8e} | {:12.8} | {:.8}",
+        "",
+        f.abs(),
+        var,
+        state2.molefracs
+    );
+
+    Ok(f.abs())
+}
+
+fn adjust_states<U: EosUnit, E: EquationOfState>(
+    var: &TPSpec<U>,
+    state1: &mut State<U, E>,
+    state2: &mut State<U, E>,
+    moles_state2: Option<&QuantityArray1<U>>,
+) -> EosResult<()> {
+    let (temperature, pressure) = match var {
+        TPSpec::Pressure(p) => (state1.temperature, *p),
+        TPSpec::Temperature(t) => (*t, state1.pressure(Contributions::Total)),
+    };
+    *state1 = State::new_npt(
+        &state1.eos,
+        temperature,
+        pressure,
+        &state1.moles,
+        InitialDensity(state1.density),
+    )?;
+    *state2 = State::new_npt(
+        &state2.eos,
+        temperature,
+        pressure,
+        moles_state2.unwrap_or(&state2.moles),
+        InitialDensity(state2.density),
+    )?;
+    Ok(())
+}
+
+fn adjust_x2<U: EosUnit, E: EquationOfState>(
+    state1: &State<U, E>,
+    state2: &mut State<U, E>,
+    verbosity: Verbosity,
+) -> EosResult<f64> {
+    let x1 = &state1.molefracs;
+    let ln_phi_1 = state1.ln_phi();
+    let ln_phi_2 = state2.ln_phi();
+    let k = (ln_phi_1 - ln_phi_2).mapv(f64::exp);
+    let err_out = (&k * x1 / &state2.molefracs - 1.0).mapv(f64::abs).sum();
+    let x2 = (x1 * &k) / (&k * x1).sum();
+    log_iter!(verbosity, "{:<14.8e} | {:14} | {:16} |", err_out, "", "");
+    *state2 = State::new_npt(
+        &state2.eos,
+        state2.temperature,
+        state2.pressure(Contributions::Total),
+        &(x2 * U::reference_moles()),
+        InitialDensity(state2.density),
+    )?;
+    Ok(err_out)
+}
+
+fn newton_step<U: EosUnit, E: EquationOfState>(
+    tp_spec: TPSpec<U>,
+    var: &mut TPSpec<U>,
+    state1: &mut State<U, E>,
+    state2: &mut State<U, E>,
+    verbosity: Verbosity,
+) -> EosResult<f64>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    match tp_spec {
+        TPSpec::Temperature(_) => newton_step_t(var, state1, state2, verbosity),
+        TPSpec::Pressure(p) => newton_step_p(p, var, state1, state2, verbosity),
+    }
+}
+
+fn newton_step_t<U: EosUnit, E: EquationOfState>(
+    pressure: &mut TPSpec<U>,
+    state1: &mut State<U, E>,
+    state2: &mut State<U, E>,
+    verbosity: Verbosity,
+) -> EosResult<f64>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    let dmu_drho_1 = (state1.dmu_dni(Contributions::Total) * state1.volume)
+        .to_reduced(U::reference_molar_energy() / U::reference_density())?
+        .dot(&state1.molefracs);
+    let dmu_drho_2 = (state2.dmu_dni(Contributions::Total) * state2.volume)
+        .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+    let dp_drho_1 = (state1.dp_dni(Contributions::Total) * state1.volume)
+        .to_reduced(U::reference_pressure() / U::reference_density())?
+        .dot(&state1.molefracs);
+    let dp_drho_2 = (state2.dp_dni(Contributions::Total) * state2.volume)
+        .to_reduced(U::reference_pressure() / U::reference_density())?;
+    let mu_1 = state1
+        .chemical_potential(Contributions::Total)
+        .to_reduced(U::reference_molar_energy())?;
+    let mu_2 = state2
+        .chemical_potential(Contributions::Total)
+        .to_reduced(U::reference_molar_energy())?;
+    let p_1 = state1
+        .pressure(Contributions::Total)
+        .to_reduced(U::reference_pressure())?;
+    let p_2 = state2
+        .pressure(Contributions::Total)
+        .to_reduced(U::reference_pressure())?;
+
+    // calculate residual
+    let res = concatenate![Axis(0), mu_1 - &mu_2, arr1(&[p_1 - p_2])];
+    let error = norm(&res);
+
+    // calculate Jacobian
+    let jacobian = concatenate![
+        Axis(1),
+        concatenate![Axis(0), -dmu_drho_2, -dp_drho_2.insert_axis(Axis(0))],
+        concatenate![
+            Axis(0),
+            dmu_drho_1.insert_axis(Axis(1)),
+            arr2(&[[dp_drho_1]])
+        ]
+    ];
+
+    // calculate Newton step
+    let dx = LU::new(jacobian)?.solve(&res);
+
+    // apply Newton step
+    let rho_l1 = state1.density - dx[dx.len() - 1] * U::reference_density();
+    let rho_l2 =
+        &state2.partial_density - &(dx.slice(s![0..-1]).to_owned() * U::reference_density());
+
+    // update states
+    *state1 = StateBuilder::new(&state1.eos)
+        .temperature(state1.temperature)
+        .density(rho_l1)
+        .molefracs(&state1.molefracs)
+        .build()?;
+    *state2 = StateBuilder::new(&state2.eos)
+        .temperature(state2.temperature)
+        .partial_density(&rho_l2)
+        .build()?;
+    *pressure = TPSpec::Pressure(state1.pressure(Contributions::Total));
+    log_iter!(
+        verbosity,
+        "{:<14.8e} | {:14} | {:12.8} | {:.8} NEWTON",
+        error,
+        "",
+        pressure,
+        state2.molefracs
+    );
+    Ok(error)
+}
+
+fn newton_step_p<U: EosUnit, E: EquationOfState>(
+    pressure: QuantityScalar<U>,
+    temperature: &mut TPSpec<U>,
+    state1: &mut State<U, E>,
+    state2: &mut State<U, E>,
+    verbosity: Verbosity,
+) -> EosResult<f64>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    let dmu_drho_1 = (state1.dmu_dni(Contributions::Total) * state1.volume)
+        .to_reduced(U::reference_molar_energy() / U::reference_density())?
+        .dot(&state1.molefracs);
+    let dmu_drho_2 = (state2.dmu_dni(Contributions::Total) * state2.volume)
+        .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+    let dmu_dt_1 = state1
+        .dmu_dt(Contributions::Total)
+        .to_reduced(U::reference_molar_energy() / U::reference_temperature())?;
+    let dmu_dt_2 = state2
+        .dmu_dt(Contributions::Total)
+        .to_reduced(U::reference_molar_energy() / U::reference_temperature())?;
+    let dp_drho_1 = (state1.dp_dni(Contributions::Total) * state1.volume)
+        .to_reduced(U::reference_pressure() / U::reference_density())?
+        .dot(&state1.molefracs);
+    let dp_dt_1 = state1
+        .dp_dt(Contributions::Total)
+        .to_reduced(U::reference_pressure() / U::reference_temperature())?;
+    let dp_dt_2 = state2
+        .dp_dt(Contributions::Total)
+        .to_reduced(U::reference_pressure() / U::reference_temperature())?;
+    let dp_drho_2 = (state2.dp_dni(Contributions::Total) * state2.volume)
+        .to_reduced(U::reference_pressure() / U::reference_density())?;
+    let mu_1 = state1
+        .chemical_potential(Contributions::Total)
+        .to_reduced(U::reference_molar_energy())?;
+    let mu_2 = state2
+        .chemical_potential(Contributions::Total)
+        .to_reduced(U::reference_molar_energy())?;
+    let p_1 = state1
+        .pressure(Contributions::Total)
+        .to_reduced(U::reference_pressure())?;
+    let p_2 = state2
+        .pressure(Contributions::Total)
+        .to_reduced(U::reference_pressure())?;
+    let p = pressure.to_reduced(U::reference_pressure())?;
+
+    // calculate residual
+    let res = concatenate![Axis(0), mu_1 - &mu_2, arr1(&[p_1 - p]), arr1(&[p_2 - p])];
+    let error = norm(&res);
+
+    // calculate Jacobian
+    let jacobian = concatenate![
+        Axis(1),
+        concatenate![
+            Axis(0),
+            -dmu_drho_2,
+            Array2::zeros((1, res.len() - 2)),
+            dp_drho_2.insert_axis(Axis(0))
+        ],
+        concatenate![
+            Axis(0),
+            dmu_drho_1.insert_axis(Axis(1)),
+            arr2(&[[dp_drho_1], [0.0]])
+        ],
+        concatenate![
+            Axis(0),
+            (dmu_dt_1 - dmu_dt_2).insert_axis(Axis(1)),
+            arr2(&[[dp_dt_1], [dp_dt_2]])
+        ]
+    ];
+
+    // calculate Newton step
+    let dx = LU::new(jacobian)?.solve(&res);
+
+    // apply Newton step
+    let rho_l1 = state1.density - dx[dx.len() - 2] * U::reference_density();
+    let rho_l2 =
+        &state2.partial_density - &(dx.slice(s![0..-2]).to_owned() * U::reference_density());
+    let t = state1.temperature - dx[dx.len() - 1] * U::reference_temperature();
+
+    // update states
+    *state1 = StateBuilder::new(&state1.eos)
+        .temperature(t)
+        .density(rho_l1)
+        .molefracs(&state1.molefracs)
+        .build()?;
+    *state2 = StateBuilder::new(&state2.eos)
+        .temperature(t)
+        .partial_density(&rho_l2)
+        .build()?;
+    *temperature = TPSpec::Temperature(t);
+    log_iter!(
+        verbosity,
+        "{:<14.8e} | {:14} | {:12.8} | {:.8} NEWTON",
+        error,
+        "",
+        temperature,
+        state2.molefracs
+    );
+    Ok(error)
+}
+
+fn promising_values<U: EosUnit, E: EquationOfState>(
+    state1: &State<U, E>,
+    state2: &State<U, E>,
+) -> bool {
+    if PhaseEquilibrium::is_trivial_solution(state1, state2) {
+        return false;
+    }
+
+    let ln_phi_1 = state1.ln_phi();
+    let ln_phi_2 = state2.ln_phi();
+    ((&state1.molefracs * &(ln_phi_1 - ln_phi_2).mapv(f64::exp)).sum() - 1.0).abs() < PROMISING_F
+}

--- a/feos-core/src/phase_equilibria/mod.rs
+++ b/feos-core/src/phase_equilibria/mod.rs
@@ -1,0 +1,310 @@
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::state::{Contributions, DensityInitialization, State};
+use crate::EosUnit;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::fmt;
+use std::fmt::Write;
+use std::rc::Rc;
+
+mod bubble_dew;
+mod phase_diagram_binary;
+mod phase_diagram_pure;
+mod stability_analysis;
+mod tp_flash;
+mod vle_pure;
+pub use phase_diagram_binary::PhaseDiagramHetero;
+pub use phase_diagram_pure::PhaseDiagram;
+
+/// Level of detail in the iteration output.
+#[derive(Copy, Clone, PartialOrd, PartialEq)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub enum Verbosity {
+    /// Do not print output.
+    None,
+    /// Print information about the success of failure of the iteration.
+    Result,
+    /// Print a detailed outpur for every iteration.
+    Iter,
+}
+
+impl Default for Verbosity {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Options for the various phase equilibria solvers.
+///
+/// If the values are [None], solver specific default
+///  values are used.
+#[derive(Copy, Clone, Default)]
+pub struct SolverOptions {
+    /// Maximum number of iterations.
+    pub max_iter: Option<usize>,
+    /// Tolerance.
+    pub tol: Option<f64>,
+    /// Iteration outpput indicated by the [Verbosity] enum.
+    pub verbosity: Verbosity,
+}
+
+impl From<(Option<usize>, Option<f64>, Option<Verbosity>)> for SolverOptions {
+    fn from(options: (Option<usize>, Option<f64>, Option<Verbosity>)) -> Self {
+        Self {
+            max_iter: options.0,
+            tol: options.1,
+            verbosity: options.2.unwrap_or(Verbosity::None),
+        }
+    }
+}
+
+impl SolverOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn max_iter(mut self, max_iter: usize) -> Self {
+        self.max_iter = Some(max_iter);
+        self
+    }
+
+    pub fn tol(mut self, tol: f64) -> Self {
+        self.tol = Some(tol);
+        self
+    }
+
+    pub fn verbosity(mut self, verbosity: Verbosity) -> Self {
+        self.verbosity = verbosity;
+        self
+    }
+
+    pub fn unwrap_or(self, max_iter: usize, tol: f64) -> (usize, f64, Verbosity) {
+        (
+            self.max_iter.unwrap_or(max_iter),
+            self.tol.unwrap_or(tol),
+            self.verbosity,
+        )
+    }
+}
+
+/// A thermodynamic equilibrium state.
+///
+/// The struct is parametrized over the number of phases with most features
+/// being implemented for the two phase vapor/liquid or liquid/liquid case.
+///
+/// ## Contents
+///
+/// + [Bubble and dew point calculations](#bubble-and-dew-point-calculations)
+/// + [Heteroazeotropes](#heteroazeotropes)
+/// + [Flash calculations](#flash-calculations)
+/// + [Pure component phase equilibria](#pure-component-phase-equilibria)
+/// + [Utility functions](#utility-functions)
+#[derive(Debug)]
+pub struct PhaseEquilibrium<U, E, const N: usize>([State<U, E>; N]);
+
+impl<U: Clone, E, const N: usize> Clone for PhaseEquilibrium<U, E, N> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<U, E, const N: usize> fmt::Display for PhaseEquilibrium<U, E, N>
+where
+    QuantityScalar<U>: fmt::Display,
+    QuantityArray1<U>: fmt::Display,
+    E: EquationOfState,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, s) in self.0.iter().enumerate() {
+            writeln!(f, "phase {}: {}", i, s)?;
+        }
+        Ok(())
+    }
+}
+
+impl<U, E, const N: usize> PhaseEquilibrium<U, E, N>
+where
+    QuantityScalar<U>: fmt::Display,
+    QuantityArray1<U>: fmt::Display,
+    E: EquationOfState,
+{
+    pub fn _repr_markdown_(&self) -> String {
+        if self.0[0].eos.components() == 1 {
+            let mut res = "||temperature|density|\n|-|-|-|\n".to_string();
+            for (i, s) in self.0.iter().enumerate() {
+                writeln!(
+                    res,
+                    "|phase {}|{:.5}|{:.5}|",
+                    i + 1,
+                    s.temperature,
+                    s.density
+                )
+                .unwrap();
+            }
+            res
+        } else {
+            let mut res = "||temperature|density|molefracs|\n|-|-|-|-|\n".to_string();
+            for (i, s) in self.0.iter().enumerate() {
+                writeln!(
+                    res,
+                    "|phase {}|{:.5}|{:.5}|{:.5}|",
+                    i + 1,
+                    s.temperature,
+                    s.density,
+                    s.molefracs
+                )
+                .unwrap();
+            }
+            res
+        }
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    pub fn vapor(&self) -> &State<U, E> {
+        &self.0[0]
+    }
+
+    pub fn liquid(&self) -> &State<U, E> {
+        &self.0[1]
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 3> {
+    pub fn vapor(&self) -> &State<U, E> {
+        &self.0[0]
+    }
+
+    pub fn liquid1(&self) -> &State<U, E> {
+        &self.0[1]
+    }
+
+    pub fn liquid2(&self) -> &State<U, E> {
+        &self.0[2]
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    pub(super) fn from_states(state1: State<U, E>, state2: State<U, E>) -> Self {
+        let (vapor, liquid) = if state1.density < state2.density {
+            (state1, state2)
+        } else {
+            (state2, state1)
+        };
+        Self([vapor, liquid])
+    }
+
+    pub(super) fn new_npt(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        pressure: QuantityScalar<U>,
+        vapor_moles: &QuantityArray1<U>,
+        liquid_moles: &QuantityArray1<U>,
+    ) -> EosResult<Self> {
+        let liquid = State::new_npt(
+            eos,
+            temperature,
+            pressure,
+            liquid_moles,
+            DensityInitialization::Liquid,
+        )?;
+        let vapor = State::new_npt(
+            eos,
+            temperature,
+            pressure,
+            vapor_moles,
+            DensityInitialization::Vapor,
+        )?;
+        Ok(Self([vapor, liquid]))
+    }
+
+    pub(super) fn vapor_phase_fraction(&self) -> f64 {
+        (self.vapor().total_moles / (self.vapor().total_moles + self.liquid().total_moles))
+            .into_value()
+            .unwrap()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState, const N: usize> PhaseEquilibrium<U, E, N> {
+    pub(super) fn update_pressure(
+        mut self,
+        temperature: QuantityScalar<U>,
+        pressure: QuantityScalar<U>,
+    ) -> EosResult<Self> {
+        for s in self.0.iter_mut() {
+            *s = State::new_npt(
+                &s.eos,
+                temperature,
+                pressure,
+                &s.moles,
+                DensityInitialization::InitialDensity(s.density),
+            )?;
+        }
+        Ok(self)
+    }
+
+    pub(super) fn update_moles(
+        &mut self,
+        pressure: QuantityScalar<U>,
+        moles: [&QuantityArray1<U>; N],
+    ) -> EosResult<()> {
+        for (i, s) in self.0.iter_mut().enumerate() {
+            *s = State::new_npt(
+                &s.eos,
+                s.temperature,
+                pressure,
+                moles[i],
+                DensityInitialization::InitialDensity(s.density),
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn update_chemical_potential(
+        &mut self,
+        chemical_potential: &QuantityArray1<U>,
+    ) -> EosResult<()> {
+        for s in self.0.iter_mut() {
+            s.update_chemical_potential(chemical_potential)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn total_gibbs_energy(&self) -> QuantityScalar<U> {
+        self.0.iter().fold(0.0 * U::reference_energy(), |acc, s| {
+            acc + s.gibbs_energy(Contributions::Total)
+        })
+    }
+}
+
+const TRIVIAL_REL_DEVIATION: f64 = 1e-5;
+
+/// # Utility functions
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    pub(super) fn check_trivial_solution(self) -> EosResult<Self> {
+        if Self::is_trivial_solution(self.vapor(), self.liquid()) {
+            Err(EosError::TrivialSolution)
+        } else {
+            Ok(self)
+        }
+    }
+
+    /// Check if the two states form a trivial solution
+    pub fn is_trivial_solution(state1: &State<U, E>, state2: &State<U, E>) -> bool {
+        let rho1 = state1
+            .partial_density
+            .to_reduced(U::reference_density())
+            .unwrap();
+        let rho2 = state2
+            .partial_density
+            .to_reduced(U::reference_density())
+            .unwrap();
+
+        rho1.iter()
+            .zip(rho2.iter())
+            .fold(0.0, |acc, (&rho1, &rho2)| {
+                (rho2 / rho1 - 1.0).abs().max(acc)
+            })
+            < TRIVIAL_REL_DEVIATION
+    }
+}

--- a/feos-core/src/phase_equilibria/phase_diagram_binary.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_binary.rs
@@ -1,0 +1,687 @@
+use super::{PhaseDiagram, PhaseEquilibrium, SolverOptions};
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::state::{Contributions, DensityInitialization, State, StateBuilder, TPSpec};
+use crate::EosUnit;
+use ndarray::{arr1, arr2, concatenate, s, Array1, Array2, Axis};
+use num_dual::linalg::{norm, LU};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::convert::{TryFrom, TryInto};
+use std::rc::Rc;
+
+const DEFAULT_POINTS: usize = 51;
+
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+    /// Create a new binary phase diagram exhibiting a
+    /// vapor/liquid equilibrium.
+    ///
+    /// If a heteroazeotrope occurs and the composition of the liquid
+    /// phases are known, they can be passed as `x_lle` to avoid
+    /// the calculation of unstable branches.
+    pub fn binary_vle(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        npoints: Option<usize>,
+        x_lle: Option<(f64, f64)>,
+        bubble_dew_options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let npoints = npoints.unwrap_or(DEFAULT_POINTS);
+        let tp = temperature_or_pressure.try_into()?;
+
+        // calculate boiling temperature/vapor pressure of pure components
+        let vle_sat = PhaseEquilibrium::vle_pure_comps(eos, temperature_or_pressure);
+        let vle_sat = [vle_sat[1].clone(), vle_sat[0].clone()];
+
+        // Only calculate up to specified compositions
+        if let Some(x_lle) = x_lle {
+            let (states1, states2) =
+                Self::calculate_vlle(eos, tp, npoints, x_lle, vle_sat, bubble_dew_options)?;
+
+            let states = states1
+                .into_iter()
+                .chain(states2.into_iter().rev())
+                .collect();
+            return Ok(Self { states });
+        }
+
+        // use dew point when calculating a supercritical tx diagram
+        let bubble = match tp {
+            TPSpec::Temperature(_) => true,
+            TPSpec::Pressure(_) => false,
+        };
+
+        // look for supercritical components
+        let (x_lim, vle_lim, bubble) = match vle_sat {
+            [None, None] => return Err(EosError::SuperCritical),
+            [Some(vle2), None] => {
+                let cp = State::critical_point_binary(
+                    eos,
+                    temperature_or_pressure,
+                    None,
+                    None,
+                    SolverOptions::default(),
+                )?;
+                let cp_vle = PhaseEquilibrium::from_states(cp.clone(), cp.clone());
+                ([0.0, cp.molefracs[0]], (vle2, cp_vle), bubble)
+            }
+            [None, Some(vle1)] => {
+                let cp = State::critical_point_binary(
+                    eos,
+                    temperature_or_pressure,
+                    None,
+                    None,
+                    SolverOptions::default(),
+                )?;
+                let cp_vle = PhaseEquilibrium::from_states(cp.clone(), cp.clone());
+                ([1.0, cp.molefracs[0]], (vle1, cp_vle), bubble)
+            }
+            [Some(vle2), Some(vle1)] => ([0.0, 1.0], (vle2, vle1), true),
+        };
+
+        let mut states = iterate_vle(
+            eos,
+            tp,
+            &x_lim,
+            vle_lim.0,
+            Some(vle_lim.1),
+            npoints,
+            bubble,
+            bubble_dew_options,
+        );
+        if !bubble {
+            states = states.into_iter().rev().collect();
+        }
+        Ok(Self { states })
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn calculate_vlle(
+        eos: &Rc<E>,
+        tp: TPSpec<U>,
+        npoints: usize,
+        x_lle: (f64, f64),
+        vle_sat: [Option<PhaseEquilibrium<U, E, 2>>; 2],
+        bubble_dew_options: (SolverOptions, SolverOptions),
+    ) -> EosResult<(
+        Vec<PhaseEquilibrium<U, E, 2>>,
+        Vec<PhaseEquilibrium<U, E, 2>>,
+    )>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        match vle_sat {
+            [Some(vle2), Some(vle1)] => {
+                let states1 = iterate_vle(
+                    eos,
+                    tp,
+                    &[0.0, x_lle.0],
+                    vle2,
+                    None,
+                    npoints / 2,
+                    true,
+                    bubble_dew_options,
+                );
+                let states2 = iterate_vle(
+                    eos,
+                    tp,
+                    &[1.0, x_lle.1],
+                    vle1,
+                    None,
+                    npoints - npoints / 2,
+                    true,
+                    bubble_dew_options,
+                );
+                Ok((states1, states2))
+            }
+            _ => Err(EosError::SuperCritical),
+        }
+    }
+
+    /// Create a new phase diagram using Tp flash calculations.
+    ///
+    /// The usual use case for this function is the calculation of
+    /// liquid-liquid phase diagrams, but it can be used for vapor-
+    /// liquid diagrams as well, as long as the feed composition is
+    /// in a two phase region.
+    pub fn lle(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        feed: &QuantityArray1<U>,
+        min_tp: QuantityScalar<U>,
+        max_tp: QuantityScalar<U>,
+        npoints: Option<usize>,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let npoints = npoints.unwrap_or(DEFAULT_POINTS);
+        let mut states = Vec::with_capacity(npoints);
+        let tp: TPSpec<U> = temperature_or_pressure.try_into()?;
+
+        let tp_vec = QuantityArray1::linspace(min_tp, max_tp, npoints)?;
+        let mut vle = None;
+        for i in 0..npoints {
+            let (_, t, p) = tp.temperature_pressure(tp_vec.get(i));
+            vle = PhaseEquilibrium::tp_flash(
+                eos,
+                t,
+                p,
+                feed,
+                vle.as_ref(),
+                SolverOptions::default(),
+                None,
+            )
+            .ok();
+            if let Some(vle) = &vle {
+                states.push(vle.clone());
+            }
+        }
+        Ok(Self { states })
+    }
+}
+
+fn iterate_vle<U: EosUnit, E: EquationOfState>(
+    eos: &Rc<E>,
+    tp: TPSpec<U>,
+    x_lim: &[f64],
+    vle_0: PhaseEquilibrium<U, E, 2>,
+    vle_1: Option<PhaseEquilibrium<U, E, 2>>,
+    npoints: usize,
+    bubble: bool,
+    bubble_dew_options: (SolverOptions, SolverOptions),
+) -> Vec<PhaseEquilibrium<U, E, 2>>
+where
+    QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+{
+    let mut vle_vec = Vec::with_capacity(npoints);
+
+    let x = Array1::linspace(x_lim[0], x_lim[1], npoints);
+    let x = if vle_1.is_some() {
+        x.slice(s![1..-1])
+    } else {
+        x.slice(s![1..])
+    };
+
+    let mut tp_old = Some(vle_0.vapor().tp(tp));
+    let mut y_old = None;
+    vle_vec.push(vle_0);
+    for xi in x {
+        let vle = PhaseEquilibrium::bubble_dew_point_with_options(
+            eos,
+            tp,
+            tp_old,
+            &arr1(&[*xi, 1.0 - xi]),
+            y_old.as_ref(),
+            bubble,
+            bubble_dew_options,
+        );
+
+        if let Ok(vle) = vle {
+            y_old = Some(if bubble {
+                vle.vapor().molefracs.clone()
+            } else {
+                vle.liquid().molefracs.clone()
+            });
+            tp_old = Some(match tp {
+                TPSpec::Temperature(_) => vle.vapor().pressure(Contributions::Total),
+                TPSpec::Pressure(_) => vle.vapor().temperature,
+            });
+            vle_vec.push(vle.clone());
+        } else {
+            y_old = None;
+            tp_old = None;
+        }
+    }
+    if let Some(vle_1) = vle_1 {
+        vle_vec.push(vle_1);
+    }
+
+    vle_vec
+}
+
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    fn tp(&self, tp: TPSpec<U>) -> QuantityScalar<U> {
+        match tp {
+            TPSpec::Temperature(_) => self.pressure(Contributions::Total),
+            TPSpec::Pressure(_) => self.temperature,
+        }
+    }
+}
+
+/// Phase diagram (Txy or pxy) for a system with heteroazeotropic phase behavior.
+pub struct PhaseDiagramHetero<U, E> {
+    pub vle1: PhaseDiagram<U, E>,
+    pub vle2: PhaseDiagram<U, E>,
+    pub lle: Option<PhaseDiagram<U, E>>,
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+    /// Create a new binary phase diagram exhibiting a
+    /// vapor/liquid/liquid equilibrium.
+    ///
+    /// The `x_lle` parameter is used as initial values for the calculation
+    /// of the heteroazeotrope.
+    pub fn binary_vlle(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        x_lle: (f64, f64),
+        tp_lim_lle: Option<QuantityScalar<U>>,
+        npoints_vle: Option<usize>,
+        npoints_lle: Option<usize>,
+        bubble_dew_options: (SolverOptions, SolverOptions),
+    ) -> EosResult<PhaseDiagramHetero<U, E>>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let npoints_vle = npoints_vle.unwrap_or(DEFAULT_POINTS);
+        let tp = temperature_or_pressure.try_into()?;
+
+        // calculate pure components
+        let vle_sat = PhaseEquilibrium::vle_pure_comps(eos, temperature_or_pressure);
+        let vle_sat = [vle_sat[1].clone(), vle_sat[0].clone()];
+
+        // calculate heteroazeotrope
+        let vlle = match tp {
+            TPSpec::Temperature(t) => PhaseEquilibrium::heteroazeotrope_t(
+                eos,
+                t,
+                x_lle,
+                SolverOptions::default(),
+                bubble_dew_options,
+            ),
+            TPSpec::Pressure(p) => PhaseEquilibrium::heteroazeotrope_p(
+                eos,
+                p,
+                x_lle,
+                SolverOptions::default(),
+                bubble_dew_options,
+            ),
+        }?;
+        let x_hetero = (vlle.liquid1().molefracs[0], vlle.liquid2().molefracs[0]);
+
+        // calculate vapor liquid equilibria
+        let (dia1, dia2) = PhaseDiagram::calculate_vlle(
+            eos,
+            tp,
+            npoints_vle,
+            x_hetero,
+            vle_sat,
+            bubble_dew_options,
+        )?;
+
+        // calculate liquid liquid equilibrium
+        let lle = tp_lim_lle
+            .map(|tp_lim| {
+                let tp_hetero = match tp {
+                    TPSpec::Pressure(_) => vlle.vapor().temperature,
+                    TPSpec::Temperature(_) => vlle.vapor().pressure(Contributions::Total),
+                };
+                let x_feed = 0.5 * (x_hetero.0 + x_hetero.1);
+                let feed = arr1(&[x_feed, 1.0 - x_feed]) * U::reference_moles();
+                PhaseDiagram::lle(
+                    eos,
+                    temperature_or_pressure,
+                    &feed,
+                    tp_lim,
+                    tp_hetero,
+                    npoints_lle,
+                )
+            })
+            .transpose()?;
+
+        Ok(PhaseDiagramHetero {
+            vle1: PhaseDiagram { states: dia1 },
+            vle2: PhaseDiagram { states: dia2 },
+            lle,
+        })
+    }
+}
+
+impl<U: Clone, E> PhaseDiagramHetero<U, E> {
+    pub fn vle(&self) -> PhaseDiagram<U, E> {
+        PhaseDiagram {
+            states: self
+                .vle1
+                .states
+                .iter()
+                .chain(self.vle2.states.iter().rev())
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+const MAX_ITER_HETERO: usize = 50;
+const TOL_HETERO: f64 = 1e-8;
+
+/// # Heteroazeotropes
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 3>
+where
+    QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+{
+    /// Calculate a heteroazeotrope (three phase equilbrium) for a binary
+    /// system and given pressure.
+    pub fn heteroazeotrope(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        x_init: (f64, f64),
+        options: SolverOptions,
+        bubble_dew_options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self> {
+        match TPSpec::try_from(temperature_or_pressure)? {
+            TPSpec::Temperature(t) => {
+                Self::heteroazeotrope_t(eos, t, x_init, options, bubble_dew_options)
+            }
+            TPSpec::Pressure(p) => {
+                Self::heteroazeotrope_p(eos, p, x_init, options, bubble_dew_options)
+            }
+        }
+    }
+
+    /// Calculate a heteroazeotrope (three phase equilbrium) for a binary
+    /// system and given temperature.
+    fn heteroazeotrope_t(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        x_init: (f64, f64),
+        options: SolverOptions,
+        bubble_dew_options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self> {
+        // calculate initial values using bubble point
+        let x1 = arr1(&[x_init.0, 1.0 - x_init.0]);
+        let x2 = arr1(&[x_init.1, 1.0 - x_init.1]);
+        let vle1 =
+            PhaseEquilibrium::bubble_point(eos, temperature, &x1, None, None, bubble_dew_options)?;
+        let vle2 =
+            PhaseEquilibrium::bubble_point(eos, temperature, &x2, None, None, bubble_dew_options)?;
+        let mut l1 = vle1.liquid().clone();
+        let mut l2 = vle2.liquid().clone();
+        let p0 = (vle1.vapor().pressure(Contributions::Total)
+            + vle2.vapor().pressure(Contributions::Total))
+            * 0.5;
+        let nv0 = (&vle1.vapor().moles + &vle2.vapor().moles) * 0.5;
+        let mut v = State::new_npt(eos, temperature, p0, &nv0, DensityInitialization::Vapor)?;
+
+        for _ in 0..options.max_iter.unwrap_or(MAX_ITER_HETERO) {
+            // calculate properties
+            let dmu_drho_l1 = (l1.dmu_dni(Contributions::Total) * l1.volume)
+                .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let dmu_drho_l2 = (l2.dmu_dni(Contributions::Total) * l2.volume)
+                .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let dmu_drho_v = (v.dmu_dni(Contributions::Total) * v.volume)
+                .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let dp_drho_l1 = (l1.dp_dni(Contributions::Total) * l1.volume)
+                .to_reduced(U::reference_pressure() / U::reference_density())?;
+            let dp_drho_l2 = (l2.dp_dni(Contributions::Total) * l2.volume)
+                .to_reduced(U::reference_pressure() / U::reference_density())?;
+            let dp_drho_v = (v.dp_dni(Contributions::Total) * v.volume)
+                .to_reduced(U::reference_pressure() / U::reference_density())?;
+            let mu_l1 = l1
+                .chemical_potential(Contributions::Total)
+                .to_reduced(U::reference_molar_energy())?;
+            let mu_l2 = l2
+                .chemical_potential(Contributions::Total)
+                .to_reduced(U::reference_molar_energy())?;
+            let mu_v = v
+                .chemical_potential(Contributions::Total)
+                .to_reduced(U::reference_molar_energy())?;
+            let p_l1 = l1
+                .pressure(Contributions::Total)
+                .to_reduced(U::reference_pressure())?;
+            let p_l2 = l2
+                .pressure(Contributions::Total)
+                .to_reduced(U::reference_pressure())?;
+            let p_v = v
+                .pressure(Contributions::Total)
+                .to_reduced(U::reference_pressure())?;
+
+            // calculate residual
+            let res = concatenate![
+                Axis(0),
+                mu_l1 - &mu_v,
+                mu_l2 - &mu_v,
+                arr1(&[p_l1 - p_v]),
+                arr1(&[p_l2 - p_v])
+            ];
+
+            // check for convergence
+            if norm(&res) < options.tol.unwrap_or(TOL_HETERO) {
+                return Ok(Self([v, l1, l2]));
+            }
+
+            // calculate Jacobian
+            let jacobian = concatenate![
+                Axis(1),
+                concatenate![
+                    Axis(0),
+                    dmu_drho_l1,
+                    Array2::zeros((2, 2)),
+                    dp_drho_l1.insert_axis(Axis(0)),
+                    Array2::zeros((1, 2))
+                ],
+                concatenate![
+                    Axis(0),
+                    Array2::zeros((2, 2)),
+                    dmu_drho_l2,
+                    Array2::zeros((1, 2)),
+                    dp_drho_l2.insert_axis(Axis(0))
+                ],
+                concatenate![
+                    Axis(0),
+                    -&dmu_drho_v,
+                    -dmu_drho_v,
+                    -dp_drho_v.clone().insert_axis(Axis(0)),
+                    -dp_drho_v.insert_axis(Axis(0))
+                ]
+            ];
+
+            // calculate Newton step
+            let dx = LU::new(jacobian)?.solve(&res);
+
+            // apply Newton step
+            let rho_l1 =
+                &l1.partial_density - &(dx.slice(s![0..2]).to_owned() * U::reference_density());
+            let rho_l2 =
+                &l2.partial_density - &(dx.slice(s![2..4]).to_owned() * U::reference_density());
+            let rho_v =
+                &v.partial_density - &(dx.slice(s![4..6]).to_owned() * U::reference_density());
+
+            // check for negative densities
+            for i in 0..2 {
+                if rho_l1.get(i).is_sign_negative()
+                    || rho_l2.get(i).is_sign_negative()
+                    || rho_v.get(i).is_sign_negative()
+                {
+                    return Err(EosError::IterationFailed(String::from(
+                        "PhaseEquilibrium::heteroazeotrope_t",
+                    )));
+                }
+            }
+
+            // update states
+            l1 = StateBuilder::new(eos)
+                .temperature(temperature)
+                .partial_density(&rho_l1)
+                .build()?;
+            l2 = StateBuilder::new(eos)
+                .temperature(temperature)
+                .partial_density(&rho_l2)
+                .build()?;
+            v = StateBuilder::new(eos)
+                .temperature(temperature)
+                .partial_density(&rho_v)
+                .build()?;
+        }
+        Err(EosError::NotConverged(String::from(
+            "PhaseEquilibrium::heteroazeotrope_t",
+        )))
+    }
+
+    /// Calculate a heteroazeotrope (three phase equilbrium) for a binary
+    /// system and given pressure.
+    fn heteroazeotrope_p(
+        eos: &Rc<E>,
+        pressure: QuantityScalar<U>,
+        x_init: (f64, f64),
+        options: SolverOptions,
+        bubble_dew_options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self> {
+        let p = pressure.to_reduced(U::reference_pressure())?;
+
+        // calculate initial values using bubble point
+        let x1 = arr1(&[x_init.0, 1.0 - x_init.0]);
+        let x2 = arr1(&[x_init.1, 1.0 - x_init.1]);
+        let vle1 =
+            PhaseEquilibrium::bubble_point(eos, pressure, &x1, None, None, bubble_dew_options)?;
+        let vle2 =
+            PhaseEquilibrium::bubble_point(eos, pressure, &x2, None, None, bubble_dew_options)?;
+        let mut l1 = vle1.liquid().clone();
+        let mut l2 = vle2.liquid().clone();
+        let t0 = (vle1.vapor().temperature + vle2.vapor().temperature) * 0.5;
+        let nv0 = (&vle1.vapor().moles + &vle2.vapor().moles) * 0.5;
+        let mut v = State::new_npt(eos, t0, pressure, &nv0, DensityInitialization::Vapor)?;
+
+        for _ in 0..options.max_iter.unwrap_or(MAX_ITER_HETERO) {
+            // calculate properties
+            let dmu_drho_l1 = (l1.dmu_dni(Contributions::Total) * l1.volume)
+                .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let dmu_drho_l2 = (l2.dmu_dni(Contributions::Total) * l2.volume)
+                .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let dmu_drho_v = (v.dmu_dni(Contributions::Total) * v.volume)
+                .to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let dmu_dt_l1 = (l1.dmu_dt(Contributions::Total))
+                .to_reduced(U::reference_molar_energy() / U::reference_temperature())?;
+            let dmu_dt_l2 = (l2.dmu_dt(Contributions::Total))
+                .to_reduced(U::reference_molar_energy() / U::reference_temperature())?;
+            let dmu_dt_v = (v.dmu_dt(Contributions::Total))
+                .to_reduced(U::reference_molar_energy() / U::reference_temperature())?;
+            let dp_drho_l1 = (l1.dp_dni(Contributions::Total) * l1.volume)
+                .to_reduced(U::reference_pressure() / U::reference_density())?;
+            let dp_drho_l2 = (l2.dp_dni(Contributions::Total) * l2.volume)
+                .to_reduced(U::reference_pressure() / U::reference_density())?;
+            let dp_drho_v = (v.dp_dni(Contributions::Total) * v.volume)
+                .to_reduced(U::reference_pressure() / U::reference_density())?;
+            let dp_dt_l1 = (l1.dp_dt(Contributions::Total))
+                .to_reduced(U::reference_pressure() / U::reference_temperature())?;
+            let dp_dt_l2 = (l2.dp_dt(Contributions::Total))
+                .to_reduced(U::reference_pressure() / U::reference_temperature())?;
+            let dp_dt_v = (v.dp_dt(Contributions::Total))
+                .to_reduced(U::reference_pressure() / U::reference_temperature())?;
+            let mu_l1 = l1
+                .chemical_potential(Contributions::Total)
+                .to_reduced(U::reference_molar_energy())?;
+            let mu_l2 = l2
+                .chemical_potential(Contributions::Total)
+                .to_reduced(U::reference_molar_energy())?;
+            let mu_v = v
+                .chemical_potential(Contributions::Total)
+                .to_reduced(U::reference_molar_energy())?;
+            let p_l1 = l1
+                .pressure(Contributions::Total)
+                .to_reduced(U::reference_pressure())?;
+            let p_l2 = l2
+                .pressure(Contributions::Total)
+                .to_reduced(U::reference_pressure())?;
+            let p_v = v
+                .pressure(Contributions::Total)
+                .to_reduced(U::reference_pressure())?;
+
+            // calculate residual
+            let res = concatenate![
+                Axis(0),
+                mu_l1 - &mu_v,
+                mu_l2 - &mu_v,
+                arr1(&[p_l1 - p]),
+                arr1(&[p_l2 - p]),
+                arr1(&[p_v - p])
+            ];
+
+            // check for convergence
+            if norm(&res) < options.tol.unwrap_or(TOL_HETERO) {
+                return Ok(Self([v, l1, l2]));
+            }
+
+            // calculate Jacobian
+            let jacobian = concatenate![
+                Axis(1),
+                concatenate![
+                    Axis(0),
+                    dmu_drho_l1,
+                    Array2::zeros((2, 2)),
+                    dp_drho_l1.insert_axis(Axis(0)),
+                    Array2::zeros((1, 2)),
+                    Array2::zeros((1, 2))
+                ],
+                concatenate![
+                    Axis(0),
+                    Array2::zeros((2, 2)),
+                    dmu_drho_l2,
+                    Array2::zeros((1, 2)),
+                    dp_drho_l2.insert_axis(Axis(0)),
+                    Array2::zeros((1, 2))
+                ],
+                concatenate![
+                    Axis(0),
+                    -&dmu_drho_v,
+                    -dmu_drho_v,
+                    Array2::zeros((1, 2)),
+                    Array2::zeros((1, 2)),
+                    dp_drho_v.insert_axis(Axis(0))
+                ],
+                concatenate![
+                    Axis(0),
+                    (dmu_dt_l1 - &dmu_dt_v).insert_axis(Axis(1)),
+                    (dmu_dt_l2 - &dmu_dt_v).insert_axis(Axis(1)),
+                    arr2(&[[dp_dt_l1]]),
+                    arr2(&[[dp_dt_l2]]),
+                    arr2(&[[dp_dt_v]])
+                ]
+            ];
+
+            // calculate Newton step
+            let dx = LU::new(jacobian)?.solve(&res);
+
+            // apply Newton step
+            let rho_l1 =
+                &l1.partial_density - &(dx.slice(s![0..2]).to_owned() * U::reference_density());
+            let rho_l2 =
+                &l2.partial_density - &(dx.slice(s![2..4]).to_owned() * U::reference_density());
+            let rho_v =
+                &v.partial_density - &(dx.slice(s![4..6]).to_owned() * U::reference_density());
+            let t = v.temperature - dx[6] * U::reference_temperature();
+
+            // check for negative densities and temperatures
+            for i in 0..2 {
+                if rho_l1.get(i).is_sign_negative()
+                    || rho_l2.get(i).is_sign_negative()
+                    || rho_v.get(i).is_sign_negative()
+                    || t.is_sign_negative()
+                {
+                    return Err(EosError::IterationFailed(String::from(
+                        "PhaseEquilibrium::heteroazeotrope_t",
+                    )));
+                }
+            }
+
+            // update states
+            l1 = StateBuilder::new(eos)
+                .temperature(t)
+                .partial_density(&rho_l1)
+                .build()?;
+            l2 = StateBuilder::new(eos)
+                .temperature(t)
+                .partial_density(&rho_l2)
+                .build()?;
+            v = StateBuilder::new(eos)
+                .temperature(t)
+                .partial_density(&rho_v)
+                .build()?;
+        }
+        Err(EosError::NotConverged(String::from(
+            "PhaseEquilibrium::heteroazeotrope_t",
+        )))
+    }
+}

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -1,0 +1,123 @@
+use super::{PhaseEquilibrium, SolverOptions};
+use crate::equation_of_state::EquationOfState;
+use crate::errors::EosResult;
+use crate::state::{State, StateVec};
+use crate::{Contributions, EosUnit};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::rc::Rc;
+
+/// Pure component and binary mixture phase diagrams.
+pub struct PhaseDiagram<U, E> {
+    pub states: Vec<PhaseEquilibrium<U, E, 2>>,
+}
+
+impl<U: Clone, E> Clone for PhaseDiagram<U, E> {
+    fn clone(&self) -> Self {
+        Self {
+            states: self.states.clone(),
+        }
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+    /// Calculate a phase diagram for a pure component.
+    pub fn pure(
+        eos: &Rc<E>,
+        min_temperature: QuantityScalar<U>,
+        npoints: usize,
+        critical_temperature: Option<QuantityScalar<U>>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut states = Vec::with_capacity(npoints);
+
+        let sc = State::critical_point(eos, None, critical_temperature, SolverOptions::default())?;
+
+        let max_temperature = min_temperature
+            + (sc.temperature - min_temperature) * ((npoints - 2) as f64 / (npoints - 1) as f64);
+        let temperatures = QuantityArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
+
+        let mut vle = None;
+        for ti in &temperatures {
+            vle = PhaseEquilibrium::pure(eos, ti, vle.as_ref(), options).ok();
+            if let Some(vle) = vle.as_ref() {
+                states.push(vle.clone());
+            }
+        }
+        states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
+
+        Ok(PhaseDiagram { states })
+    }
+
+    /// Return the vapor states of the diagram.
+    pub fn vapor(&self) -> StateVec<'_, U, E> {
+        self.states.iter().map(|s| s.vapor()).collect()
+    }
+
+    /// Return the liquid states of the diagram.
+    pub fn liquid(&self) -> StateVec<'_, U, E> {
+        self.states.iter().map(|s| s.liquid()).collect()
+    }
+
+    pub fn mix(
+        eos: &Rc<E>,
+        moles: &QuantityArray1<U>,
+        min_pressure: QuantityScalar<U>,
+        npoints: usize,
+        critical_temperature: Option<QuantityScalar<U>>,
+        options: (SolverOptions, SolverOptions),
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut states = Vec::with_capacity(npoints);
+
+        let sc = State::critical_point(
+            eos,
+            Some(moles),
+            critical_temperature,
+            SolverOptions::default(),
+        )?;
+
+        let max_pressure = min_pressure
+            + (sc.pressure(Contributions::Total) - min_pressure)
+                * ((npoints - 2) as f64 / (npoints - 1) as f64);
+        let pressures = QuantityArray1::linspace(min_pressure, max_pressure, npoints - 1)?;
+        let molefracs = moles.to_reduced(moles.sum())?;
+
+        let mut vle_liquid: Option<PhaseEquilibrium<U, E, 2>> = None;
+        let mut vle_vapor: Option<PhaseEquilibrium<U, E, 2>> = None;
+        for ti in &pressures {
+            // calculate new liquid point
+            let t_init = vle_liquid.as_ref().map(|vle| vle.vapor().temperature);
+            let vapor_molefracs = vle_liquid.as_ref().map(|vle| &vle.vapor().molefracs);
+            vle_liquid = PhaseEquilibrium::bubble_point(
+                eos,
+                ti,
+                &molefracs,
+                t_init,
+                vapor_molefracs,
+                options,
+            )
+            .ok();
+
+            // calculate new vapor point
+            let t_init = vle_vapor.as_ref().map(|vle| vle.liquid().temperature);
+            let liquid_molefracs = vle_vapor.as_ref().map(|vle| &vle.liquid().molefracs);
+            vle_vapor =
+                PhaseEquilibrium::dew_point(eos, ti, &molefracs, t_init, liquid_molefracs, options)
+                    .ok();
+            if let (Some(vle_liquid), Some(vle_vapor)) = (vle_liquid.as_ref(), vle_vapor.as_ref()) {
+                states.push(PhaseEquilibrium::from_states(
+                    vle_liquid.liquid().clone(),
+                    vle_vapor.vapor().clone(),
+                ));
+            }
+        }
+        states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
+
+        Ok(PhaseDiagram { states })
+    }
+}

--- a/feos-core/src/phase_equilibria/stability_analysis.rs
+++ b/feos-core/src/phase_equilibria/stability_analysis.rs
@@ -1,0 +1,233 @@
+use super::{PhaseEquilibrium, SolverOptions, Verbosity};
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::state::{Contributions, DensityInitialization, State};
+use crate::EosUnit;
+use ndarray::*;
+use num_dual::linalg::smallest_ev;
+use num_dual::linalg::LU;
+use std::f64::EPSILON;
+use std::ops::MulAssign;
+
+const X_DOMINANT: f64 = 0.99;
+const MINIMIZE_TOL: f64 = 1E-06;
+const MIN_EIGENVAL: f64 = 1E-03;
+const ETA_STEP: f64 = 0.25;
+const MINIMIZE_KMAX: usize = 100;
+const ZERO_TPD: f64 = -1E-08;
+
+/// # Stability analysis
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    /// Determine if the state is stable, i.e. if a phase split should
+    /// occur or not.
+    pub fn is_stable(&self, options: SolverOptions) -> EosResult<bool> {
+        Ok(self.stability_analysis(options)?.is_empty())
+    }
+
+    /// Perform a stability analysis. The result is a list of [State]s with
+    /// negative tangent plane distance (i.e. lower Gibbs energy) that can be
+    /// used as initial estimates for a phase equilibrium calculation.
+    pub fn stability_analysis(&self, options: SolverOptions) -> EosResult<Vec<State<U, E>>> {
+        let mut result = Vec::new();
+        for i_trial in 0..self.eos.components() + 1 {
+            let phase = if i_trial == self.eos.components() {
+                "Vapor phase".to_string()
+            } else {
+                format!("Liquid phase {}", i_trial + 1)
+            };
+            if let Ok(mut trial_state) = self.define_trial_state(i_trial) {
+                let (tpd, i) = self.minimize_tpd(&mut trial_state, options)?;
+                let msg = if let Some(tpd) = tpd {
+                    if tpd < ZERO_TPD {
+                        if result
+                            .iter()
+                            .any(|s| PhaseEquilibrium::is_trivial_solution(s, &trial_state))
+                        {
+                            "Found already identified minimum"
+                        } else {
+                            result.push(trial_state);
+                            "Found candidate"
+                        }
+                    } else {
+                        "Found minimum > 0"
+                    }
+                } else {
+                    "Found trivial solution"
+                };
+                log_result!(options.verbosity, "{}: {} in {} step(s)\n", phase, msg, i);
+            }
+        }
+        Ok(result)
+    }
+
+    fn define_trial_state(&self, dominant_component: usize) -> EosResult<State<U, E>> {
+        let x_feed = &self.molefracs;
+
+        let (x_trial, phase) = if dominant_component == self.eos.components() {
+            // try an ideal vapor phase
+            let x_trial = self.ln_phi().mapv(f64::exp) * x_feed;
+            (&x_trial / x_trial.sum(), DensityInitialization::Vapor)
+        } else {
+            // try each component as nearly pure phase
+            let factor = (1.0 - X_DOMINANT) / (x_feed.sum() - x_feed[dominant_component]);
+            (
+                Array1::from_shape_fn(self.eos.components(), |i| {
+                    if i == dominant_component {
+                        X_DOMINANT
+                    } else {
+                        x_feed[i] * factor
+                    }
+                }),
+                DensityInitialization::Liquid,
+            )
+        };
+
+        State::new_npt(
+            &self.eos,
+            self.temperature,
+            self.pressure(Contributions::Total),
+            &(x_trial * U::reference_moles()),
+            phase,
+        )
+    }
+
+    fn minimize_tpd(
+        &self,
+        trial: &mut State<U, E>,
+        options: SolverOptions,
+    ) -> EosResult<(Option<f64>, usize)> {
+        let (max_iter, tol, verbosity) = options.unwrap_or(MINIMIZE_KMAX, MINIMIZE_TOL);
+        let mut newton = false;
+        let mut scaled_tol = tol;
+        let mut tpd = 1E10;
+        let di = self.molefracs.mapv(f64::ln) + self.ln_phi();
+
+        log_iter!(verbosity, " iter |    residual    |     tpd     | Newton");
+        log_iter!(verbosity, "{:-<46}", "");
+
+        for i in 1..=max_iter {
+            let error = if !newton {
+                // case: direct substitution
+                let y = (&di - &trial.ln_phi()).mapv(f64::exp);
+                let tpd_old = tpd;
+                tpd = 1.0 - y.sum();
+                let error = (&y / y.sum() - &trial.molefracs).mapv(f64::abs).sum();
+
+                *trial = State::new_npt(
+                    &trial.eos,
+                    trial.temperature,
+                    trial.pressure(Contributions::Total),
+                    &(U::reference_moles() * &y),
+                    DensityInitialization::InitialDensity(trial.density),
+                )?;
+                if (i > 4 && error > scaled_tol) || (tpd > tpd_old + 1E-05 && i > 2) {
+                    newton = true; // switch to newton scheme
+                }
+                error
+            } else {
+                // case: newton step
+                trial.stability_newton_step(&di, &mut tpd)?
+            };
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:11.8} | {}",
+                i,
+                error,
+                tpd,
+                newton
+            );
+            if PhaseEquilibrium::is_trivial_solution(self, &*trial) {
+                return Ok((None, i));
+            }
+            if tpd < -1E-02 {
+                scaled_tol = tol * 1E01
+            }
+            if tpd < -1E-01 {
+                scaled_tol = tol * 1E02
+            }
+            if tpd < -1E-01 && i > 5 {
+                scaled_tol = tol * 1E03
+            }
+            if error < scaled_tol {
+                return Ok((Some(tpd), i));
+            }
+        }
+        Err(EosError::NotConverged(String::from("stability analysis")))
+    }
+
+    fn stability_newton_step(&mut self, di: &Array1<f64>, tpd: &mut f64) -> EosResult<f64> {
+        // save old values
+        let tpd_old = *tpd;
+
+        // calculate residual and ideal hesse matrix
+        let mut hesse = (self.dln_phi_dnj() * U::reference_moles()).into_value()?;
+        let lnphi = self.ln_phi();
+        let y = self.moles.to_reduced(U::reference_moles())?;
+        let ln_y = Zip::from(&y).map_collect(|&y| if y > EPSILON { y.ln() } else { 0.0 });
+        let sq_y = y.mapv(f64::sqrt);
+        let gradient = (&ln_y + &lnphi - di) * &sq_y;
+
+        let hesse_ig = Array2::eye(self.eos.components());
+        for i in 0..self.eos.components() {
+            hesse
+                .index_axis_mut(Axis(0), i)
+                .mul_assign(&(sq_y[i] * &sq_y));
+            if y[i] > EPSILON {
+                hesse[[i, i]] += ln_y[i] + lnphi[i] - di[i];
+            }
+        }
+
+        // !-----------------------------------------------------------------------------
+        // ! use method of Murray, by adding a unity matrix to Hessian, if:
+        // ! (1) H is not positive definite
+        // ! (2) step size is too large
+        // ! (3) objective function (tpd) does not descent
+        // !-----------------------------------------------------------------------------
+        let mut adjust_hessian = true;
+        let mut hessian: Array2<f64>;
+        let mut eta_h = 1.0;
+
+        while adjust_hessian {
+            adjust_hessian = false;
+            hessian = &hesse + &(eta_h * &hesse_ig);
+
+            let (min_eigenval, _) = smallest_ev(hessian.clone());
+            if min_eigenval < MIN_EIGENVAL && eta_h < 20.0 {
+                eta_h += 2.0 * ETA_STEP;
+                adjust_hessian = true;
+                continue; // continue, because of Hessian-criterion (1): H not positive definite
+            }
+
+            // solve: hessian * delta_y = gradient
+            let delta_y = LU::new(hessian)?.solve(&gradient);
+            if delta_y
+                .iter()
+                .zip(y.iter())
+                .any(|(dy, y)| ((0.5 * dy).powi(2) / y).abs() > 5.0)
+            {
+                adjust_hessian = true;
+                eta_h += 2.0 * ETA_STEP;
+                continue; //  continue, because of Hessian-criterion (2): too large step-size
+            }
+
+            let y = (&sq_y - &(delta_y / 2.0)).mapv(|v| v.powi(2));
+            let ln_y = Zip::from(&y).map_collect(|&y| if y > EPSILON { y.ln() } else { 0.0 });
+            *tpd = 1.0 + (&y * &(&ln_y + &lnphi - di - 1.0)).sum();
+            if *tpd > tpd_old + 0.0 * 1E-03 && eta_h < 30.0 {
+                eta_h += ETA_STEP;
+                adjust_hessian = true;
+                continue; // continue, because of Hessian-criterion (3): tpd does not descent
+            }
+
+            // accept step and update state
+            *self = State::new_npt(
+                &self.eos,
+                self.temperature,
+                self.pressure(Contributions::Total),
+                &(U::reference_moles() * y),
+                DensityInitialization::InitialDensity(self.density),
+            )?;
+        }
+        Ok(gradient.mapv(f64::abs).sum())
+    }
+}

--- a/feos-core/src/phase_equilibria/tp_flash.rs
+++ b/feos-core/src/phase_equilibria/tp_flash.rs
@@ -1,0 +1,376 @@
+use super::{PhaseEquilibrium, SolverOptions, Verbosity};
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::state::{Contributions, DensityInitialization, State};
+use crate::EosUnit;
+use ndarray::*;
+use num_dual::linalg::norm;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::rc::Rc;
+
+const MAX_ITER_TP: usize = 400;
+const TOL_TP: f64 = 1e-8;
+
+/// # Flash calculations
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    /// Perform a Tp-flash calculation. If no initial values are
+    /// given, the solution is initialized using a stability analysis.
+    ///
+    /// The algorithm can be use to calculate phase equilibria of systems
+    /// containing non-volatile components (e.g. ions).
+    pub fn tp_flash(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        pressure: QuantityScalar<U>,
+        feed: &QuantityArray1<U>,
+        initial_state: Option<&PhaseEquilibrium<U, E, 2>>,
+        options: SolverOptions,
+        non_volatile_components: Option<Vec<usize>>,
+    ) -> EosResult<Self> {
+        State::new_npt(
+            eos,
+            temperature,
+            pressure,
+            feed,
+            DensityInitialization::None,
+        )?
+        .tp_flash(initial_state, options, non_volatile_components)
+    }
+}
+
+/// # Flash calculations
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    /// Perform a Tp-flash calculation using the [State] as feed.
+    /// If no initial values are given, the solution is initialized
+    /// using a stability analysis.
+    ///
+    /// The algorithm can be use to calculate phase equilibria of systems
+    /// containing non-volatile components (e.g. ions).
+    pub fn tp_flash(
+        &self,
+        initial_state: Option<&PhaseEquilibrium<U, E, 2>>,
+        options: SolverOptions,
+        non_volatile_components: Option<Vec<usize>>,
+    ) -> EosResult<PhaseEquilibrium<U, E, 2>> {
+        // set options
+        let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_TP, TOL_TP);
+
+        // initialization
+        let mut new_vle_state = match initial_state {
+            Some(init) => init
+                .clone()
+                .update_pressure(self.temperature, self.pressure(Contributions::Total))?,
+            None => PhaseEquilibrium::vle_init_stability(self)?,
+        };
+
+        log_iter!(
+            verbosity,
+            " iter |    residual    |  phase I mole fractions  |  phase II mole fractions  "
+        );
+        log_iter!(verbosity, "{:-<77}", "");
+        log_iter!(
+            verbosity,
+            " {:4} |                | {:10.8} | {:10.8}",
+            0,
+            new_vle_state.vapor().molefracs,
+            new_vle_state.liquid().molefracs,
+        );
+
+        let mut iter = 0;
+        if non_volatile_components.is_none() {
+            // 3 steps of successive substitution
+            new_vle_state.successive_substitution(
+                self,
+                3,
+                &mut iter,
+                &mut None,
+                tol,
+                verbosity,
+                &non_volatile_components,
+            )?;
+
+            // check convergence
+            let beta = new_vle_state.vapor_phase_fraction();
+            let tpd = [
+                self.tangent_plane_distance(new_vle_state.vapor()),
+                self.tangent_plane_distance(new_vle_state.liquid()),
+            ];
+            let dg = (1.0 - beta) * tpd[1] + beta * tpd[0];
+
+            // fix if only tpd[1] is positive
+            if tpd[0] < 0.0 && dg >= 0.0 {
+                let mut k = (self.ln_phi() - new_vle_state.vapor().ln_phi()).mapv(f64::exp);
+                // Set k = 0 for non-volatile components
+                if let Some(nvc) = non_volatile_components.as_ref() {
+                    nvc.iter().for_each(|&c| k[c] = 0.0);
+                }
+                new_vle_state.update_states(self, &k)?;
+                new_vle_state.successive_substitution(
+                    self,
+                    1,
+                    &mut iter,
+                    &mut None,
+                    tol,
+                    verbosity,
+                    &non_volatile_components,
+                )?;
+            }
+
+            // fix if only tpd[0] is positive
+            if tpd[1] < 0.0 && dg >= 0.0 {
+                let mut k = (new_vle_state.liquid().ln_phi() - self.ln_phi()).mapv(f64::exp);
+                // Set k = 0 for non-volatile components
+                if let Some(nvc) = non_volatile_components.as_ref() {
+                    nvc.iter().for_each(|&c| k[c] = 0.0);
+                }
+                new_vle_state.update_states(self, &k)?;
+                new_vle_state.successive_substitution(
+                    self,
+                    1,
+                    &mut iter,
+                    &mut None,
+                    tol,
+                    verbosity,
+                    &non_volatile_components,
+                )?;
+            }
+        }
+
+        //continue with accelerated successive subsitution
+        new_vle_state.accelerated_successive_substitution(
+            self,
+            &mut iter,
+            max_iter,
+            tol,
+            verbosity,
+            &non_volatile_components,
+        )?;
+
+        Ok(new_vle_state)
+    }
+
+    fn tangent_plane_distance(&self, trial_state: &State<U, E>) -> f64 {
+        let ln_phi_z = self.ln_phi();
+        let ln_phi_w = trial_state.ln_phi();
+        let z = &self.molefracs;
+        let w = &trial_state.molefracs;
+        (w * &(w.mapv(f64::ln) + ln_phi_w - z.mapv(f64::ln) - ln_phi_z)).sum()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    fn accelerated_successive_substitution(
+        &mut self,
+        feed_state: &State<U, E>,
+        iter: &mut usize,
+        max_iter: usize,
+        tol: f64,
+        verbosity: Verbosity,
+        non_volatile_components: &Option<Vec<usize>>,
+    ) -> EosResult<()> {
+        for _ in 0..max_iter {
+            // do 5 successive substitution steps and check for convergence
+            let mut k_vec = Array::zeros((4, self.vapor().eos.components()));
+            if self.successive_substitution(
+                feed_state,
+                5,
+                iter,
+                &mut Some(&mut k_vec),
+                tol,
+                verbosity,
+                non_volatile_components,
+            )? {
+                log_result!(
+                    verbosity,
+                    "Tp flash: calculation converged in {} step(s)\n",
+                    iter
+                );
+                return Ok(());
+            }
+
+            // calculate total Gibbs energy before the extrapolation
+            let gibbs = self.total_gibbs_energy();
+
+            // extrapolate K values
+            let delta_vec = &k_vec.slice(s![1.., ..]) - &k_vec.slice(s![..3, ..]);
+            let delta = Array::from_shape_fn((3, 3), |(i, j)| {
+                (&delta_vec.index_axis(Axis(0), i) * &delta_vec.index_axis(Axis(0), j)).sum()
+            });
+            let d = delta[(0, 1)] * delta[(0, 1)] - delta[(0, 0)] * delta[(1, 1)];
+            let a = (delta[(0, 2)] * delta[(0, 1)] - delta[(1, 2)] * delta[(0, 0)]) / d;
+            let b = (delta[(1, 2)] * delta[(0, 1)] - delta[(0, 2)] * delta[(1, 1)]) / d;
+
+            let mut k = (&k_vec.index_axis(Axis(0), 3)
+                + &((b * &delta_vec.index_axis(Axis(0), 1)
+                    + (a + b) * &delta_vec.index_axis(Axis(0), 2))
+                    / (1.0 - a - b)))
+                .mapv(f64::exp);
+
+            // Set k = 0 for non-volatile components
+            if let Some(nvc) = non_volatile_components.as_ref() {
+                nvc.iter().for_each(|&c| k[c] = 0.0);
+            }
+            if !k.iter().all(|i| i.is_finite()) {
+                continue;
+            }
+
+            // calculate new states
+            let mut trial_vle_state = self.clone();
+            trial_vle_state.update_states(feed_state, &k)?;
+            if trial_vle_state.total_gibbs_energy() < gibbs {
+                *self = trial_vle_state;
+            }
+        }
+        Err(EosError::NotConverged("TP flash".to_owned()))
+    }
+
+    fn successive_substitution(
+        &mut self,
+        feed_state: &State<U, E>,
+        iterations: usize,
+        iter: &mut usize,
+        k_vec: &mut Option<&mut Array2<f64>>,
+        abs_tol: f64,
+        verbosity: Verbosity,
+        non_volatile_components: &Option<Vec<usize>>,
+    ) -> EosResult<bool> {
+        for i in 0..iterations {
+            let ln_phi_v = self.vapor().ln_phi();
+            let ln_phi_l = self.liquid().ln_phi();
+            let mut k = (&ln_phi_l - &ln_phi_v).mapv(f64::exp);
+
+            // Set k = 0 for non-volatile components
+            if let Some(nvc) = non_volatile_components.as_ref() {
+                nvc.iter().for_each(|&c| k[c] = 0.0);
+            }
+
+            // check for convergence
+            *iter += 1;
+            let mut res_vec = ln_phi_l - ln_phi_v
+                + (&self.liquid().molefracs / &self.vapor().molefracs).map(|&i| {
+                    if i > 0.0 {
+                        i.ln()
+                    } else {
+                        0.0
+                    }
+                });
+
+            // Set residuum to 0 for non-volatile components
+            if let Some(nvc) = non_volatile_components.as_ref() {
+                nvc.iter().for_each(|&c| res_vec[c] = 0.0);
+            }
+            let res = norm(&res_vec);
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:.8} | {:.8}",
+                iter,
+                res,
+                self.vapor().molefracs,
+                self.liquid().molefracs,
+            );
+            if res < abs_tol {
+                return Ok(true);
+            }
+
+            self.update_states(feed_state, &k)?;
+            if let Some(k_vec) = k_vec {
+                if i >= iterations - 3 {
+                    k_vec
+                        .index_axis_mut(Axis(0), i + 3 - iterations)
+                        .assign(&k.map(|ki| if *ki > 0.0 { ki.ln() } else { 0.0 }));
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    fn update_states(&mut self, feed_state: &State<U, E>, k: &Array1<f64>) -> EosResult<()> {
+        // calculate vapor phase fraction using Rachford-Rice algorithm
+        let mut beta = self.vapor_phase_fraction();
+        beta = rachford_rice(&feed_state.molefracs, k, Some(beta))?;
+
+        // update VLE
+        let v = beta * k / (1.0 - beta + beta * k) * feed_state.moles.clone();
+        let l = (1.0 - beta) / (1.0 - beta + beta * k) * feed_state.moles.clone();
+        self.update_moles(feed_state.pressure(Contributions::Total), [&v, &l])?;
+        Ok(())
+    }
+
+    fn vle_init_stability(feed_state: &State<U, E>) -> EosResult<Self> {
+        let mut stable_states = feed_state.stability_analysis(SolverOptions::default())?;
+        let state1 = stable_states.pop();
+        let state2 = stable_states.pop();
+        match (state1, state2) {
+            (Some(s1), Some(s2)) => Ok(Self::from_states(s1, s2)),
+            (Some(s1), None) => Ok(Self::from_states(s1, feed_state.clone())),
+            _ => Err(EosError::NoPhaseSplit),
+        }
+    }
+}
+
+fn rachford_rice(feed: &Array1<f64>, k: &Array1<f64>, beta_in: Option<f64>) -> EosResult<f64> {
+    const MAX_ITER: usize = 10;
+    const ABS_TOL: f64 = 1e-6;
+
+    // check if solution exists
+    let (mut beta_min, mut beta_max) =
+        if (feed * k).sum() > 1.0 && (feed / k).iter().filter(|x| !x.is_nan()).sum::<f64>() > 1.0 {
+            (0.0, 1.0)
+        } else {
+            return Err(EosError::IterationFailed(String::from("rachford_rice")));
+        };
+
+    // look for tighter bounds
+    for (&k, &f) in k.iter().zip(feed.iter()) {
+        if k > 1.0 {
+            let b = (k * f - 1.0) / (k - 1.0);
+            if b > beta_min {
+                beta_min = b;
+            }
+        }
+        if k < 1.0 {
+            let b = (1.0 - f) / (1.0 - k);
+            if b < beta_max {
+                beta_max = b;
+            }
+        }
+    }
+
+    // initialize
+    let mut beta = 0.5 * (beta_min + beta_max);
+    if let Some(b) = beta_in {
+        if b > beta_min && b < beta_max {
+            beta = b;
+        }
+    }
+    let g = (feed * &(k - 1.0) / (1.0 - beta + beta * k)).sum();
+    if g > 0.0 {
+        beta_min = beta
+    } else {
+        beta_max = beta
+    }
+
+    // iterate
+    for _ in 0..MAX_ITER {
+        let frac = (k - 1.0) / (1.0 - beta + beta * k);
+        let g = (feed * &frac).sum();
+        let dg = -(feed * &frac * &frac).sum();
+        if g > 0.0 {
+            beta_min = beta;
+        } else {
+            beta_max = beta;
+        }
+
+        let dbeta = g / dg;
+        beta -= dbeta;
+
+        if beta < beta_min || beta > beta_max {
+            beta = 0.5 * (beta_min + beta_max);
+        }
+        if dbeta.abs() < ABS_TOL {
+            return Ok(beta);
+        }
+    }
+
+    Ok(beta)
+}

--- a/feos-core/src/phase_equilibria/vle_pure.rs
+++ b/feos-core/src/phase_equilibria/vle_pure.rs
@@ -1,0 +1,469 @@
+use super::{PhaseEquilibrium, SolverOptions, Verbosity};
+use crate::density_iteration::pressure_spinodal;
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::state::{Contributions, DensityInitialization, State, TPSpec};
+use crate::EosUnit;
+use ndarray::{arr1, Array1};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::convert::TryFrom;
+use std::rc::Rc;
+
+const SCALE_T_NEW: f64 = 0.7;
+
+const MAX_ITER_PURE: usize = 50;
+const TOL_PURE: f64 = 1e-12;
+
+/// # Pure component phase equilibria
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    /// Calculate a phase equilibrium for a pure component.
+    pub fn pure(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        initial_state: Option<&PhaseEquilibrium<U, E, 2>>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        match TPSpec::try_from(temperature_or_pressure)? {
+            TPSpec::Temperature(t) => Self::pure_t(eos, t, initial_state, options),
+            TPSpec::Pressure(p) => Self::pure_p(eos, p, initial_state, options),
+        }
+    }
+
+    /// Calculate a phase equilibrium for a pure component
+    /// and given temperature.
+    fn pure_t(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        initial_state: Option<&PhaseEquilibrium<U, E, 2>>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
+
+        // First use given initial state if applicable
+        let mut vle = initial_state.and_then(|init| {
+            Self::init_pure_state(init, temperature)
+                .and_then(|vle| vle.iterate_pure_t(max_iter, tol, verbosity))
+                .ok()
+        });
+
+        // Next try to initialize with an ideal gas assumption
+        vle = vle.or_else(|| {
+            Self::init_pure_ideal_gas(eos, temperature)
+                .and_then(|vle| vle.iterate_pure_t(max_iter, tol, verbosity))
+                .ok()
+        });
+
+        // Finally use the spinodal to initialize the calculation
+        vle.map_or_else(
+            || {
+                Self::init_pure_spinodal(eos, temperature)
+                    .and_then(|vle| vle.iterate_pure_t(max_iter, tol, verbosity))
+            },
+            Ok,
+        )
+    }
+
+    fn iterate_pure_t(self, max_iter: usize, tol: f64, verbosity: Verbosity) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut p_old = self.vapor().pressure(Contributions::Total);
+        let [mut vapor, mut liquid] = self.0;
+
+        log_iter!(verbosity,
+            " iter |     residual      |     pressure     |    liquid density    |    vapor density     | Newton steps"
+        );
+        log_iter!(verbosity, "{:-<106}", "");
+        log_iter!(
+            verbosity,
+            " {:4} |                   | {:12.8} | {:12.8} | {:12.8} |",
+            0,
+            p_old,
+            liquid.density,
+            vapor.density
+        );
+
+        for i in 1..=max_iter {
+            // calculate the pressures and derivatives
+            let (p_l, p_rho_l) = liquid.p_dpdrho();
+            let (p_v, p_rho_v) = vapor.p_dpdrho();
+            // calculate the molar Helmholtz energies (already cached)
+            let a_l = liquid.molar_helmholtz_energy(Contributions::Total);
+            let a_v = vapor.molar_helmholtz_energy(Contributions::Total);
+
+            // Estimate the new pressure
+            let delta_v = 1.0 / vapor.density - 1.0 / liquid.density;
+            let delta_a = a_v - a_l;
+            let mut p_new = -delta_a / delta_v;
+
+            // If the pressure becomes negative, assume the gas phase is ideal. The
+            // resulting pressure is always positive.
+            if p_new.is_sign_negative() {
+                let mu_v = vapor.chemical_potential(Contributions::Total).get(0);
+                p_new = p_v
+                    * (a_l - mu_v)
+                        .to_reduced(vapor.temperature * U::gas_constant())?
+                        .exp();
+            }
+
+            // Improve the estimate by exploiting the almost ideal behavior of the gas phase
+            let kt = U::gas_constant() * vapor.temperature;
+            let mut newton_iter = 0;
+            let newton_tol = p_old * delta_v * tol;
+            for _ in 0..20 {
+                let p_frac = p_new.to_reduced(p_old)?;
+                let f = p_new * delta_v + delta_a + (p_frac.ln() + 1.0 - p_frac) * kt;
+                let df_dp = delta_v + (1.0 / p_new - 1.0 / p_old) * kt;
+                p_new -= f / df_dp;
+                newton_iter += 1;
+                if f.abs() < newton_tol {
+                    break;
+                }
+            }
+
+            // Emergency brake if the implementation of the EOS is not safe.
+            if p_new.is_nan() {
+                return Err(EosError::IterationFailed("pure_t".to_owned()));
+            }
+
+            // Calculate Newton steps for the densities and update state.
+            let rho_l = liquid.density + (p_new - p_l) / p_rho_l;
+            let rho_v = vapor.density + (p_new - p_v) / p_rho_v;
+            liquid = State::new_pure(&liquid.eos, liquid.temperature, rho_l)?;
+            vapor = State::new_pure(&vapor.eos, vapor.temperature, rho_v)?;
+            if Self::is_trivial_solution(&vapor, &liquid) {
+                return Err(EosError::TrivialSolution);
+            }
+
+            // Check for convergence
+            let res = (p_new - p_old).abs();
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:12.8} | {:12.8} | {:12.8} | {}",
+                i,
+                res,
+                p_new,
+                liquid.density,
+                vapor.density,
+                newton_iter
+            );
+            if res < p_old * tol {
+                log_result!(
+                    verbosity,
+                    "PhaseEquilibrium::pure_t: calculation converged in {} step(s)\n",
+                    i
+                );
+                return Ok(Self([vapor, liquid]));
+            }
+            p_old = p_new;
+        }
+        Err(EosError::NotConverged("pure_t".to_owned()))
+    }
+
+    /// Calculate a phase equilibrium for a pure component
+    /// and given pressure.
+    fn pure_p(
+        eos: &Rc<E>,
+        pressure: QuantityScalar<U>,
+        initial_state: Option<&Self>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
+
+        // Initialize the phase equilibrium
+        let mut vle = match initial_state {
+            Some(init) => init
+                .clone()
+                .update_pressure(init.vapor().temperature, pressure)?,
+            None => PhaseEquilibrium::init_pure_p(eos, pressure)?,
+        };
+
+        log_iter!(
+            verbosity,
+            " iter |     residual     |   temperature   |    liquid density    |    vapor density     "
+        );
+        log_iter!(verbosity, "{:-<89}", "");
+        log_iter!(
+            verbosity,
+            " {:4} |                  | {:13.8} | {:12.8} | {:12.8}",
+            0,
+            vle.vapor().temperature,
+            vle.liquid().density,
+            vle.vapor().density
+        );
+        for i in 1..=max_iter {
+            // calculate the pressures and derivatives
+            let (p_l, p_rho_l) = vle.liquid().p_dpdrho();
+            let (p_v, p_rho_v) = vle.vapor().p_dpdrho();
+            let p_t_l = vle.liquid().dp_dt(Contributions::Total);
+            let p_t_v = vle.vapor().dp_dt(Contributions::Total);
+
+            // calculate the molar entropies (already cached)
+            let s_l = vle.liquid().molar_entropy(Contributions::Total);
+            let s_v = vle.vapor().molar_entropy(Contributions::Total);
+
+            // calculate the molar Helmholtz energies (already cached)
+            let a_l = vle.liquid().molar_helmholtz_energy(Contributions::Total);
+            let a_v = vle.vapor().molar_helmholtz_energy(Contributions::Total);
+
+            // calculate the molar volumes
+            let v_l = 1.0 / vle.liquid().density;
+            let v_v = 1.0 / vle.vapor().density;
+
+            // estimate the temperature steps
+            let delta_t = (pressure * (v_v - v_l) + (a_v - a_l)) / (s_v - s_l);
+            let t_new = vle.vapor().temperature + delta_t;
+
+            // calculate Newton steps for the densities and update state.
+            let rho_l = vle.liquid().density + (pressure - p_l - p_t_l * delta_t) / p_rho_l;
+            let rho_v = vle.vapor().density + (pressure - p_v - p_t_v * delta_t) / p_rho_v;
+
+            if rho_l.is_sign_negative()
+                || rho_v.is_sign_negative()
+                || delta_t.abs() > U::reference_temperature()
+            {
+                // if densities are negative or the temperature step is large use density iteration instead
+                vle = vle
+                    .update_pressure(t_new, pressure)?
+                    .check_trivial_solution()?;
+            } else {
+                // update state
+                vle = Self([
+                    State::new_pure(eos, t_new, rho_v)?,
+                    State::new_pure(eos, t_new, rho_l)?,
+                ]);
+            }
+
+            // check for convergence
+            let res = delta_t.abs();
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:13.8} | {:12.8} | {:12.8}",
+                i,
+                res,
+                vle.vapor().temperature,
+                vle.liquid().density,
+                vle.vapor().density
+            );
+            if res < vle.vapor().temperature * tol {
+                log_result!(
+                    verbosity,
+                    "PhaseEquilibrium::pure_p: calculation converged in {} step(s)\n",
+                    i
+                );
+                return Ok(vle);
+            }
+        }
+        Err(EosError::NotConverged("pure_p".to_owned()))
+    }
+
+    fn init_pure_state(initial_state: &Self, temperature: QuantityScalar<U>) -> EosResult<Self> {
+        let vapor = initial_state.vapor().update_temperature(temperature)?;
+        let liquid = initial_state.liquid().update_temperature(temperature)?;
+        Ok(Self([vapor, liquid]))
+    }
+
+    fn init_pure_ideal_gas(eos: &Rc<E>, temperature: QuantityScalar<U>) -> EosResult<Self> {
+        let m = arr1(&[1.0]) * U::reference_moles();
+        let density = 0.75 * eos.max_density(None)?;
+        let liquid = State::new_nvt(eos, temperature, U::reference_moles() / density, &m)?;
+        let z = liquid.compressibility(Contributions::Total);
+        let mu = liquid.chemical_potential(Contributions::ResidualNvt);
+        let p = temperature
+            * density
+            * U::gas_constant()
+            * (mu.get(0).to_reduced(U::gas_constant() * temperature)? - z).exp();
+        PhaseEquilibrium::new_npt(eos, temperature, p, &m, &m)?.check_trivial_solution()
+    }
+
+    fn init_pure_spinodal(eos: &Rc<E>, temperature: QuantityScalar<U>) -> EosResult<Self> {
+        let m = arr1(&[1.0]) * U::reference_moles();
+        let spinodal = Self::spinodal(eos, temperature, &m)?;
+        let pv = spinodal.vapor().pressure(Contributions::Total);
+        let pl = spinodal.liquid().pressure(Contributions::Total);
+        let p = 0.5 * ((0.0 * U::reference_pressure()).max(pl)? + pv);
+        PhaseEquilibrium::new_npt(eos, temperature, p, &m, &m)
+    }
+
+    fn spinodal(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+    ) -> EosResult<Self> {
+        let max_density = eos.max_density(Some(moles))?;
+        let sp = pressure_spinodal(eos, temperature, max_density * 1e-5, moles)?;
+        let vapor = State::new_nvt(eos, temperature, moles.get(0) / sp.rho, moles)?;
+        let sp = pressure_spinodal(eos, temperature, max_density, moles)?;
+        let liquid = State::new_nvt(eos, temperature, moles.get(0) / sp.rho, moles)?;
+        Ok(PhaseEquilibrium([vapor, liquid]))
+    }
+
+    /// Initialize a new VLE for a pure substance for a given pressure.
+    fn init_pure_p(eos: &Rc<E>, pressure: QuantityScalar<U>) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        let trial_temperatures = [
+            300.0 * U::reference_temperature(),
+            500.0 * U::reference_temperature(),
+            200.0 * U::reference_temperature(),
+        ];
+        let m = arr1(&[1.0]) * U::reference_moles();
+        let mut vle = None;
+        let mut t0 = U::reference_temperature();
+        for t in trial_temperatures.iter() {
+            t0 = *t;
+            let _vle = PhaseEquilibrium::new_npt(eos, *t, pressure, &m, &m)?;
+            if !Self::is_trivial_solution(_vle.vapor(), _vle.liquid()) {
+                return Ok(_vle);
+            }
+            vle = Some(_vle);
+        }
+
+        let cp = State::critical_point(eos, None, None, SolverOptions::default())?;
+        if pressure > cp.pressure(Contributions::Total) {
+            return Err(EosError::SuperCritical);
+        };
+        if let Some(mut e) = vle {
+            if e.vapor().density < cp.density {
+                for _ in 0..8 {
+                    t0 = t0 * SCALE_T_NEW;
+                    e.0[1] = State::new_npt(eos, t0, pressure, &m, DensityInitialization::Liquid)?;
+                    if e.liquid().density > cp.density {
+                        break;
+                    }
+                }
+            } else {
+                for _ in 0..8 {
+                    t0 = t0 / SCALE_T_NEW;
+                    e.0[0] = State::new_npt(eos, t0, pressure, &m, DensityInitialization::Vapor)?;
+                    if e.vapor().density < cp.density {
+                        break;
+                    }
+                }
+            }
+
+            for _ in 0..20 {
+                t0 = (e.vapor().enthalpy(Contributions::Total)
+                    - e.liquid().enthalpy(Contributions::Total))
+                    / (e.vapor().entropy(Contributions::Total)
+                        - e.liquid().entropy(Contributions::Total));
+                let trial_state =
+                    State::new_npt(eos, t0, pressure, &m, DensityInitialization::Vapor)?;
+                if trial_state.density < cp.density {
+                    e.0[0] = trial_state;
+                }
+                let trial_state =
+                    State::new_npt(eos, t0, pressure, &m, DensityInitialization::Liquid)?;
+                if trial_state.density > cp.density {
+                    e.0[1] = trial_state;
+                }
+                if e.liquid().temperature == e.vapor().temperature {
+                    return Ok(e);
+                }
+            }
+            Err(EosError::IterationFailed(
+                "new_init_p: could not find proper initial state".to_owned(),
+            ))
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+    /// Calculate the pure component vapor pressures of all
+    /// components in the system for the given temperature.
+    pub fn vapor_pressure(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+    ) -> Vec<Option<QuantityScalar<U>>>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        (0..eos.components())
+            .map(|i| {
+                let pure_eos = Rc::new(eos.subset(&[i]));
+                PhaseEquilibrium::pure_t(&pure_eos, temperature, None, SolverOptions::default())
+                    .map(|vle| vle.vapor().pressure(Contributions::Total))
+                    .ok()
+            })
+            .collect()
+    }
+
+    /// Calculate the pure component boiling temperatures of all
+    /// components in the system for the given pressure.
+    pub fn boiling_temperature(
+        eos: &Rc<E>,
+        pressure: QuantityScalar<U>,
+    ) -> Vec<Option<QuantityScalar<U>>>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        (0..eos.components())
+            .map(|i| {
+                let pure_eos = Rc::new(eos.subset(&[i]));
+                PhaseEquilibrium::pure_p(&pure_eos, pressure, None, SolverOptions::default())
+                    .map(|vle| vle.vapor().temperature)
+                    .ok()
+            })
+            .collect()
+    }
+
+    /// Calculate the pure component phase equilibria of all
+    /// components in the system.
+    pub fn vle_pure_comps(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+    ) -> Vec<Option<PhaseEquilibrium<U, E, 2>>>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        (0..eos.components())
+            .map(|i| {
+                let pure_eos = Rc::new(eos.subset(&[i]));
+                PhaseEquilibrium::pure(
+                    &pure_eos,
+                    temperature_or_pressure,
+                    None,
+                    SolverOptions::default(),
+                )
+                .ok()
+                .map(|vle_pure| {
+                    let mut moles_vapor = Array1::zeros(eos.components()) * U::reference_moles();
+                    let mut moles_liquid = moles_vapor.clone();
+                    moles_vapor
+                        .try_set(i, vle_pure.vapor().total_moles)
+                        .unwrap();
+                    moles_liquid
+                        .try_set(i, vle_pure.liquid().total_moles)
+                        .unwrap();
+                    let vapor = State::new_nvt(
+                        eos,
+                        vle_pure.vapor().temperature,
+                        vle_pure.vapor().volume,
+                        &moles_vapor,
+                    )
+                    .unwrap();
+                    let liquid = State::new_nvt(
+                        eos,
+                        vle_pure.liquid().temperature,
+                        vle_pure.liquid().volume,
+                        &moles_liquid,
+                    )
+                    .unwrap();
+                    PhaseEquilibrium::from_states(vapor, liquid)
+                })
+            })
+            .collect()
+    }
+}

--- a/feos-core/src/python/cubic.rs
+++ b/feos-core/src/python/cubic.rs
@@ -1,0 +1,72 @@
+use crate::cubic::{PengRobinsonParameters, PengRobinsonRecord};
+use crate::joback::JobackRecord;
+use crate::parameter::{
+    BinaryRecord, Identifier, IdentifierOption, Parameter, ParameterError, PureRecord,
+};
+use crate::python::joback::PyJobackRecord;
+use crate::python::parameter::PyIdentifier;
+use crate::*;
+use numpy::PyReadonlyArray2;
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use std::convert::{TryFrom, TryInto};
+use std::rc::Rc;
+
+/// A pure substance parameter for the Peng-Robinson equation of state.
+#[pyclass(name = "PengRobinsonRecord", unsendable)]
+#[derive(Clone)]
+pub struct PyPengRobinsonRecord(PengRobinsonRecord);
+
+#[pymethods]
+impl PyPengRobinsonRecord {
+    #[new]
+    fn new(tc: f64, pc: f64, acentric_factor: f64) -> Self {
+        Self(PengRobinsonRecord::new(tc, pc, acentric_factor))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl_json_handling!(PyPengRobinsonRecord);
+
+impl_pure_record!(
+    PengRobinsonRecord,
+    PyPengRobinsonRecord,
+    JobackRecord,
+    PyJobackRecord
+);
+
+impl_binary_record!();
+
+/// Create a set of Peng-Robinson parameters from records.
+///
+/// Parameters
+/// ----------
+/// pure_records : List[PureRecord]
+///     pure substance records.
+/// binary_records : List[BinaryRecord], optional
+///     binary parameter records
+/// substances : List[str], optional
+///     The substances to use. Filters substances from `pure_records` according to
+///     `search_option`.
+///     When not provided, all entries of `pure_records` are used.
+/// search_option : {'Name', 'Cas', 'Inchi', 'IupacName', 'Formula', 'Smiles'}, optional, defaults to 'Name'.
+///     Identifier that is used to search substance.
+///
+/// Returns
+/// -------
+/// PengRobinsonParameters
+#[pyclass(name = "PengRobinsonParameters", unsendable)]
+#[derive(Clone)]
+pub struct PyPengRobinsonParameters(pub Rc<PengRobinsonParameters>);
+
+impl_parameter!(PengRobinsonParameters, PyPengRobinsonParameters);
+
+#[pymethods]
+impl PyPengRobinsonParameters {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}

--- a/feos-core/src/python/equation_of_state.rs
+++ b/feos-core/src/python/equation_of_state.rs
@@ -1,0 +1,133 @@
+#[macro_export]
+macro_rules! impl_equation_of_state {
+    ($py_eos:ty) => {
+        #[pymethods]
+        impl $py_eos {
+            /// Return maximum density for given amount of substance of each component.
+            ///
+            /// Parameters
+            /// ----------
+            /// moles : SIArray1, optional
+            ///     The amount of substance in mol for each component.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "(moles=None)")]
+            fn max_density(&self, moles: Option<PySIArray1>) -> PyResult<PySINumber> {
+                let m = moles.as_deref();
+                Ok(self.0.max_density(m)?.into())
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_virial_coefficients {
+    ($py_eos:ty) => {
+        #[pymethods]
+        impl $py_eos {
+            /// Calculate the second Virial coefficient B(T,x).
+            ///
+            /// Parameters
+            /// ----------
+            /// temperature : SINumber
+            ///     The temperature for which B should be computed.
+            /// moles : SIArray1, optional
+            ///     The amount of substance in mol for each component.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "(temperature, moles=None)")]
+            fn second_virial_coefficient(
+                &self,
+                temperature: PySINumber,
+                moles: Option<PySIArray1>,
+            ) -> PyResult<PySINumber> {
+                let m = moles.as_deref();
+                Ok(self
+                    .0
+                    .second_virial_coefficient(temperature.into(), m)?
+                    .into())
+            }
+
+            /// Calculate the third Virial coefficient C(T,x).
+            ///
+            /// Parameters
+            /// ----------
+            /// temperature : SINumber
+            ///     The temperature for which C should be computed.
+            /// moles : SIArray1, optional
+            ///     The amount of substance in mol for each component.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "(temperature, moles=None)")]
+            fn third_virial_coefficient(
+                &self,
+                temperature: PySINumber,
+                moles: Option<PySIArray1>,
+            ) -> PyResult<PySINumber> {
+                let m = moles.as_deref();
+                Ok(self
+                    .0
+                    .third_virial_coefficient(temperature.into(), m)?
+                    .into())
+            }
+
+            /// Calculate the derivative of the second Virial coefficient B(T,x)
+            /// with respect to temperature.
+            ///
+            /// Parameters
+            /// ----------
+            /// temperature : SINumber
+            ///     The temperature for which B' should be computed.
+            /// moles : SIArray1, optional
+            ///     The amount of substance in mol for each component.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "(temperature, moles=None)")]
+            fn second_virial_coefficient_temperature_derivative(
+                &self,
+                temperature: PySINumber,
+                moles: Option<PySIArray1>,
+            ) -> PyResult<PySINumber> {
+                let m = moles.as_deref();
+                Ok(self
+                    .0
+                    .second_virial_coefficient_temperature_derivative(temperature.into(), m)?
+                    .into())
+            }
+
+            /// Calculate the derivative of the third Virial coefficient C(T,x)
+            /// with respect to temperature.
+            ///
+            /// Parameters
+            /// ----------
+            /// temperature : SINumber
+            ///     The temperature for which C' should be computed.
+            /// moles : SIArray1, optional
+            ///     The amount of substance in mol for each component.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "(temperature, moles=None)")]
+            fn third_virial_coefficient_temperature_derivative(
+                &self,
+                temperature: PySINumber,
+                moles: Option<PySIArray1>,
+            ) -> PyResult<PySINumber> {
+                let m = moles.as_deref();
+                Ok(self
+                    .0
+                    .third_virial_coefficient_temperature_derivative(temperature.into(), m)?
+                    .into())
+            }
+        }
+    };
+}

--- a/feos-core/src/python/joback.rs
+++ b/feos-core/src/python/joback.rs
@@ -1,0 +1,47 @@
+use crate::impl_json_handling;
+use crate::joback::JobackRecord;
+use crate::parameter::ParameterError;
+use pyo3::prelude::*;
+
+/// Create a set of Joback ideal gas heat capacity parameters
+/// for a segment or a pure component.
+///
+/// The fourth order coefficient `e` is not present in the
+/// orginial publication by Joback and Reid but is required
+/// for correlations for some pure components that are modeled
+/// using the same polynomial approach.
+///
+/// Parameters
+/// ----------
+/// a : float
+///     zeroth order coefficient
+/// b : float
+///     first order coefficient
+/// c : float
+///     second order coefficient
+/// d : float
+///     third order coefficient
+/// e : float
+///     fourth order coefficient
+///
+/// Returns
+/// -------
+/// JobackRecord
+#[pyclass(name = "JobackRecord")]
+#[derive(Clone)]
+#[pyo3(text_signature = "(a, b, c, d, e)")]
+pub struct PyJobackRecord(pub JobackRecord);
+
+#[pymethods]
+impl PyJobackRecord {
+    #[new]
+    fn new(a: f64, b: f64, c: f64, d: f64, e: f64) -> Self {
+        Self(JobackRecord::new(a, b, c, d, e))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl_json_handling!(PyJobackRecord);

--- a/feos-core/src/python/mod.rs
+++ b/feos-core/src/python/mod.rs
@@ -1,0 +1,18 @@
+use crate::EosError;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::PyErr;
+
+pub mod cubic;
+mod equation_of_state;
+pub mod joback;
+pub mod parameter;
+mod phase_equilibria;
+mod state;
+pub mod statehd;
+pub mod user_defined;
+
+impl From<EosError> for PyErr {
+    fn from(e: EosError) -> PyErr {
+        PyRuntimeError::new_err(e.to_string())
+    }
+}

--- a/feos-core/src/python/parameter.rs
+++ b/feos-core/src/python/parameter.rs
@@ -1,0 +1,770 @@
+use crate::impl_json_handling;
+use crate::parameter::{BinaryRecord, ChemicalRecord, Identifier, ParameterError};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+impl From<ParameterError> for PyErr {
+    fn from(e: ParameterError) -> PyErr {
+        PyRuntimeError::new_err(e.to_string())
+    }
+}
+
+/// Create an identifier for a pure substance.
+///
+/// Parameters
+/// ----------
+/// cas : str, optional
+///     CAS number.
+/// name : str, optional
+///     name
+/// iupac_name : str, optional
+///     Iupac name.
+/// smiles : str, optional
+///     Canonical SMILES
+/// inchi : str, optional
+///     Inchi number
+/// formula : str, optional
+///     Molecular formula.
+///
+/// Returns
+/// -------
+/// Identifier
+#[pyclass(name = "Identifier")]
+#[derive(Clone)]
+#[pyo3(
+    text_signature = "(cas=None, name=None, iupac_name=None, smiles=None, inchi=None, formula=None)"
+)]
+pub struct PyIdentifier(pub Identifier);
+
+#[pymethods]
+impl PyIdentifier {
+    #[new]
+    fn new(
+        cas: Option<&str>,
+        name: Option<&str>,
+        iupac_name: Option<&str>,
+        smiles: Option<&str>,
+        inchi: Option<&str>,
+        formula: Option<&str>,
+    ) -> Self {
+        Self(Identifier::new(
+            cas, name, iupac_name, smiles, inchi, formula,
+        ))
+    }
+
+    #[getter]
+    fn get_cas(&self) -> Option<String> {
+        self.0.cas.clone()
+    }
+
+    #[setter]
+    fn set_cas(&mut self, cas: &str) {
+        self.0.cas = Some(cas.to_string());
+    }
+
+    #[getter]
+    fn get_name(&self) -> Option<String> {
+        self.0.name.clone()
+    }
+
+    #[setter]
+    fn set_name(&mut self, name: &str) {
+        self.0.name = Some(name.to_string());
+    }
+
+    #[getter]
+    fn get_iupac_name(&self) -> Option<String> {
+        self.0.iupac_name.clone()
+    }
+
+    #[setter]
+    fn set_iupac_name(&mut self, iupac_name: &str) {
+        self.0.iupac_name = Some(iupac_name.to_string());
+    }
+
+    #[getter]
+    fn get_smiles(&self) -> Option<String> {
+        self.0.smiles.clone()
+    }
+
+    #[setter]
+    fn set_smiles(&mut self, smiles: &str) {
+        self.0.smiles = Some(smiles.to_string());
+    }
+
+    #[getter]
+    fn get_inchi(&self) -> Option<String> {
+        self.0.inchi.clone()
+    }
+
+    #[setter]
+    fn set_inchi(&mut self, inchi: &str) {
+        self.0.inchi = Some(inchi.to_string());
+    }
+
+    #[getter]
+    fn get_formula(&self) -> Option<String> {
+        self.0.formula.clone()
+    }
+
+    #[setter]
+    fn set_formula(&mut self, formula: &str) {
+        self.0.formula = Some(formula.to_string());
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl_json_handling!(PyIdentifier);
+
+/// Create a chemical record for a pure substance.
+///
+/// Parameters
+/// ----------
+/// identifier : Identifier
+///     The identifier of the pure component.
+/// segments : [str]
+///     List of segments, that the molecule consists of.
+/// bonds : [[int, int]], optional
+///     List of bonds with the indices starting at 0 and
+///     referring to the list of segments passed as first
+///     argument. If no bonds are specified, the molecule
+///     is assumed to be linear.
+///
+/// Returns
+/// -------
+/// ChemicalRecord
+#[pyclass(name = "ChemicalRecord")]
+#[derive(Clone)]
+#[pyo3(text_signature = "(identifier, segments, bonds=None)")]
+pub struct PyChemicalRecord(pub ChemicalRecord);
+
+#[pymethods]
+impl PyChemicalRecord {
+    #[new]
+    fn new(
+        identifier: PyIdentifier,
+        segments: Vec<String>,
+        bonds: Option<Vec<[usize; 2]>>,
+    ) -> Self {
+        Self(ChemicalRecord::new(identifier.0, segments, bonds))
+    }
+
+    #[getter]
+    fn get_identifier(&self) -> PyIdentifier {
+        PyIdentifier(self.0.identifier.clone())
+    }
+
+    #[getter]
+    fn get_segments(&self) -> Vec<String> {
+        self.0.segments.clone()
+    }
+
+    #[getter]
+    fn get_bonds(&self) -> Vec<[usize; 2]> {
+        self.0.bonds.clone()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl_json_handling!(PyChemicalRecord);
+
+#[macro_export]
+macro_rules! impl_binary_record {
+    () => {
+        #[pyclass(name = "BinaryModelRecord")]
+        #[derive(Clone)]
+        struct PyBinaryModelRecord(f64);
+        impl_binary_record!(f64, PyBinaryModelRecord);
+    };
+    ($model_record:ident, $py_model_record:ident) => {
+        /// Create a record for a binary interaction parameter.
+        ///
+        /// Parameters
+        /// ----------
+        /// id1 : Identifier
+        ///     The identifier of the first component.
+        /// id2 : Identifier
+        ///     The identifier of the second component.
+        /// model_record : float or BinaryModelRecord
+        ///     The binary interaction parameter.
+        ///
+        /// Returns
+        /// -------
+        /// BinaryRecord
+        #[pyclass(name = "BinaryRecord")]
+        #[pyo3(text_signature = "(id1, id2, model_record)")]
+        #[derive(Clone)]
+        pub struct PyBinaryRecord(pub BinaryRecord<Identifier, $model_record>);
+
+        #[pymethods]
+        impl PyBinaryRecord {
+            #[new]
+            fn new(id1: PyIdentifier, id2: PyIdentifier, model_record: &PyAny) -> PyResult<Self> {
+                if let Ok(mr) = model_record.extract::<f64>() {
+                    Ok(Self(BinaryRecord::new(id1.0, id2.0, mr.try_into()?)))
+                } else if let Ok(mr) = model_record.extract::<$py_model_record>() {
+                    Ok(Self(BinaryRecord::new(id1.0, id2.0, mr.0)))
+                } else {
+                    Err(PyErr::new::<PyTypeError, _>(format!(
+                        "Could not parse model_record input!"
+                    )))
+                }
+            }
+
+            #[getter]
+            fn get_id1(&self) -> PyIdentifier {
+                PyIdentifier(self.0.id1.clone())
+            }
+
+            #[setter]
+            fn set_id1(&mut self, id1: PyIdentifier) {
+                self.0.id1 = id1.0;
+            }
+
+            #[getter]
+            fn get_id2(&self) -> PyIdentifier {
+                PyIdentifier(self.0.id2.clone())
+            }
+
+            #[setter]
+            fn set_id2(&mut self, id2: PyIdentifier) {
+                self.0.id2 = id2.0;
+            }
+
+            #[getter]
+            fn get_model_record(&self, py: Python) -> PyObject {
+                if let Ok(mr) = f64::try_from(self.0.model_record.clone()) {
+                    mr.to_object(py)
+                } else {
+                    $py_model_record(self.0.model_record.clone()).into_py(py)
+                }
+            }
+
+            #[setter]
+            fn set_model_record(&mut self, model_record: &PyAny) -> PyResult<()> {
+                if let Ok(mr) = model_record.extract::<f64>() {
+                    self.0.model_record = mr.try_into()?;
+                } else if let Ok(mr) = model_record.extract::<$py_model_record>() {
+                    self.0.model_record = mr.0;
+                } else {
+                    return Err(PyErr::new::<PyTypeError, _>(format!(
+                        "Could not parse model_record input!"
+                    )));
+                }
+                Ok(())
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+        impl_json_handling!(PyBinaryRecord);
+    };
+}
+
+/// Create a record for a binary segment interaction parameter.
+///
+/// Parameters
+/// ----------
+/// id1 : str
+///     The identifier of the first segment.
+/// id2 : str
+///     The identifier of the second segment.
+/// model_record : float
+///     The binary segment interaction parameter.
+///
+/// Returns
+/// -------
+/// BinarySegmentRecord
+#[pyclass(name = "BinarySegmentRecord")]
+#[pyo3(text_signature = "(id1, id2, model_record)")]
+#[derive(Clone)]
+pub struct PyBinarySegmentRecord(pub BinaryRecord<String, f64>);
+
+#[pymethods]
+impl PyBinarySegmentRecord {
+    #[new]
+    fn new(id1: String, id2: String, model_record: f64) -> PyResult<Self> {
+        Ok(Self(BinaryRecord::new(id1, id2, model_record)))
+    }
+
+    #[getter]
+    fn get_id1(&self) -> String {
+        self.0.id1.clone()
+    }
+
+    #[setter]
+    fn set_id1(&mut self, id1: String) {
+        self.0.id1 = id1;
+    }
+
+    #[getter]
+    fn get_id2(&self) -> String {
+        self.0.id2.clone()
+    }
+
+    #[setter]
+    fn set_id2(&mut self, id2: String) {
+        self.0.id2 = id2;
+    }
+
+    #[getter]
+    fn get_model_record(&self) -> f64 {
+        self.0.model_record
+    }
+
+    #[setter]
+    fn set_model_record(&mut self, model_record: f64) {
+        self.0.model_record = model_record;
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl_json_handling!(PyBinarySegmentRecord);
+
+#[macro_export]
+macro_rules! impl_pure_record {
+    ($model_record:ident, $py_model_record:ident, $ideal_gas_record:ident, $py_ideal_gas_record:ident) => {
+        /// All information required to characterize a pure component.
+        ///
+        /// Parameters
+        /// ----------
+        /// identifier : Identifier
+        ///     The identifier of the pure component.
+        /// molarweight : float
+        ///     The molar weight (in g/mol) of the pure component.
+        /// model_record : ModelRecord
+        ///     The pure component model parameters.
+        /// ideal_gas_record: IdealGasRecord, optional
+        ///     The pure component parameters for the ideal gas model.
+        ///
+        /// Returns
+        /// -------
+        /// PureRecord
+        #[pyclass(name = "PureRecord")]
+        #[pyo3(text_signature = "(identifier, molarweight, model_record, ideal_gas_record=None)")]
+        #[derive(Clone)]
+        pub struct PyPureRecord(pub PureRecord<$model_record, $ideal_gas_record>);
+
+        #[pymethods]
+        impl PyPureRecord {
+            #[new]
+            fn new(
+                identifier: PyIdentifier,
+                molarweight: f64,
+                model_record: $py_model_record,
+                ideal_gas_record: Option<$py_ideal_gas_record>,
+            ) -> PyResult<Self> {
+                Ok(Self(PureRecord::new(
+                    identifier.0,
+                    molarweight,
+                    model_record.0,
+                    ideal_gas_record.map(|ig| ig.0),
+                )))
+            }
+
+            #[getter]
+            fn get_identifier(&self) -> PyIdentifier {
+                PyIdentifier(self.0.identifier.clone())
+            }
+
+            #[setter]
+            fn set_identifier(&mut self, identifier: PyIdentifier) {
+                self.0.identifier = identifier.0;
+            }
+
+            #[getter]
+            fn get_molarweight(&self) -> f64 {
+                self.0.molarweight
+            }
+
+            #[setter]
+            fn set_molarweight(&mut self, molarweight: f64) {
+                self.0.molarweight = molarweight;
+            }
+
+            #[getter]
+            fn get_model_record(&self) -> $py_model_record {
+                $py_model_record(self.0.model_record.clone())
+            }
+
+            #[setter]
+            fn set_model_record(&mut self, model_record: $py_model_record) {
+                self.0.model_record = model_record.0;
+            }
+
+            #[getter]
+            fn get_ideal_gas_record(&self) -> Option<$py_ideal_gas_record> {
+                self.0.ideal_gas_record.clone().map($py_ideal_gas_record)
+            }
+
+            #[setter]
+            fn set_ideal_gas_record(&mut self, ideal_gas_record: $py_ideal_gas_record) {
+                self.0.ideal_gas_record = Some(ideal_gas_record.0);
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+        impl_json_handling!(PyPureRecord);
+    };
+}
+
+#[macro_export]
+macro_rules! impl_segment_record {
+    ($model_record:ident, $py_model_record:ident, $ideal_gas_record:ident, $py_ideal_gas_record:ident) => {
+        /// All information required to characterize a single segment.
+        ///
+        /// Parameters
+        /// ----------
+        /// identifier : str
+        ///     The identifier of the segment.
+        /// molarweight : float
+        ///     The molar weight (in g/mol) of the segment.
+        /// model_record : ModelRecord
+        ///     The segment model parameters.
+        /// ideal_gas_record: IdealGasRecord, optional
+        ///     The segment ideal gas parameters.
+        ///
+        /// Returns
+        /// -------
+        /// SegmentRecord
+        #[pyclass(name = "SegmentRecord")]
+        #[pyo3(text_signature = "(identifier, molarweight, model_record, ideal_gas_record=None)")]
+        #[derive(Clone)]
+        pub struct PySegmentRecord(SegmentRecord<$model_record, $ideal_gas_record>);
+
+        #[pymethods]
+        impl PySegmentRecord {
+            #[new]
+            fn new(
+                identifier: String,
+                molarweight: f64,
+                model_record: $py_model_record,
+                ideal_gas_record: Option<$py_ideal_gas_record>,
+            ) -> PyResult<Self> {
+                Ok(Self(SegmentRecord::new(
+                    identifier,
+                    molarweight,
+                    model_record.0,
+                    ideal_gas_record.map(|ig| ig.0),
+                )))
+            }
+
+            /// Read a list of `SegmentRecord`s from a JSON file.
+            ///
+            /// Parameters
+            /// ----------
+            /// path : str
+            ///     Path to file containing the segment records.
+            ///
+            /// Returns
+            /// -------
+            /// SegmentRecord
+            #[staticmethod]
+            #[pyo3(text_signature = "(path)")]
+            fn from_json(path: &str) -> Result<Vec<Self>, ParameterError> {
+                Ok(SegmentRecord::from_json(path)?
+                    .into_iter()
+                    .map(|s| Self(s))
+                    .collect())
+            }
+
+            #[getter]
+            fn get_identifier(&self) -> String {
+                self.0.identifier.clone()
+            }
+
+            #[setter]
+            fn set_identifier(&mut self, identifier: String) {
+                self.0.identifier = identifier;
+            }
+
+            #[getter]
+            fn get_molarweight(&self) -> f64 {
+                self.0.molarweight
+            }
+
+            #[setter]
+            fn set_molarweight(&mut self, molarweight: f64) {
+                self.0.molarweight = molarweight;
+            }
+
+            #[getter]
+            fn get_model_record(&self) -> $py_model_record {
+                $py_model_record(self.0.model_record.clone())
+            }
+
+            #[setter]
+            fn set_model_record(&mut self, model_record: $py_model_record) {
+                self.0.model_record = model_record.0;
+            }
+
+            #[getter]
+            fn get_ideal_gas_record(&self) -> Option<$py_ideal_gas_record> {
+                self.0.ideal_gas_record.clone().map($py_ideal_gas_record)
+            }
+
+            #[setter]
+            fn set_ideal_gas_record(&mut self, ideal_gas_record: $py_ideal_gas_record) {
+                self.0.ideal_gas_record = Some(ideal_gas_record.0);
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+        impl_json_handling!(PySegmentRecord);
+    };
+}
+
+#[macro_export]
+macro_rules! impl_parameter {
+    ($parameter:ty, $py_parameter:ty) => {
+        #[pymethods]
+        impl $py_parameter {
+            /// Creates parameters from records.
+            ///
+            /// Parameters
+            /// ----------
+            /// pure_records : [PureRecord]
+            ///     A list of pure component parameters.
+            /// binary_records : numpy.ndarray[float] or List[BinaryRecord]
+            ///     A matrix of binary interaction parameters or a list
+            ///     containing records for binary interactions.
+            /// search_option : IdentifierOption, optional, defaults to IdentifierOption.Name
+            ///     Identifier that is used to search binary records.
+            #[staticmethod]
+            #[pyo3(text_signature = "(pure_records, binary_records, search_option)")]
+            fn from_records(
+                pure_records: Vec<PyPureRecord>,
+                binary_records: &PyAny,
+                search_option: Option<IdentifierOption>,
+            ) -> PyResult<Self> {
+                let prs = pure_records.into_iter().map(|pr| pr.0).collect();
+                let brs = if let Ok(br) = binary_records.extract::<PyReadonlyArray2<f64>>() {
+                    Ok(br.to_owned_array().mapv(|r| r.try_into().unwrap()))
+                } else if let Ok(br) = binary_records.extract::<Vec<PyBinaryRecord>>() {
+                    let brs: Vec<_> = br.into_iter().map(|br| br.0).collect();
+                    Ok(<$parameter>::binary_matrix_from_records(
+                        &prs,
+                        &brs,
+                        search_option.unwrap_or(IdentifierOption::Name),
+                    ))
+                } else {
+                    Err(PyErr::new::<PyTypeError, _>(format!(
+                        "Could not parse binary input!"
+                    )))
+                };
+                Ok(Self(Rc::new(<$parameter>::from_records(prs, brs.unwrap()))))
+            }
+
+            /// Creates parameters for a pure component from a pure record.
+            ///
+            /// Parameters
+            /// ----------
+            /// pure_record : PureRecord
+            ///     The pure component parameters.
+            #[staticmethod]
+            #[pyo3(text_signature = "(pure_record)")]
+            fn new_pure(pure_record: PyPureRecord) -> Self {
+                Self(Rc::new(<$parameter>::new_pure(pure_record.0)))
+            }
+
+            /// Creates parameters for a binary system from pure records and an optional
+            /// binary interaction parameter or binary interaction parameter record.
+            ///
+            /// Parameters
+            /// ----------
+            /// pure_records : [PureRecord]
+            ///     A list of pure component parameters.
+            /// binary_record : float or BinaryRecord, optional
+            ///     The binary interaction parameter or binary interaction record.
+            #[staticmethod]
+            #[pyo3(text_signature = "(pure_records, binary_record)")]
+            fn new_binary(
+                pure_records: Vec<PyPureRecord>,
+                binary_record: Option<&PyAny>,
+            ) -> PyResult<Self> {
+                let prs = pure_records.into_iter().map(|pr| pr.0).collect();
+                let br = binary_record
+                    .map(|br| {
+                        if let Ok(r) = br.extract::<f64>() {
+                            Ok(r.try_into()?)
+                        } else if let Ok(r) = br.extract::<PyBinaryRecord>() {
+                            Ok(r.0.model_record)
+                        } else {
+                            Err(PyErr::new::<PyTypeError, _>(format!(
+                                "Could not parse binary input!"
+                            )))
+                        }
+                    })
+                    .transpose()?;
+                Ok(Self(Rc::new(<$parameter>::new_binary(prs, br))))
+            }
+
+            /// Creates parameters from json files.
+            ///
+            /// Parameters
+            /// ----------
+            /// substances : List[str]
+            ///     The substances to search.
+            /// pure_path : str
+            ///     Path to file containing pure substance parameters.
+            /// binary_path : str, optional
+            ///     Path to file containing binary substance parameters.
+            /// search_option : IdentifierOption, optional, defaults to IdentifierOption.Name
+            ///     Identifier that is used to search substance.
+            #[staticmethod]
+            #[pyo3(text_signature = "(substances, pure_path, binary_path, search_option)")]
+            fn from_json(
+                substances: Vec<&str>,
+                pure_path: String,
+                binary_path: Option<String>,
+                search_option: Option<IdentifierOption>,
+            ) -> Result<Self, ParameterError> {
+                Ok(Self(Rc::new(<$parameter>::from_json(
+                    substances,
+                    pure_path,
+                    binary_path,
+                    search_option.unwrap_or(IdentifierOption::Name),
+                )?)))
+            }
+
+            /// Creates parameters from json files.
+            ///
+            /// Parameters
+            /// ----------
+            /// input : List[Tuple[List[str], str]]
+            ///     The substances to search and their respective parameter files.
+            ///     E.g. [(["methane", "propane"], "parameters/alkanes.json"), (["methanol"], "parameters/alcohols.json")]
+            /// binary_path : str, optional
+            ///     Path to file containing binary substance parameters.
+            /// search_option : IdentifierOption, optional, defaults to IdentifierOption.Name
+            ///     Identifier that is used to search substance.
+            #[staticmethod]
+            #[pyo3(text_signature = "(input, binary_path=None, search_option='Name')")]
+            fn from_multiple_json(
+                input: Vec<(Vec<&str>, &str)>,
+                binary_path: Option<&str>,
+                search_option: Option<IdentifierOption>,
+            ) -> Result<Self, ParameterError> {
+                Ok(Self(Rc::new(<$parameter>::from_multiple_json(
+                    &input,
+                    binary_path,
+                    search_option.unwrap_or(IdentifierOption::Name),
+                )?)))
+            }
+
+            #[getter]
+            fn get_pure_records(&self) -> Vec<PyPureRecord> {
+                self.0
+                    .records()
+                    .0
+                    .iter()
+                    .map(|r| PyPureRecord(r.clone()))
+                    .collect()
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_parameter_from_segments {
+    ($parameter:ty, $py_parameter:ty) => {
+        #[pymethods]
+        impl $py_parameter {
+            /// Creates parameters from segment records.
+            ///
+            /// Parameters
+            /// ----------
+            /// chemical_records : [ChemicalRecord]
+            ///     A list of pure component chemical records.
+            /// segment_records : [SegmentRecord]
+            ///     A list of records containing the parameters of
+            ///     all individual segments.
+            /// binary_segment_records : [BinarySegmentRecord], optional
+            ///     A list of binary segment-segment parameters.
+            #[staticmethod]
+            #[pyo3(text_signature = "(chemical_records, segment_records, binary_segment_records=None)")]
+            fn from_segments(
+                chemical_records: Vec<PyChemicalRecord>,
+                segment_records: Vec<PySegmentRecord>,
+                binary_segment_records: Option<Vec<PyBinarySegmentRecord>>,
+            ) -> Result<Self, ParameterError> {
+                Ok(Self(Rc::new(<$parameter>::from_segments(
+                    chemical_records.into_iter().map(|cr| cr.0).collect(),
+                    segment_records.into_iter().map(|sr| sr.0).collect(),
+                    binary_segment_records.map(|r| r.into_iter().map(|r| BinaryRecord{id1:r.0.id1,id2:r.0.id2,model_record:r.0.model_record.into()}).collect()),
+                )?)))
+            }
+
+            /// Creates parameters using segments from json file.
+            ///
+            /// Parameters
+            /// ----------
+            /// substances : List[str]
+            ///     The substances to search.
+            /// pure_path : str
+            ///     Path to file containing pure substance parameters.
+            /// segments_path : str
+            ///     Path to file containing segment parameters.
+            /// binary_path : str, optional
+            ///     Path to file containing binary segment-segment parameters.
+            /// search_option : IdentifierOption, optional, defaults to IdentifierOption.Name
+            ///     Identifier that is used to search substance.
+            #[staticmethod]
+            #[pyo3(
+                text_signature = "(substances, pure_path, segments_path, binary_path, search_option)"
+            )]
+            fn from_json_segments(
+                substances: Vec<&str>,
+                pure_path: String,
+                segments_path: String,
+                binary_path: Option<String>,
+                search_option: Option<IdentifierOption>,
+            ) -> Result<Self, ParameterError> {
+                Ok(Self(Rc::new(<$parameter>::from_json_segments(
+                    &substances,
+                    pure_path,
+                    segments_path,
+                    binary_path,
+                    search_option.unwrap_or(IdentifierOption::Name),
+                )?)))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_json_handling {
+    ($py_parameter:ty) => {
+        #[pymethods]
+        impl $py_parameter {
+            /// Creates record from json string.
+            #[staticmethod]
+            #[pyo3(text_signature = "(json)")]
+            fn from_json_str(json: &str) -> Result<Self, ParameterError> {
+                Ok(Self(serde_json::from_str(json)?))
+            }
+
+            /// Creates a json string from record.
+            fn to_json_str(&self) -> Result<String, ParameterError> {
+                Ok(serde_json::to_string(&self.0)?)
+            }
+        }
+    };
+}

--- a/feos-core/src/python/phase_equilibria.rs
+++ b/feos-core/src/python/phase_equilibria.rs
@@ -1,0 +1,825 @@
+#[macro_export]
+macro_rules! impl_phase_equilibrium {
+    ($eos:ty, $py_eos:ty) => {
+        /// A thermodynamic two phase equilibrium state.
+        #[pyclass(name = "PhaseEquilibrium", unsendable)]
+        #[derive(Clone)]
+        pub struct PyPhaseEquilibrium(PhaseEquilibrium<SIUnit, $eos, 2>);
+
+        #[pymethods]
+        impl PyPhaseEquilibrium {
+            /// Create a liquid and vapor state in equilibrium
+            /// for a pure substance.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure : SINumber
+            ///     The system temperature or pressure.
+            /// initial_state : PhaseEquilibrium, optional
+            ///     A phase equilibrium used as initial guess.
+            ///     Can speed up convergence.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseEquilibrium
+            ///
+            /// Raises
+            /// ------
+            /// RuntimeError
+            ///     When pressure iteration fails or no phase equilibrium is found.
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, initial_state=None, max_iter=None, tol=None, verbosity=None)")]
+            pub fn pure(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                initial_state: Option<&PyPhaseEquilibrium>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                Ok(Self(PhaseEquilibrium::pure(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    initial_state.and_then(|s| Some(&s.0)),
+                    (max_iter, tol, verbosity).into(),
+                )?))
+            }
+
+            /// Create a liquid and vapor state in equilibrium
+            /// for given temperature, pressure and feed composition.
+            ///
+            /// Can also be used to calculate liquid liquid phase separation.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature : SINumber
+            ///     The system temperature.
+            /// pressure : SINumber
+            ///     The system pressure.
+            /// feed : SIArray1
+            ///     Feed composition (units of amount of substance).
+            /// initial_state : PhaseEquilibrium, optional
+            ///     A phase equilibrium used as initial guess.
+            ///     Can speed up convergence.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseEquilibrium
+            ///
+            /// Raises
+            /// ------
+            /// RuntimeError
+            ///     When pressure iteration fails or no phase equilibrium is found.
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature, pressure, feed, initial_state=None, max_iter=None, tol=None, verbosity=None, non_volatile_components=None)")]
+            pub fn tp_flash(
+                eos: $py_eos,
+                temperature: PySINumber,
+                pressure: PySINumber,
+                feed: &PySIArray1,
+                initial_state: Option<&PyPhaseEquilibrium>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+                non_volatile_components: Option<Vec<usize>>,
+            ) -> PyResult<Self> {
+                Ok(Self(PhaseEquilibrium::tp_flash(
+                    &eos.0,
+                    temperature.into(),
+                    pressure.into(),
+                    feed,
+                    initial_state.and_then(|s| Some(&s.0)),
+                    (max_iter, tol, verbosity).into(), non_volatile_components
+                )?))
+            }
+
+            /// Compute a phase equilibrium for given temperature
+            /// or pressure and liquid mole fractions.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure : SINumber
+            ///     The system temperature_or_pressure.
+            /// liquid_molefracs : numpy.ndarray
+            ///     The mole fraction of the liquid phase.
+            /// tp_init : SINumber, optional
+            ///     The system pressure/temperature used as starting
+            ///     condition for the iteration.
+            /// vapor_molefracs : numpy.ndarray, optional
+            ///     The mole fraction of the vapor phase used as
+            ///     starting condition for iteration.
+            /// max_iter_inner : int, optional
+            ///     The maximum number of inner iterations.
+            /// max_iter_outer : int, optional
+            ///     The maximum number of outer iterations.
+            /// tol_inner : float, optional
+            ///     The solution tolerance in the inner loop.
+            /// tol_outer : float, optional
+            ///     The solution tolerance in the outer loop.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseEquilibrium
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, liquid_molefracs, tp_init=None, vapor_molefracs=None, max_iter_inner=None, max_iter_outer=None, tol_inner=None, tol_outer=None, verbosity=None)")]
+            pub fn bubble_point(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                liquid_molefracs: &PyArray1<f64>,
+                tp_init: Option<PySINumber>,
+                vapor_molefracs: Option<&PyArray1<f64>>,
+                max_iter_inner: Option<usize>,
+                max_iter_outer: Option<usize>,
+                tol_inner: Option<f64>,
+                tol_outer: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                let x = vapor_molefracs.and_then(|m| Some(m.to_owned_array()));
+                Ok(Self(PhaseEquilibrium::bubble_point(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    &liquid_molefracs.to_owned_array(),
+                    tp_init.map(|p| p.into()),
+                    x.as_ref(),
+                    (
+                        (max_iter_inner, tol_inner, verbosity).into(),
+                        (max_iter_outer, tol_outer, verbosity).into()
+                    )
+                )?))
+            }
+
+            /// Compute a phase equilibrium for given temperature
+            /// or pressure and vapor mole fractions.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure : SINumber
+            ///     The system temperature or pressure.
+            /// vapor_molefracs : numpy.ndarray
+            ///     The mole fraction of the vapor phase.
+            /// tp_init : SINumber, optional
+            ///     The system pressure/temperature used as starting
+            ///     condition for the iteration.
+            /// liquid_molefracs : numpy.ndarray, optional
+            ///     The mole fraction of the liquid phase used as
+            ///     starting condition for iteration.
+            /// max_iter_inner : int, optional
+            ///     The maximum number of inner iterations.
+            /// max_iter_outer : int, optional
+            ///     The maximum number of outer iterations.
+            /// tol_inner : float, optional
+            ///     The solution tolerance in the inner loop.
+            /// tol_outer : float, optional
+            ///     The solution tolerance in the outer loop.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseEquilibrium
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, vapor_molefracs, tp_init=None, liquid_molefracs=None, max_iter_inner=None, max_iter_outer=None, tol_inner=None, tol_outer=None, verbosity=None)")]
+            pub fn dew_point(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                vapor_molefracs: &PyArray1<f64>,
+                tp_init: Option<PySINumber>,
+                liquid_molefracs: Option<&PyArray1<f64>>,
+                max_iter_inner: Option<usize>,
+                max_iter_outer: Option<usize>,
+                tol_inner: Option<f64>,
+                tol_outer: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                let x = liquid_molefracs.and_then(|m| Some(m.to_owned_array()));
+                Ok(Self(PhaseEquilibrium::dew_point(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    &vapor_molefracs.to_owned_array(),
+                    tp_init.map(|p| p.into()),
+                    x.as_ref(),
+                    (
+                        (max_iter_inner, tol_inner, verbosity).into(),
+                        (max_iter_outer, tol_outer, verbosity).into()
+                    )
+                )?))
+            }
+
+            #[getter]
+            fn get_vapor(&self) -> PyState {
+                PyState(self.0.vapor().clone())
+            }
+
+            #[getter]
+            fn get_liquid(&self) -> PyState {
+                PyState(self.0.liquid().clone())
+            }
+
+            /// Calculate a new PhaseEquilibrium with the given chemical potential.
+            /// The temperature remains constant, but the states are not in
+            /// a mechanical equilibrium anymore.
+            ///
+            /// Parameters
+            /// ----------
+            /// chemical_potential: SIArray1
+            ///     The new chemical potential
+            ///
+            #[pyo3(text_signature = "(chemical_potential)")]
+            fn update_chemical_potential(slf: &PyCell<Self>, chemical_potential: &PySIArray1) -> PyResult<()> {
+                slf.borrow_mut().0.update_chemical_potential(chemical_potential)?;
+                Ok(())
+            }
+
+            /// Calculate the pure component vapor-liquid equilibria for all
+            /// components in the system.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure : SINumber
+            ///     The system temperature or pressure.
+            ///
+            /// Returns
+            /// -------
+            /// list[PhaseEquilibrium]
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure)")]
+            fn vle_pure_comps(eos: $py_eos, temperature_or_pressure: PySINumber) -> Vec<Option<Self>> {
+                PhaseEquilibrium::vle_pure_comps(&eos.0, temperature_or_pressure.into())
+                    .into_iter()
+                    .map(|o| o.map(Self))
+                    .collect()
+            }
+
+            /// Calculate the pure component vapor pressures for all the
+            /// components in the system.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature : SINumber
+            ///     The system temperature.
+            ///
+            /// Returns
+            /// -------
+            /// list[SINumber]
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature)")]
+            fn vapor_pressure(eos: $py_eos, temperature: PySINumber) -> Vec<Option<PySINumber>> {
+                PhaseEquilibrium::vapor_pressure(&eos.0, temperature.into())
+                    .into_iter()
+                    .map(|o| o.map(|n| n.into()))
+                    .collect()
+            }
+
+            /// Calculate the pure component boiling temperatures for all the
+            /// components in the system.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// pressure : SINumber
+            ///     The system pressure.
+            ///
+            /// Returns
+            /// -------
+            /// list[SINumber]
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, pressure)")]
+            fn boiling_temperature(eos: $py_eos, pressure: PySINumber) -> Vec<Option<PySINumber>> {
+                PhaseEquilibrium::boiling_temperature(&eos.0, pressure.into())
+                    .into_iter()
+                    .map(|o| o.map(|n| n.into()))
+                    .collect()
+            }
+
+            fn _repr_markdown_(&self) -> String {
+                self.0._repr_markdown_()
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+        /// A thermodynamic three phase equilibrium state.
+        #[pyclass(name = "ThreePhaseEquilibrium", unsendable)]
+        #[derive(Clone)]
+        struct PyThreePhaseEquilibrium(PhaseEquilibrium<SIUnit, $eos, 3>);
+
+        #[pymethods]
+        impl PyPhaseEquilibrium {
+            /// Calculate a heteroazeotrope in a binary mixture for a given temperature
+            /// or pressure.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure : SINumber
+            ///     The system temperature or pressure.
+            /// x_init : list[float]
+            ///     Initial guesses for the liquid molefracs of component 1
+            ///     at the heteroazeotropic point.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            /// max_iter_bd_inner : int, optional
+            ///     The maximum number of inner iterations in the bubble/dew point iteration.
+            /// max_iter_bd_outer : int, optional
+            ///     The maximum number of outer iterations in the bubble/dew point iteration.
+            /// tol_bd_inner : float, optional
+            ///     The solution tolerance in the inner loop of the bubble/dew point iteration.
+            /// tol_bd_outer : float, optional
+            ///     The solution tolerance in the outer loop of the bubble/dew point iteration.
+            /// verbosity_bd : Verbosity, optional
+            ///     The verbosity of the bubble/dew point iteration.
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, x_init, max_iter=None, tol=None, verbosity=None, max_iter_bd_inner=None, max_iter_bd_outer=None, tol_bd_inner=None, tol_bd_outer=None, verbosity_bd=None)")]
+            fn heteroazeotrope(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                x_init: (f64, f64),
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+                max_iter_bd_inner: Option<usize>,
+                max_iter_bd_outer: Option<usize>,
+                tol_bd_inner: Option<f64>,
+                tol_bd_outer: Option<f64>,
+                verbosity_bd: Option<Verbosity>,
+            ) -> PyResult<PyThreePhaseEquilibrium> {
+                Ok(PyThreePhaseEquilibrium(PhaseEquilibrium::heteroazeotrope(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    x_init,
+                    (max_iter, tol, verbosity).into(),
+                    (
+                        (max_iter_bd_inner, tol_bd_inner, verbosity_bd).into(),
+                        (max_iter_bd_outer, tol_bd_outer, verbosity_bd).into(),
+                    )
+                )?))
+            }
+        }
+
+        #[pymethods]
+        impl PyThreePhaseEquilibrium {
+            #[getter]
+            fn get_vapor(&self) -> PyState {
+                PyState(self.0.vapor().clone())
+            }
+
+            #[getter]
+            fn get_liquid1(&self) -> PyState {
+                PyState(self.0.liquid1().clone())
+            }
+
+            #[getter]
+            fn get_liquid2(&self) -> PyState {
+                PyState(self.0.liquid2().clone())
+            }
+
+            fn _repr_markdown_(&self) -> String {
+                self.0._repr_markdown_()
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+        #[pymethods]
+        impl PyState {
+            /// Calculates a two phase Tp-flash with the state as feed.
+            ///
+            /// Parameters
+            /// ----------
+            /// initial_state : PhaseEquilibrium, optional
+            ///     A phase equilibrium used as initial guess.
+            ///     Can speed up convergence.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseEquilibrium
+            ///
+            /// Raises
+            /// ------
+            /// RuntimeError
+            ///     When pressure iteration fails or no phase equilibrium is found.
+            #[pyo3(text_signature = "($self, initial_state=None, max_iter=None, tol=None, verbosity=None, non_volatile_components=None)")]
+            pub fn tp_flash(
+                &self,
+                initial_state: Option<&PyPhaseEquilibrium>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+                non_volatile_components: Option<Vec<usize>>,
+            ) -> PyResult<PyPhaseEquilibrium> {
+                Ok(PyPhaseEquilibrium(self.0.tp_flash(
+                    initial_state.and_then(|s| Some(&s.0)),
+                    (max_iter, tol, verbosity).into(),
+                    non_volatile_components
+                )?))
+            }
+        }
+
+        /// Phase diagram for a pure component or a binary mixture.
+        #[pyclass(name = "PhaseDiagram", unsendable)]
+        pub struct PyPhaseDiagram(PhaseDiagram<SIUnit, $eos>);
+
+        #[pymethods]
+        impl PyPhaseDiagram {
+            /// Calculate a pure component phase diagram.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos: Eos
+            ///     The equation of state.
+            /// min_temperature: SINumber
+            ///     The lower limit for the temperature.
+            /// npoints: int
+            ///     The number of points.
+            /// critical_temperature: SINumber, optional
+            ///     An estimate for the critical temperature to initialize
+            ///     the calculation if necessary. For most components not necessary.
+            ///     Defaults to `None`.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseDiagram
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, min_temperature, npoints, critical_temperature=None, max_iter=None, tol=None, verbosity=None)")]
+            pub fn pure(
+                eos: &$py_eos,
+                min_temperature: PySINumber,
+                npoints: usize,
+                critical_temperature: Option<PySINumber>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                let dia = PhaseDiagram::pure(
+                    &eos.0,
+                    min_temperature.into(),
+                    npoints,
+                    critical_temperature.map(|t| t.into()),
+                    (max_iter, tol, verbosity).into(),
+                )?;
+                Ok(Self(dia))
+            }
+
+            /// Calculate a phase diagram for a mixture with fixed composition.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos: Eos
+            ///     The equation of state.
+            /// moles: SIArray1
+            ///     The moles of the individual components
+            /// min_temperature: SINumber
+            ///     The lower limit for the temperature.
+            /// npoints: int
+            ///     The number of points.
+            /// critical_temperature: SINumber, optional
+            ///     An estimate for the critical temperature to initialize
+            ///     the calculation if necessary. For most components not necessary.
+            ///     Defaults to `None`.
+            /// max_iter_inner : int, optional
+            ///     The maximum number of inner iterations in the bubble/dew point iteration.
+            /// max_iter_outer : int, optional
+            ///     The maximum number of outer iterations in the bubble/dew point iteration.
+            /// tol_inner : float, optional
+            ///     The solution tolerance in the inner loop of the bubble/dew point iteration.
+            /// tol_outer : float, optional
+            ///     The solution tolerance in the outer loop of the bubble/dew point iteration.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity of the bubble/dew point iteration.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseDiagram
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, moles, min_temperature, npoints, critical_temperature=None, max_iter_inner=None, max_iter_outer=None, tol_inner=None, tol_outer=None, verbosity=None)")]
+            pub fn mix(
+                eos: &$py_eos,
+                moles: PySIArray1,
+                min_temperature: PySINumber,
+                npoints: usize,
+                critical_temperature: Option<PySINumber>,
+                max_iter_inner: Option<usize>,
+                max_iter_outer: Option<usize>,
+                tol_inner: Option<f64>,
+                tol_outer: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                let dia = PhaseDiagram::mix(
+                    &eos.0,
+                    &moles,
+                    min_temperature.into(),
+                    npoints,
+                    critical_temperature.map(|t| t.into()),
+                    (
+                        (max_iter_inner, tol_inner, verbosity).into(),
+                        (max_iter_outer, tol_outer, verbosity).into(),
+                    )
+                )?;
+                Ok(Self(dia))
+            }
+
+            #[getter]
+            pub fn get_states(&self) -> Vec<PyPhaseEquilibrium> {
+                self.0
+                    .states
+                    .iter()
+                    .map(|vle| PyPhaseEquilibrium(vle.clone()))
+                    .collect()
+            }
+
+            #[getter]
+            pub fn get_vapor(&self) -> PyStateVec {
+                self.0.vapor().into()
+            }
+
+            #[getter]
+            pub fn get_liquid(&self) -> PyStateVec {
+                self.0.liquid().into()
+            }
+
+            /// Returns the phase diagram as dictionary.
+            ///
+            /// Units
+            /// -----
+            /// temperature : K
+            /// pressure : Pa
+            /// densities : mol / m³
+            /// molar enthalpies : kJ / mol
+            /// molar entropies : kJ / mol / K
+            ///
+            /// Returns
+            /// -------
+            /// dict[str, list[float]]
+            ///     Keys: property names. Values: property for each state.
+            ///
+            /// Notes
+            /// -----
+            /// xi: liquid molefraction of component i
+            /// yi: vapor molefraction of component i
+            /// i: component index according to order in parameters.
+            pub fn to_dict(&self) -> PyResult<HashMap<String, Vec<f64>>> {
+                let n = self.0.states[0].liquid().eos.components();
+                let mut dict = HashMap::with_capacity(8 + 2 * n);
+                if n != 1 {
+                    let xs = self.0.liquid().molefracs();
+                    let ys = self.0.vapor().molefracs();
+                    for i in 0..n {
+                        dict.insert(String::from(format!("x{}", i)), xs.column(i).to_vec());
+                        dict.insert(String::from(format!("y{}", i)), ys.column(i).to_vec());
+                    }
+                }
+                dict.insert(String::from("temperature"), (self.0.vapor().temperature() / KELVIN).into_value()?.into_raw_vec());
+                dict.insert(String::from("pressure"), (self.0.vapor().pressure() / PASCAL).into_value()?.into_raw_vec());
+                dict.insert(String::from("density liquid"), (self.0.liquid().density() / (MOL / METER.powi(3))).into_value()?.into_raw_vec());
+                dict.insert(String::from("density vapor"), (self.0.vapor().density() / (MOL / METER.powi(3))).into_value()?.into_raw_vec());
+                dict.insert(String::from("molar enthalpy liquid"), (self.0.liquid().molar_enthalpy() / (KILO*JOULE / MOL)).into_value()?.into_raw_vec());
+                dict.insert(String::from("molar enthalpy vapor"), (self.0.vapor().molar_enthalpy() / (KILO*JOULE / MOL)).into_value()?.into_raw_vec());
+                dict.insert(String::from("molar entropy liquid"), (self.0.liquid().molar_entropy() / (KILO*JOULE / KELVIN / MOL)).into_value()?.into_raw_vec());
+                dict.insert(String::from("molar entropy vapor"), (self.0.vapor().molar_entropy() / (KILO*JOULE / KELVIN / MOL)).into_value()?.into_raw_vec());
+                Ok(dict)
+            }
+
+            /// Binary phase diagram calculated using bubble/dew point iterations.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure: SINumber
+            ///     The constant temperature or pressure.
+            /// npoints: int, optional
+            ///     The number of points (default 51).
+            /// x_lle: (float, float), optional
+            ///     An estimate for the molefractions of component 1
+            ///     at the heteroazeotrop
+            /// max_iter_inner : int, optional
+            ///     The maximum number of inner iterations in the bubble/dew point iteration.
+            /// max_iter_outer : int, optional
+            ///     The maximum number of outer iterations in the bubble/dew point iteration.
+            /// tol_inner : float, optional
+            ///     The solution tolerance in the inner loop of the bubble/dew point iteration.
+            /// tol_outer : float, optional
+            ///     The solution tolerance in the outer loop of the bubble/dew point iteration.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity of the bubble/dew point iteration.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseDiagram
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, npoints=None, x_lle=None, max_iter_inner=None, max_iter_outer=None, tol_inner=None, tol_outer=None, verbosity=None)")]
+            pub fn binary_vle(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                npoints: Option<usize>,
+                x_lle: Option<(f64, f64)>,
+                max_iter_inner: Option<usize>,
+                max_iter_outer: Option<usize>,
+                tol_inner: Option<f64>,
+                tol_outer: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                let dia = PhaseDiagram::binary_vle(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    npoints,
+                    x_lle,
+                    (
+                        (max_iter_inner, tol_inner, verbosity).into(),
+                        (max_iter_outer, tol_outer, verbosity).into(),
+                    )
+                )?;
+                Ok(Self(dia))
+            }
+
+            /// Create a new phase diagram using Tp flash calculations.
+            ///
+            /// The usual use case for this function is the calculation of
+            /// liquid-liquid phase diagrams, but it can be used for vapor-
+            /// liquid diagrams as well, as long as the feed composition is
+            /// in a two phase region.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : EquationOfState
+            ///     The equation of state.
+            /// temperature_or_pressure: SINumber
+            ///     The consant temperature or pressure.
+            /// feed: SIArray1
+            ///     Mole numbers in the (unstable) feed state.
+            /// min_tp:
+            ///     The lower limit of the temperature/pressure range.
+            /// max_tp:
+            ///     The upper limit of the temperature/pressure range.
+            /// npoints: int, optional
+            ///     The number of points (default 51).
+            ///
+            /// Returns
+            /// -------
+            /// PhaseDiagram
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, feed, min_tp, max_tp, npoints=None)")]
+            pub fn lle(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                feed: PySIArray1,
+                min_tp: PySINumber,
+                max_tp: PySINumber,
+                npoints: Option<usize>,
+            ) -> PyResult<Self> {
+                let dia = PhaseDiagram::lle(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    &feed,
+                    min_tp.into(),
+                    max_tp.into(),
+                    npoints,
+                )?;
+                Ok(Self(dia))
+            }
+        }
+
+        /// Phase diagram for a binary mixture exhibiting a heteroazeotrope.
+        #[pyclass(name = "PhaseDiagramHetero", unsendable)]
+        pub struct PyPhaseDiagramHetero(PhaseDiagramHetero<SIUnit, $eos>);
+
+        #[pymethods]
+        impl PyPhaseDiagram {
+            /// Phase diagram for a binary mixture exhibiting a heteroazeotrope.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos: SaftFunctional
+            ///     The SAFT Helmholtz energy functional.
+            /// pressure: SINumber
+            ///     The pressure.
+            /// x_lle: SINumber
+            ///     Initial values for the molefractions of component 1
+            ///     at the heteroazeotrop.
+            /// min_temperature_lle: SINumber, optional
+            ///     The minimum temperature up to which the LLE is calculated.
+            ///     If it is not provided, no LLE is calcualted.
+            /// npoints_vle: int, optional
+            ///     The number of points for the VLE (default 51).
+            /// npoints_lle: int, optional
+            ///     The number of points for the LLE (default 51).
+            /// max_iter_inner : int, optional
+            ///     The maximum number of inner iterations in the bubble/dew point iteration.
+            /// max_iter_outer : int, optional
+            ///     The maximum number of outer iterations in the bubble/dew point iteration.
+            /// tol_inner : float, optional
+            ///     The solution tolerance in the inner loop of the bubble/dew point iteration.
+            /// tol_outer : float, optional
+            ///     The solution tolerance in the outer loop of the bubble/dew point iteration.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity of the bubble/dew point iteration.
+            ///
+            /// Returns
+            /// -------
+            /// PhaseDiagramHetero
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, pressure, x_lle, min_temperature_lle=None, npoints_vle=None, npoints_lle=None, max_iter_bd_inner=None, max_iter_bd_outer=None, tol_bd_inner=None, tol_bd_outer=None, verbosity_bd=None)")]
+            pub fn binary_vlle(
+                eos: $py_eos,
+                pressure: PySINumber,
+                x_lle: (f64, f64),
+                min_temperature_lle: Option<PySINumber>,
+                npoints_vle: Option<usize>,
+                npoints_lle: Option<usize>,
+                max_iter_inner: Option<usize>,
+                max_iter_outer: Option<usize>,
+                tol_inner: Option<f64>,
+                tol_outer: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<PyPhaseDiagramHetero> {
+                let dia = PhaseDiagram::binary_vlle(
+                    &eos.0,
+                    pressure.into(),
+                    x_lle,
+                    min_temperature_lle.map(|t| t.into()),
+                    npoints_vle,
+                    npoints_lle,
+                    (
+                        (max_iter_inner, tol_inner, verbosity).into(),
+                        (max_iter_outer, tol_outer, verbosity).into(),
+                    )
+                )?;
+                Ok(PyPhaseDiagramHetero(dia))
+            }
+        }
+
+        #[pymethods]
+        impl PyPhaseDiagramHetero {
+            #[getter]
+            pub fn get_vle(&self) -> PyPhaseDiagram {
+                PyPhaseDiagram(self.0.vle().clone())
+            }
+
+            #[getter]
+            pub fn get_vle1(&self) -> PyPhaseDiagram {
+                PyPhaseDiagram(self.0.vle1.clone())
+            }
+
+            #[getter]
+            pub fn get_vle2(&self) -> PyPhaseDiagram {
+                PyPhaseDiagram(self.0.vle2.clone())
+            }
+
+            #[getter]
+            pub fn get_lle(&self) -> Option<PyPhaseDiagram> {
+                self.0
+                    .lle
+                    .as_ref()
+                    .map(|d| PyPhaseDiagram(d.clone()))
+            }
+        }
+    }
+}

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -1,0 +1,1331 @@
+#[macro_export]
+macro_rules! impl_state {
+    ($eos:ty, $py_eos:ty) => {
+        /// A thermodynamic state at given conditions.
+        ///
+        /// Parameters
+        /// ----------
+        /// eos : Eos
+        ///     The equation of state to use.
+        /// temperature : SINumber, optional
+        ///     Temperature.
+        /// volume : SINumber, optional
+        ///     Volume.
+        /// density : SINumber, optional
+        ///     Molar density.
+        /// partial_density : SIArray1, optional
+        ///     Partial molar densities.
+        /// total_moles : SINumber, optional
+        ///     Total amount of substance (of a mixture).
+        /// moles : SIArray1, optional
+        ///     Amount of substance for each component.
+        /// molefracs : numpy.ndarray[float]
+        ///     Molar fraction of each component.
+        /// pressure : SINumber, optional
+        ///     Pressure.
+        /// molar_enthalpy : SINumber, optional
+        ///     Molar enthalpy.
+        /// molar_entropy : SINumber, optional
+        ///     Molar entropy.
+        /// molar_internal_energy: SINumber, optional
+        ///     Molar internal energy
+        /// density_initialization : {'vapor', 'liquid', SINumber, None}, optional
+        ///     Method used to initialize density for density iteration.
+        ///     'vapor' and 'liquid' are inferred from the maximum density of the equation of state.
+        ///     If no density or keyword is provided, the vapor and liquid phase is tested and, if
+        ///     different, the result with the lower free energy is returned.
+        /// initial_temperature : SINumber, optional
+        ///     Initial temperature for temperature iteration. Can improve convergence
+        ///     when the state is specified with pressure and molar entropy or enthalpy.
+        ///
+        /// Returns
+        /// -------
+        /// State : state at given conditions
+        ///
+        /// Raises
+        /// ------
+        /// Error
+        ///     When the state cannot be created using the combination of input.
+        #[pyclass(name = "State", unsendable)]
+        #[derive(Clone)]
+        #[pyo3(text_signature = "(eos, temperature=None, volume=None, density=None, partial_density=None, total_moles=None, moles=None, molefracs=None, pressure=None, molar_enthalpy=None, molar_entropy=None, molar_internal_energy=None, density_initialization=None, initial_temperature=None)")]
+        pub struct PyState(pub State<SIUnit, $eos>);
+
+        #[pymethods]
+        impl PyState {
+            #[new]
+            pub fn new(
+                eos: $py_eos,
+                temperature: Option<PySINumber>,
+                volume: Option<PySINumber>,
+                density: Option<PySINumber>,
+                partial_density: Option<PySIArray1>,
+                total_moles: Option<PySINumber>,
+                moles: Option<PySIArray1>,
+                molefracs: Option<&PyArray1<f64>>,
+                pressure: Option<PySINumber>,
+                molar_enthalpy: Option<PySINumber>,
+                molar_entropy: Option<PySINumber>,
+                molar_internal_energy: Option<PySINumber>,
+                density_initialization: Option<&PyAny>,
+                initial_temperature: Option<PySINumber>,
+            ) -> PyResult<Self> {
+                let x = molefracs.and_then(|m| Some(m.to_owned_array()));
+                let density_init = if let Some(di) = density_initialization {
+                    if let Ok(d) = di.extract::<&str>() {
+                        match d {
+                            "vapor" => Ok(DensityInitialization::Vapor),
+                            "liquid" => Ok(DensityInitialization::Liquid),
+                            _ => Err(PyErr::new::<PyValueError, _>(format!(
+                                "`density_initialization` must be 'vapor' or 'liquid'."
+                            ))),
+                        }
+                    } else if let Ok(d) = di.extract::<PySINumber>() {
+                        Ok(DensityInitialization::InitialDensity(d.into()))
+                    } else {
+                        Err(PyErr::new::<PyValueError, _>(format!(
+                            "`density_initialization` must be 'vapor' or 'liquid' or a molar density as `SINumber` has to be provided."
+                        )))
+                    }
+                } else {
+                    Ok(DensityInitialization::None)
+                };
+                let s = State::new(
+                    &eos.0,
+                    temperature.map(|t| t.into()),
+                    volume.map(|t| t.into()),
+                    density.map(|s| s.into()),
+                    partial_density.as_deref(),
+                    total_moles.map(|s| s.into()),
+                    moles.as_deref(),
+                    x.as_ref(),
+                    pressure.map(|s| s.into()),
+                    molar_enthalpy.map(|s| s.into()),
+                    molar_entropy.map(|s| s.into()),
+                    molar_internal_energy.map(|s| s.into()),
+                    density_init?,
+                    initial_temperature.map(|s| s.into()),
+                )?;
+                Ok(Self(s))
+            }
+
+            /// Return a list of thermodynamic state at critical conditions
+            /// for each pure substance in the system.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos: EquationOfState
+            ///     The equation of state to use.
+            /// initial_temperature: SINumber, optional
+            ///     The initial temperature.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// State : tate at critical conditions
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, initial_temperature=None, max_iter=None, tol=None, verbosity=None)")]
+            fn critical_point_pure(
+                eos: $py_eos,
+                initial_temperature: Option<PySINumber>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Vec<Self>> {
+                let t = initial_temperature.and_then(|t0| Some(t0.into()));
+                let cp = State::critical_point_pure(&eos.0, t, (max_iter, tol, verbosity).into())?;
+                Ok(cp.into_iter().map(Self).collect())
+            }
+
+            /// Create a thermodynamic state at critical conditions.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos: EquationOfState
+            ///     The equation of state to use.
+            /// moles: SIArray1, optional
+            ///     Amount of substance of each component.
+            ///     Only optional for a pure component.
+            /// initial_temperature: SINumber, optional
+            ///     The initial temperature.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// State : State at critical conditions.
+            #[staticmethod]
+            #[args(initial_temperature = "None")]
+            #[pyo3(text_signature = "(eos, moles=None, initial_temperature=None, max_iter=None, tol=None, verbosity=None)")]
+            fn critical_point(
+                eos: $py_eos,
+                moles: Option<PySIArray1>,
+                initial_temperature: Option<PySINumber>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                Ok(PyState(State::critical_point(
+                    &eos.0,
+                    moles.as_deref(),
+                    initial_temperature.map(|t| t.into()),
+                    (max_iter, tol, verbosity).into(),
+                )?))
+            }
+
+            /// Create a thermodynamic state at critical conditions for a binary system.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos: EquationOfState
+            ///     The equation of state to use.
+            /// temperature_or_pressure: SINumber
+            ///     temperature_or_pressure.
+            /// initial_temperature: SINumber, optional
+            ///     An initial guess for the temperature.
+            /// initial_molefracs: [float], optional
+            ///     An initial guess for the composition.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// State : State at critical conditions.
+            #[staticmethod]
+            #[pyo3(text_signature = "(eos, temperature_or_pressure, initial_molefracs=None, max_iter=None, tol=None, verbosity=None)")]
+            fn critical_point_binary(
+                eos: $py_eos,
+                temperature_or_pressure: PySINumber,
+                initial_temperature: Option<PySINumber>,
+                initial_molefracs: Option<[f64; 2]>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                Ok(PyState(State::critical_point_binary(
+                    &eos.0,
+                    temperature_or_pressure.into(),
+                    initial_temperature.map(|t| t.into()),
+                    initial_molefracs,
+                    (max_iter, tol, verbosity).into(),
+                )?))
+            }
+
+            /// Performs a stability analysis and returns a list of stable
+            /// candidate states.
+            ///
+            /// Parameters
+            /// ----------
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// State
+            #[pyo3(text_signature = "(max_iter=None, tol=None, verbosity=None)")]
+            fn stability_analysis(&self,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Vec<Self>> {
+                Ok(self
+                    .0
+                    .stability_analysis((max_iter, tol, verbosity).into())?
+                    .into_iter()
+                    .map(Self)
+                    .collect())
+            }
+
+            /// Performs a stability analysis and returns whether the state
+            /// is stable
+            ///
+            /// Parameters
+            /// ----------
+            /// max_iter : int, optional
+            ///     The maximum number of iterations.
+            /// tol: float, optional
+            ///     The solution tolerance.
+            /// verbosity : Verbosity, optional
+            ///     The verbosity.
+            ///
+            /// Returns
+            /// -------
+            /// bool
+            #[pyo3(text_signature = "(max_iter=None, tol=None, verbosity=None)")]
+            fn is_stable(&self,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<bool> {
+                Ok(self.0.is_stable((max_iter, tol, verbosity).into())?)
+            }
+
+            /// Return pressure.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn pressure(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.pressure(contributions))
+            }
+
+            /// Return pressure contributions.
+            ///
+            /// Returns
+            /// -------
+            /// List[Tuple[str, SINumber]]
+            #[pyo3(text_signature = "($self)")]
+            fn pressure_contributions(&self) -> Vec<(String, PySINumber)> {
+                self.0
+                    .pressure_contributions()
+                    .into_iter()
+                    .map(|(s, q)| (s, PySINumber::from(q)))
+                    .collect()
+            }
+
+            /// Return compressibility.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// float
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn compressibility(&self, contributions: Contributions) -> f64 {
+                self.0.compressibility(contributions)
+            }
+
+            /// Return partial derivative of pressure w.r.t. volume.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dp_dv(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.dp_dv(contributions))
+            }
+
+            /// Return partial derivative of pressure w.r.t. density.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dp_drho(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.dp_drho(contributions))
+            }
+
+            /// Return partial derivative of pressure w.r.t. temperature.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dp_dt(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.dp_dt(contributions))
+            }
+
+            /// Return partial derivative of pressure w.r.t. amount of substance.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dp_dni(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.dp_dni(contributions))
+            }
+
+            /// Return second partial derivative of pressure w.r.t. volume.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn d2p_dv2(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.d2p_dv2(contributions))
+            }
+
+            /// Return second partial derivative of pressure w.r.t. density.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn d2p_drho2(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.d2p_drho2(contributions))
+            }
+
+            /// Return molar volume of each component.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn molar_volume(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.molar_volume(contributions))
+            }
+
+            /// Return chemical potential of each component.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn chemical_potential(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.chemical_potential(contributions))
+            }
+
+            /// Return chemical potential contributions.
+            ///
+            /// Parameters
+            /// ----------
+            /// component: int
+            ///     the component for which the contributions
+            ///     are calculated
+            ///
+            /// Returns
+            /// -------
+            /// List[Tuple[str, SINumber]]
+            #[pyo3(text_signature = "($self, component)")]
+            fn chemical_potential_contributions(&self, component: usize) -> Vec<(String, PySINumber)> {
+                self.0
+                    .chemical_potential_contributions(component)
+                    .into_iter()
+                    .map(|(s, q)| (s, PySINumber::from(q)))
+                    .collect()
+            }
+
+            /// Return derivative of chemical potential w.r.t temperature.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dmu_dt(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.dmu_dt(contributions))
+            }
+
+            /// Return derivative of chemical potential w.r.t amount of substance.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray2
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dmu_dni(&self, contributions: Contributions) -> PySIArray2 {
+                PySIArray2::from(self.0.dmu_dni(contributions))
+            }
+
+            /// Return logarithmic fugacity coefficient.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray
+            #[pyo3(text_signature = "($self)")]
+            fn ln_phi<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
+                self.0.ln_phi().view().to_pyarray(py)
+            }
+
+            /// Return logarithmic pure substance fugacity coefficient.
+            ///
+            /// For each component, the hypothetical liquid fugacity coefficient
+            /// at mixture temperature and pressure is computed.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray
+            #[pyo3(text_signature = "($self)")]
+            fn ln_phi_pure<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self.0.ln_phi_pure()?.view().to_pyarray(py))
+            }
+
+            /// Return logarithmic symmetric activity coefficient.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray
+            #[pyo3(text_signature = "($self)")]
+            fn ln_symmetric_activity_coefficient<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self.0.ln_symmetric_activity_coefficient()?.view().to_pyarray(py))
+            }
+
+            /// Return derivative of logarithmic fugacity coefficient w.r.t. temperature.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[pyo3(text_signature = "($self)")]
+            fn dln_phi_dt(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.dln_phi_dt())
+            }
+
+            /// Return derivative of logarithmic fugacity coefficient w.r.t. pressure.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[pyo3(text_signature = "($self)")]
+            fn dln_phi_dp(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.dln_phi_dp())
+            }
+
+            /// Return derivative of logarithmic fugacity coefficient w.r.t. amount of substance.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray2
+            #[pyo3(text_signature = "($self)")]
+            fn dln_phi_dnj(&self) -> PySIArray2 {
+                PySIArray2::from(self.0.dln_phi_dnj())
+            }
+
+            /// Return thermodynamic factor.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray
+            #[pyo3(text_signature = "($self)")]
+            fn thermodynamic_factor<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
+                self.0.thermodynamic_factor().view().to_pyarray(py)
+            }
+
+            /// Return isochoric heat capacity.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn c_v(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.c_v(contributions))
+            }
+
+            /// Return derivative of isochoric heat capacity w.r.t. temperature.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn dc_v_dt(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.dc_v_dt(contributions))
+            }
+
+            /// Return isobaric heat capacity.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn c_p(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.c_p(contributions))
+            }
+
+	        /// Return entropy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn entropy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.entropy(contributions))
+            }
+
+            /// Return derivative of entropy with respect to temperature.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn ds_dt(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.ds_dt(contributions))
+            }
+
+            /// Return molar entropy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn molar_entropy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.molar_entropy(contributions))
+            }
+
+
+            /// Return partial molar entropy of each component.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn partial_molar_entropy(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.partial_molar_entropy(contributions))
+            }
+
+            /// Return enthalpy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn enthalpy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.enthalpy(contributions))
+            }
+
+            /// Return molar enthalpy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn molar_enthalpy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.molar_enthalpy(contributions))
+            }
+
+
+            /// Return partial molar enthalpy of each component.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn partial_molar_enthalpy(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.partial_molar_enthalpy(contributions))
+            }
+
+            /// Return helmholtz_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn helmholtz_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.helmholtz_energy(contributions))
+            }
+
+            /// Return molar helmholtz_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn molar_helmholtz_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.molar_helmholtz_energy(contributions))
+            }
+
+            /// Return helmholtz energy contributions.
+            ///
+            /// Returns
+            /// -------
+            /// List[Tuple[str, SINumber]]
+            #[pyo3(text_signature = "($self)")]
+            fn helmholtz_energy_contributions(&self) -> Vec<(String, PySINumber)> {
+                self.0
+                    .helmholtz_energy_contributions()
+                    .into_iter()
+                    .map(|(s, q)| (s, PySINumber::from(q)))
+                    .collect()
+            }
+
+            /// Return gibbs_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn gibbs_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.gibbs_energy(contributions))
+            }
+
+            /// Return molar gibbs_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn molar_gibbs_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.molar_gibbs_energy(contributions))
+            }
+
+
+            /// Return internal_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn internal_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.internal_energy(contributions))
+            }
+
+            /// Return molar internal_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn molar_internal_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.molar_internal_energy(contributions))
+            }
+
+            /// Return Joule Thomson coefficient.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn joule_thomson(&self) -> PySINumber {
+                PySINumber::from(self.0.joule_thomson())
+            }
+
+            /// Return isentropy compressibility coefficient.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn isentropic_compressibility(&self) -> PySINumber {
+                PySINumber::from(self.0.isentropic_compressibility())
+            }
+
+            /// Return isothermal compressibility coefficient.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn isothermal_compressibility(&self) -> PySINumber {
+                PySINumber::from(self.0.isothermal_compressibility())
+            }
+
+            /// Return structure factor.
+            ///
+            /// Returns
+            /// -------
+            /// float
+            #[pyo3(text_signature = "($self)")]
+            fn structure_factor(&self) -> f64 {
+                self.0.structure_factor()
+            }
+
+            #[getter]
+            fn get_total_moles(&self) -> PySINumber {
+                PySINumber::from(self.0.total_moles)
+            }
+
+            #[getter]
+            fn get_temperature(&self) -> PySINumber {
+                PySINumber::from(self.0.temperature)
+            }
+
+            #[getter]
+            fn get_volume(&self) -> PySINumber {
+                PySINumber::from(self.0.volume)
+            }
+
+            #[getter]
+            fn get_density(&self) -> PySINumber {
+                PySINumber::from(self.0.density)
+            }
+
+            #[getter]
+            fn get_moles(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.moles.clone())
+            }
+
+            #[getter]
+            fn get_partial_density(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.partial_density.clone())
+            }
+
+            #[getter]
+            fn get_molefracs<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
+                self.0.molefracs.view().to_pyarray(py)
+            }
+
+            fn _repr_markdown_(&self) -> String {
+                if self.0.eos.components() == 1 {
+                    format!(
+                        "|temperature|density|\n|-|-|\n|{:.5}|{:.5}|",
+                        self.0.temperature, self.0.density
+                    )
+                } else {
+                    format!(
+                        "|temperature|density|molefracs\n|-|-|-|\n|{:.5}|{:.5}|{:.5}|",
+                        self.0.temperature, self.0.density, self.0.molefracs
+                    )
+                }
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+
+        #[pyclass(name = "StateVec", unsendable)]
+        pub struct PyStateVec(Vec<State<SIUnit, $eos>>);
+
+        impl From<StateVec<'_, SIUnit, $eos>> for PyStateVec {
+            fn from(vec: StateVec<SIUnit, $eos>) -> Self {
+                Self(vec.into_iter().map(|s| s.clone()).collect())
+            }
+        }
+
+        impl<'a> From<&'a PyStateVec> for StateVec<'a, SIUnit, $eos> {
+            fn from(vec: &'a PyStateVec) -> Self {
+                Self(vec.0.iter().collect())
+            }
+        }
+
+        #[pymethods]
+        impl PyStateVec {
+            fn __len__(&self) -> PyResult<usize> {
+                Ok(self.0.len())
+            }
+
+            fn __getitem__(&self, idx: isize) -> PyResult<PyState> {
+                let i = if idx < 0 {
+                    self.0.len() as isize + idx
+                } else {
+                    idx
+                };
+                if (0..self.0.len()).contains(&(i as usize)) {
+                    Ok(PyState(self.0[i as usize].clone()))
+                } else {
+                    Err(PyIndexError::new_err(format!("StateVec index out of range")))
+                }
+            }
+        }
+
+        #[pymethods]
+        impl PyStateVec {
+            #[getter]
+            fn get_temperature(&self) -> PySIArray1{
+                StateVec::from(self).temperature().into()
+            }
+
+            #[getter]
+            fn get_pressure(&self) -> PySIArray1 {
+                StateVec::from(self).pressure().into()
+            }
+
+            #[getter]
+            fn get_compressibility<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
+                StateVec::from(self).compressibility().view().to_pyarray(py)
+            }
+
+            #[getter]
+            fn get_density(&self) -> PySIArray1 {
+                StateVec::from(self).density().into()
+            }
+
+            #[getter]
+            fn get_molefracs<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
+                StateVec::from(self).molefracs().view().to_pyarray(py)
+            }
+
+            #[getter]
+            fn get_molar_enthalpy(&self) -> PySIArray1 {
+                StateVec::from(self).molar_enthalpy().into()
+            }
+
+            #[getter]
+            fn get_molar_entropy(&self) -> PySIArray1 {
+                StateVec::from(self).molar_entropy().into()
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_state_molarweight {
+    ($eos:ty, $py_eos:ty) => {
+        #[pymethods]
+        impl PyState {
+            /// Return total molar weight.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn total_molar_weight(&self) -> PySINumber {
+                PySINumber::from(self.0.total_molar_weight())
+            }
+
+            /// Return speed of sound.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn speed_of_sound(&self) -> PySINumber {
+                PySINumber::from(self.0.speed_of_sound())
+            }
+
+            /// Returns mass of each component in the system.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[pyo3(text_signature = "($self)")]
+            fn mass(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.mass())
+            }
+
+            /// Returns system's total mass.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn total_mass(&self) -> PySINumber {
+                PySINumber::from(self.0.total_mass())
+            }
+
+            /// Returns system's mass density.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn mass_density(&self) -> PySINumber {
+                PySINumber::from(self.0.mass_density())
+            }
+
+            /// Returns mass fractions for each component.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray[Float64]
+            #[pyo3(text_signature = "($self)")]
+            fn massfracs<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
+                self.0.massfracs().view().to_pyarray(py)
+            }
+
+            /// Return mass specific helmholtz_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn specific_helmholtz_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.specific_helmholtz_energy(contributions))
+            }
+
+            /// Return mass specific entropy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn specific_entropy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.specific_entropy(contributions))
+            }
+
+            /// Return mass specific internal_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn specific_internal_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.specific_internal_energy(contributions))
+            }
+
+            /// Return mass specific gibbs_energy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn specific_gibbs_energy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.specific_gibbs_energy(contributions))
+            }
+
+            /// Return mass specific enthalpy.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn specific_enthalpy(&self, contributions: Contributions) -> PySINumber {
+                PySINumber::from(self.0.specific_enthalpy(contributions))
+            }
+        }
+
+        #[pymethods]
+        impl PyStateVec {
+            #[getter]
+            fn get_mass_density(&self) -> PySIArray1 {
+                StateVec::from(self).mass_density().into()
+            }
+
+            #[getter]
+            fn get_massfracs<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
+                StateVec::from(self).massfracs().view().to_pyarray(py)
+            }
+
+            #[getter]
+            fn get_specific_enthalpy(&self) -> PySIArray1 {
+                StateVec::from(self).specific_enthalpy().into()
+            }
+
+            #[getter]
+            fn get_specific_entropy(&self) -> PySIArray1 {
+                StateVec::from(self).specific_entropy().into()
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_state_entropy_scaling {
+    ($eos:ty, $py_eos:ty) => {
+        #[pymethods]
+        impl PyState {
+            /// Return viscosity via entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn viscosity(&self) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(self.0.viscosity()?))
+            }
+
+            /// Return reference viscosity for entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn viscosity_reference(&self) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(self.0.viscosity_reference()?))
+            }
+
+            /// Return logarithmic reduced viscosity.
+            ///
+            /// This equals the viscosity correlation function
+            /// as used by entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// float
+            #[pyo3(text_signature = "($self)")]
+            fn ln_viscosity_reduced(&self) -> PyResult<f64> {
+                Ok(self.0.ln_viscosity_reduced()?)
+            }
+
+            /// Return diffusion coefficient via entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn diffusion(&self) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(self.0.diffusion()?))
+            }
+
+            /// Return reference diffusion for entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn diffusion_reference(&self) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(self.0.diffusion_reference()?))
+            }
+
+            /// Return logarithmic reduced diffusion.
+            ///
+            /// This equals the diffusion correlation function
+            /// as used by entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// float
+            #[pyo3(text_signature = "($self)")]
+            fn ln_diffusion_reduced(&self) -> PyResult<f64> {
+                Ok(self.0.ln_diffusion_reduced()?)
+            }
+
+            /// Return thermal conductivity via entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn thermal_conductivity(&self) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(self.0.thermal_conductivity()?))
+            }
+
+            /// Return reference thermal conductivity for entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[pyo3(text_signature = "($self)")]
+            fn thermal_conductivity_reference(&self) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(self.0.thermal_conductivity_reference()?))
+            }
+
+            /// Return logarithmic reduced thermal conductivity.
+            ///
+            /// This equals the thermal conductivity correlation function
+            /// as used by entropy scaling.
+            ///
+            /// Returns
+            /// -------
+            /// float
+            #[pyo3(text_signature = "($self)")]
+            fn ln_thermal_conductivity_reduced(&self) -> PyResult<f64> {
+                Ok(self.0.ln_thermal_conductivity_reduced()?)
+            }
+        }
+    };
+}

--- a/feos-core/src/python/statehd.rs
+++ b/feos-core/src/python/statehd.rs
@@ -1,0 +1,176 @@
+use crate::StateHD;
+use ndarray::Array1;
+use num_dual::python::{PyDual3Dual64, PyDual3_64, PyDual64, PyHyperDual64, PyHyperDualDual64};
+use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualVec64, HyperDual, HyperDual64};
+use pyo3::prelude::*;
+use std::convert::From;
+
+#[pyclass(name = "StateF")]
+#[derive(Clone)]
+pub struct PyStateF(StateHD<f64>);
+
+impl From<StateHD<f64>> for PyStateF {
+    fn from(s: StateHD<f64>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateHD")]
+#[derive(Clone)]
+pub struct PyStateHD(StateHD<HyperDual64>);
+
+impl From<StateHD<HyperDual64>> for PyStateHD {
+    fn from(s: StateHD<HyperDual64>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateHDD")]
+#[derive(Clone)]
+pub struct PyStateHDD(StateHD<HyperDual<Dual64, f64>>);
+
+impl From<StateHD<HyperDual<Dual64, f64>>> for PyStateHDD {
+    fn from(s: StateHD<HyperDual<Dual64, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateHDDV2")]
+#[derive(Clone)]
+pub struct PyStateHDDV2(StateHD<HyperDual<DualVec64<2>, f64>>);
+
+impl From<StateHD<HyperDual<DualVec64<2>, f64>>> for PyStateHDDV2 {
+    fn from(s: StateHD<HyperDual<DualVec64<2>, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateHDDV3")]
+#[derive(Clone)]
+pub struct PyStateHDDV3(StateHD<HyperDual<DualVec64<3>, f64>>);
+
+impl From<StateHD<HyperDual<DualVec64<3>, f64>>> for PyStateHDDV3 {
+    fn from(s: StateHD<HyperDual<DualVec64<3>, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateD")]
+#[derive(Clone)]
+pub struct PyStateD(StateHD<Dual64>);
+
+impl From<StateHD<Dual64>> for PyStateD {
+    fn from(s: StateHD<Dual64>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateDDV3")]
+#[derive(Clone)]
+pub struct PyStateDDV3(StateHD<Dual<DualVec64<3>, f64>>);
+
+impl From<StateHD<Dual<DualVec64<3>, f64>>> for PyStateDDV3 {
+    fn from(s: StateHD<Dual<DualVec64<3>, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateD3")]
+#[derive(Clone)]
+pub struct PyStateD3(StateHD<Dual3_64>);
+
+impl From<StateHD<Dual3_64>> for PyStateD3 {
+    fn from(s: StateHD<Dual3_64>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateD3D")]
+#[derive(Clone)]
+pub struct PyStateD3D(StateHD<Dual3<Dual64, f64>>);
+
+impl From<StateHD<Dual3<Dual64, f64>>> for PyStateD3D {
+    fn from(s: StateHD<Dual3<Dual64, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateD3DV2")]
+#[derive(Clone)]
+pub struct PyStateD3DV2(StateHD<Dual3<DualVec64<2>, f64>>);
+
+impl From<StateHD<Dual3<DualVec64<2>, f64>>> for PyStateD3DV2 {
+    fn from(s: StateHD<Dual3<DualVec64<2>, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateD3DV3")]
+#[derive(Clone)]
+pub struct PyStateD3DV3(StateHD<Dual3<DualVec64<3>, f64>>);
+
+impl From<StateHD<Dual3<DualVec64<3>, f64>>> for PyStateD3DV3 {
+    fn from(s: StateHD<Dual3<DualVec64<3>, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+macro_rules! impl_state_hd {
+    ($pystate:ty, $pyhd:ty, $state:ty, $hd:ty) => {
+        #[pymethods]
+        impl $pystate {
+            #[new]
+            pub fn new(temperature: $pyhd, volume: $pyhd, moles: Vec<$pyhd>) -> Self {
+                let m = Array1::from(moles).mapv(<$hd>::from);
+                Self(<$state>::new(temperature.into(), volume.into(), m))
+            }
+
+            #[getter]
+            pub fn get_temperature(&self) -> $pyhd {
+                <$pyhd>::from(self.0.temperature)
+            }
+
+            #[getter]
+            pub fn get_volume(&self) -> $pyhd {
+                <$pyhd>::from(self.0.volume)
+            }
+
+            #[getter]
+            pub fn get_moles(&self) -> Vec<$pyhd> {
+                self.0.moles.mapv(<$pyhd>::from).into_raw_vec()
+            }
+
+            #[getter]
+            pub fn get_partial_density(&self) -> Vec<$pyhd> {
+                self.0.partial_density.mapv(<$pyhd>::from).into_raw_vec()
+            }
+
+            #[getter]
+            pub fn get_molefracs(&self) -> Vec<$pyhd> {
+                self.0.molefracs.mapv(<$pyhd>::from).into_raw_vec()
+            }
+
+            #[getter]
+            pub fn get_density(&self) -> $pyhd {
+                <$pyhd>::from(self.0.partial_density.sum())
+            }
+        }
+    };
+}
+
+impl_state_hd!(PyStateF, f64, StateHD<f64>, f64);
+impl_state_hd!(PyStateHD, PyHyperDual64, StateHD<HyperDual64>, HyperDual64);
+impl_state_hd!(
+    PyStateHDD,
+    PyHyperDualDual64,
+    StateHD<HyperDual<Dual64, f64>>,
+    HyperDual<Dual64, f64>
+);
+impl_state_hd!(PyStateD, PyDual64, StateHD<Dual64>, Dual64);
+impl_state_hd!(PyStateD3, PyDual3_64, StateHD<Dual3_64>, Dual3_64);
+impl_state_hd!(
+    PyStateD3D,
+    PyDual3Dual64,
+    StateHD<Dual3<Dual64, f64>>,
+    Dual3<Dual64, f64>
+);

--- a/feos-core/src/python/user_defined.rs
+++ b/feos-core/src/python/user_defined.rs
@@ -1,0 +1,222 @@
+use crate::python::statehd::*;
+use crate::*;
+use ndarray::prelude::*;
+use num_dual::python::{PyDual3Dual64, PyDual3_64, PyDual64, PyHyperDual64, PyHyperDualDual64};
+use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualVec64, HyperDual, HyperDual64};
+use numpy::convert::IntoPyArray;
+use pyo3::prelude::*;
+use quantity::python::PySIArray1;
+use std::fmt;
+
+struct PyHelmholtzEnergy(Py<PyAny>);
+
+pub struct PyEoSObj {
+    obj: Py<PyAny>,
+    contributions: Vec<Box<dyn HelmholtzEnergy>>,
+}
+
+impl PyEoSObj {
+    pub fn new(obj: Py<PyAny>) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            let attr = obj.as_ref(py).hasattr("components")?;
+            if !attr {
+                panic!("Python Class has to have a method 'components' with signature:\n\tdef signature(self) -> int")
+            }
+            let attr = obj.as_ref(py).hasattr("subset")?;
+            if !attr {
+                panic!("Python Class has to have a method 'subset' with signature:\n\tdef subset(self, component_list: List[int]) -> Self")
+            }
+            let attr = obj.as_ref(py).hasattr("molar_weight")?;
+            if !attr {
+                panic!("Python Class has to have a method 'molar_weight' with signature:\n\tdef molar_weight(self) -> SIArray1\nwhere the size of the returned array has to be 'components'.")
+            }
+            let attr = obj.as_ref(py).hasattr("max_density")?;
+            if !attr {
+                panic!("Python Class has to have a method 'max_density' with signature:\n\tdef max_density(self, moles: numpy.ndarray[float]) -> float\nwhere the size of the input array has to be 'components'.")
+            }
+            let attr = obj.as_ref(py).hasattr("helmholtz_energy")?;
+            if !attr {
+                panic!("{}", "Python Class has to have a method 'helmholtz_energy' with signature:\n\tdef helmholtz_energy(self, state: StateHD) -> HD\nwhere 'HD' has to be any of {{float, Dual64, HyperDual64, HyperDualDual64, Dual3Dual64, Dual3_64}}.")
+            }
+            Ok(Self {
+                obj: obj.clone(),
+                contributions: vec![Box::new(PyHelmholtzEnergy(obj))],
+            })
+        })
+    }
+}
+
+impl MolarWeight<SIUnit> for PyEoSObj {
+    fn molar_weight(&self) -> SIArray1 {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let py_result = self.obj.as_ref(py).call_method0("molar_weight").unwrap();
+        if py_result.get_type().name().unwrap() != "SIArray1" {
+            panic!(
+                "Expected an 'SIArray1' for the 'molar_weight' method return type, got {}",
+                py_result.get_type().name().unwrap()
+            );
+        }
+        py_result.extract::<PySIArray1>().unwrap().into()
+    }
+}
+
+impl EquationOfState for PyEoSObj {
+    fn components(&self) -> usize {
+        Python::with_gil(|py| {
+            let py_result = self.obj.as_ref(py).call_method0("components").unwrap();
+            if py_result.get_type().name().unwrap() != "int" {
+                panic!(
+                    "Expected an integer for the components() method signature, got {}",
+                    py_result.get_type().name().unwrap()
+                );
+            }
+            py_result.extract().unwrap()
+        })
+    }
+
+    fn subset(&self, component_list: &[usize]) -> Self {
+        Python::with_gil(|py| {
+            let py_result = self
+                .obj
+                .as_ref(py)
+                .call_method1("subset", (component_list.to_vec(),))
+                .unwrap();
+            Self::new(py_result.extract().unwrap()).unwrap()
+        })
+    }
+
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let py_result = self
+            .obj
+            .as_ref(py)
+            .call_method1("max_density", (moles.to_owned().into_pyarray(py),))
+            .unwrap();
+        // if py_result.get_type().name().unwrap() != "numpy.float64" {
+        //     panic!(
+        //         "Expected an 'numpy.float64' for the 'compute_max_density' method return type, got {}",
+        //         py_result.get_type().name().unwrap()
+        //     );
+        // }
+        py_result.extract().unwrap()
+    }
+
+    fn residual(&self) -> &[Box<dyn HelmholtzEnergy>] {
+        &self.contributions
+    }
+}
+
+macro_rules! impl_helmholtz_energy {
+    ($pystate:ty, $pyhd:ty, $hd:ty) => {
+        impl HelmholtzEnergyDual<$hd> for PyHelmholtzEnergy {
+            fn helmholtz_energy(&self, state: &StateHD<$hd>) -> $hd {
+                let gil = Python::acquire_gil();
+                let py = gil.python();
+                let py_result = self
+                    .0
+                    .as_ref(py)
+                    .call_method1("helmholtz_energy", (<$pystate>::from(state.clone()),))
+                    .unwrap();
+                // if py_result.get_type().name() != stringify!($hd) {
+                //     panic!(
+                //         "Expected an {} for the 'helmholtz_energy' method signature, got {}",
+                //         stringify!($hd),
+                //         py_result.get_type().name()
+                //     );
+                // }
+                <$hd>::from(py_result.extract::<$pyhd>().unwrap())
+            }
+
+            // fn identifier(&self) -> String {
+            //     let gil = Python::acquire_gil();
+            //     let py = gil.python();
+            //     let py_result = self.obj.as_ref(py).call_method0("identifier").unwrap();
+            //     if py_result.get_type().name() != "str" {
+            //         panic!(
+            //             "Expected an 'str' for the 'identifier' method signature, got {}",
+            //             py_result.get_type().name()
+            //         );
+            //     }
+            //     py_result.extract().unwrap()
+            // }
+        }
+    };
+}
+
+impl fmt::Display for PyHelmholtzEnergy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Custom")
+    }
+}
+
+#[pyclass(name = "DualDualVec64_2")]
+#[derive(Clone)]
+pub struct PyDualDualVec64_3(Dual<DualVec64<3>, f64>);
+
+impl From<PyDualDualVec64_3> for Dual<DualVec64<3>, f64> {
+    fn from(value: PyDualDualVec64_3) -> Self {
+        value.0
+    }
+}
+
+#[pyclass(name = "HyperDualDualVec64_2")]
+#[derive(Clone)]
+pub struct PyHyperDualDualVec64_2(HyperDual<DualVec64<2>, f64>);
+
+impl From<PyHyperDualDualVec64_2> for HyperDual<DualVec64<2>, f64> {
+    fn from(value: PyHyperDualDualVec64_2) -> Self {
+        value.0
+    }
+}
+
+#[pyclass(name = "HyperDualDualVec64_3")]
+#[derive(Clone)]
+pub struct PyHyperDualDualVec64_3(HyperDual<DualVec64<3>, f64>);
+
+impl From<PyHyperDualDualVec64_3> for HyperDual<DualVec64<3>, f64> {
+    fn from(value: PyHyperDualDualVec64_3) -> Self {
+        value.0
+    }
+}
+
+#[pyclass(name = "Dual3DualVec64_2")]
+#[derive(Clone)]
+pub struct PyDual3DualVec64_2(Dual3<DualVec64<2>, f64>);
+
+impl From<PyDual3DualVec64_2> for Dual3<DualVec64<2>, f64> {
+    fn from(value: PyDual3DualVec64_2) -> Self {
+        value.0
+    }
+}
+
+#[pyclass(name = "Dual3DualVec64_3")]
+#[derive(Clone)]
+pub struct PyDual3DualVec64_3(Dual3<DualVec64<3>, f64>);
+
+impl From<PyDual3DualVec64_3> for Dual3<DualVec64<3>, f64> {
+    fn from(value: PyDual3DualVec64_3) -> Self {
+        value.0
+    }
+}
+
+impl_helmholtz_energy!(PyStateD, PyDual64, Dual64);
+impl_helmholtz_energy!(PyStateDDV3, PyDualDualVec64_3, Dual<DualVec64<3>, f64>);
+impl_helmholtz_energy!(PyStateHD, PyHyperDual64, HyperDual64);
+impl_helmholtz_energy!(PyStateHDD, PyHyperDualDual64, HyperDual<Dual64, f64>);
+impl_helmholtz_energy!(
+    PyStateHDDV2,
+    PyHyperDualDualVec64_2,
+    HyperDual<DualVec64<2>, f64>
+);
+impl_helmholtz_energy!(
+    PyStateHDDV3,
+    PyHyperDualDualVec64_3,
+    HyperDual<DualVec64<3>, f64>
+);
+impl_helmholtz_energy!(PyStateD3, PyDual3_64, Dual3_64);
+impl_helmholtz_energy!(PyStateD3D, PyDual3Dual64, Dual3<Dual64, f64>);
+impl_helmholtz_energy!(PyStateD3DV2, PyDual3DualVec64_2, Dual3<DualVec64<2>, f64>);
+impl_helmholtz_energy!(PyStateD3DV3, PyDual3DualVec64_3, Dual3<DualVec64<3>, f64>);
+impl_helmholtz_energy!(PyStateF, f64, f64);

--- a/feos-core/src/state/builder.rs
+++ b/feos-core/src/state/builder.rs
@@ -1,0 +1,224 @@
+use super::{DensityInitialization, State};
+use crate::equation_of_state::EquationOfState;
+use crate::errors::EosResult;
+use crate::EosUnit;
+use ndarray::Array1;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::rc::Rc;
+
+/// A simple tool to construct [State]s with arbitrary input parameters.
+///
+/// # Examples
+/// ```
+/// # use feos_core::{EosResult, StateBuilder};
+/// # use feos_core::cubic::{PengRobinson, PengRobinsonParameters};
+/// # use quantity::si::*;
+/// # use std::rc::Rc;
+/// # use ndarray::arr1;
+/// # use approx::assert_relative_eq;
+/// # fn main() -> EosResult<()> {
+/// // Create a state for given T,V,N
+/// let eos = Rc::new(PengRobinson::new(Rc::new(PengRobinsonParameters::new_simple(&[369.8], &[41.9 * 1e5], &[0.15], &[15.0])?)));
+/// let state = StateBuilder::new(&eos)
+///                 .temperature(300.0 * KELVIN)
+///                 .volume(12.5 * METER.powi(3))
+///                 .moles(&(arr1(&[2.5]) * MOL))
+///                 .build()?;
+/// assert_eq!(state.density, 0.2 * MOL / METER.powi(3));
+///
+/// // For a pure component, the composition does not need to be specified.
+/// let eos = Rc::new(PengRobinson::new(Rc::new(PengRobinsonParameters::new_simple(&[369.8], &[41.9 * 1e5], &[0.15], &[15.0])?)));
+/// let state = StateBuilder::new(&eos)
+///                 .temperature(300.0 * KELVIN)
+///                 .volume(12.5 * METER.powi(3))
+///                 .total_moles(2.5 * MOL)
+///                 .build()?;
+/// assert_eq!(state.density, 0.2 * MOL / METER.powi(3));
+///
+/// // The state can be constructed without providing any extensive property.
+/// let eos = Rc::new(PengRobinson::new(
+///     Rc::new(PengRobinsonParameters::new_simple(
+///         &[369.8, 305.4],
+///         &[41.9 * 1e5, 48.2 * 1e5],
+///         &[0.15, 0.10],
+///         &[15.0, 30.0]
+///     )?)
+/// ));
+/// let state = StateBuilder::new(&eos)
+///                 .temperature(300.0 * KELVIN)
+///                 .partial_density(&(arr1(&[0.2, 0.6]) * MOL / METER.powi(3)))
+///                 .build()?;
+/// assert_relative_eq!(state.molefracs, arr1(&[0.25, 0.75]));
+/// assert_relative_eq!(state.density, 0.8 * MOL / METER.powi(3));
+/// # Ok(())
+/// # }
+/// ```
+pub struct StateBuilder<'a, U: EosUnit, E: EquationOfState> {
+    eos: Rc<E>,
+    temperature: Option<QuantityScalar<U>>,
+    volume: Option<QuantityScalar<U>>,
+    density: Option<QuantityScalar<U>>,
+    partial_density: Option<&'a QuantityArray1<U>>,
+    total_moles: Option<QuantityScalar<U>>,
+    moles: Option<&'a QuantityArray1<U>>,
+    molefracs: Option<&'a Array1<f64>>,
+    pressure: Option<QuantityScalar<U>>,
+    molar_enthalpy: Option<QuantityScalar<U>>,
+    molar_entropy: Option<QuantityScalar<U>>,
+    molar_internal_energy: Option<QuantityScalar<U>>,
+    density_initialization: DensityInitialization<U>,
+    initial_temperature: Option<QuantityScalar<U>>,
+}
+
+impl<'a, U: EosUnit, E: EquationOfState> StateBuilder<'a, U, E> {
+    /// Create a new `StateBuilder` for the given equation of state.
+    pub fn new(eos: &Rc<E>) -> Self {
+        StateBuilder {
+            eos: eos.clone(),
+            temperature: None,
+            volume: None,
+            density: None,
+            partial_density: None,
+            total_moles: None,
+            moles: None,
+            molefracs: None,
+            pressure: None,
+            molar_enthalpy: None,
+            molar_entropy: None,
+            molar_internal_energy: None,
+            density_initialization: DensityInitialization::None,
+            initial_temperature: None,
+        }
+    }
+
+    /// Provide the temperature for the new state.
+    pub fn temperature(mut self, temperature: QuantityScalar<U>) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    /// Provide the volume for the new state.
+    pub fn volume(mut self, volume: QuantityScalar<U>) -> Self {
+        self.volume = Some(volume);
+        self
+    }
+
+    /// Provide the density for the new state.
+    pub fn density(mut self, density: QuantityScalar<U>) -> Self {
+        self.density = Some(density);
+        self
+    }
+
+    /// Provide partial densities for the new state.
+    pub fn partial_density(mut self, partial_density: &'a QuantityArray1<U>) -> Self {
+        self.partial_density = Some(partial_density);
+        self
+    }
+
+    /// Provide the total moles for the new state.
+    pub fn total_moles(mut self, total_moles: QuantityScalar<U>) -> Self {
+        self.total_moles = Some(total_moles);
+        self
+    }
+
+    /// Provide the moles for the new state.
+    pub fn moles(mut self, moles: &'a QuantityArray1<U>) -> Self {
+        self.moles = Some(moles);
+        self
+    }
+
+    /// Provide the molefracs for the new state.
+    pub fn molefracs(mut self, molefracs: &'a Array1<f64>) -> Self {
+        self.molefracs = Some(molefracs);
+        self
+    }
+
+    /// Provide the pressure for the new state.
+    pub fn pressure(mut self, pressure: QuantityScalar<U>) -> Self {
+        self.pressure = Some(pressure);
+        self
+    }
+
+    /// Provide the molar enthalpy for the new state.
+    pub fn molar_enthalpy(mut self, molar_enthalpy: QuantityScalar<U>) -> Self {
+        self.molar_enthalpy = Some(molar_enthalpy);
+        self
+    }
+
+    /// Provide the molar entropy for the new state.
+    pub fn molar_entropy(mut self, molar_entropy: QuantityScalar<U>) -> Self {
+        self.molar_entropy = Some(molar_entropy);
+        self
+    }
+
+    /// Provide the molar internal energy for the new state.
+    pub fn molar_internal_energy(mut self, molar_internal_energy: QuantityScalar<U>) -> Self {
+        self.molar_internal_energy = Some(molar_internal_energy);
+        self
+    }
+
+    /// Specify a vapor state.
+    pub fn vapor(mut self) -> Self {
+        self.density_initialization = DensityInitialization::Vapor;
+        self
+    }
+
+    /// Specify a liquid state.
+    pub fn liquid(mut self) -> Self {
+        self.density_initialization = DensityInitialization::Liquid;
+        self
+    }
+
+    /// Provide an initial density used in density iterations.
+    pub fn initial_density(mut self, initial_density: QuantityScalar<U>) -> Self {
+        self.density_initialization = DensityInitialization::InitialDensity(initial_density);
+        self
+    }
+
+    /// Provide an initial temperature used in the Newton solver.
+    pub fn initial_temperature(mut self, initial_temperature: QuantityScalar<U>) -> Self {
+        self.initial_temperature = Some(initial_temperature);
+        self
+    }
+
+    /// Try to build the state with the given inputs.
+    pub fn build(self) -> EosResult<State<U, E>> {
+        State::new(
+            &self.eos,
+            self.temperature,
+            self.volume,
+            self.density,
+            self.partial_density,
+            self.total_moles,
+            self.moles,
+            self.molefracs,
+            self.pressure,
+            self.molar_enthalpy,
+            self.molar_entropy,
+            self.molar_internal_energy,
+            self.density_initialization,
+            self.initial_temperature,
+        )
+    }
+}
+
+impl<'a, U: EosUnit, E: EquationOfState> Clone for StateBuilder<'a, U, E> {
+    fn clone(&self) -> Self {
+        Self {
+            eos: self.eos.clone(),
+            temperature: self.temperature,
+            volume: self.volume,
+            density: self.density,
+            partial_density: self.partial_density,
+            total_moles: self.total_moles,
+            moles: self.moles,
+            molefracs: self.molefracs,
+            pressure: self.pressure,
+            molar_enthalpy: self.molar_enthalpy,
+            molar_entropy: self.molar_entropy,
+            molar_internal_energy: self.molar_internal_energy,
+            density_initialization: self.density_initialization,
+            initial_temperature: self.initial_temperature,
+        }
+    }
+}

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -1,0 +1,99 @@
+use super::{Derivative, PartialDerivative};
+use num_dual::*;
+use std::cmp::{max, min};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Cache {
+    pub map: HashMap<PartialDerivative, f64>,
+    pub hit: u64,
+    pub miss: u64,
+}
+
+impl Cache {
+    pub fn with_capacity(components: usize) -> Cache {
+        let capacity = 6 + 3 * components + components * (components + 1) / 2;
+        Cache {
+            map: HashMap::with_capacity(capacity),
+            hit: 0,
+            miss: 0,
+        }
+    }
+
+    pub fn get_or_insert_with_f64<F: FnOnce() -> f64>(&mut self, f: F) -> f64 {
+        if let Some(&value) = self.map.get(&PartialDerivative::Zeroth) {
+            self.hit += 1;
+            value
+        } else {
+            self.miss += 1;
+            let value = f();
+            self.map.insert(PartialDerivative::Zeroth, value);
+            value
+        }
+    }
+
+    pub fn get_or_insert_with_d64<F: FnOnce() -> Dual64>(
+        &mut self,
+        derivative: Derivative,
+        f: F,
+    ) -> f64 {
+        if let Some(&value) = self.map.get(&PartialDerivative::First(derivative)) {
+            self.hit += 1;
+            value
+        } else {
+            self.miss += 1;
+            let value = f();
+            self.map.insert(PartialDerivative::Zeroth, value.re);
+            self.map
+                .insert(PartialDerivative::First(derivative), value.eps[0]);
+            value.eps[0]
+        }
+    }
+
+    pub fn get_or_insert_with_hd64<F: FnOnce() -> HyperDual64>(
+        &mut self,
+        derivative1: Derivative,
+        derivative2: Derivative,
+        f: F,
+    ) -> f64 {
+        let d1 = min(derivative1, derivative2);
+        let d2 = max(derivative1, derivative2);
+        if let Some(&value) = self.map.get(&PartialDerivative::Second(d1, d2)) {
+            self.hit += 1;
+            value
+        } else {
+            self.miss += 1;
+            let value = f();
+            self.map.insert(PartialDerivative::Zeroth, value.re);
+            self.map
+                .insert(PartialDerivative::First(derivative1), value.eps1[0]);
+            self.map
+                .insert(PartialDerivative::First(derivative2), value.eps2[0]);
+            self.map
+                .insert(PartialDerivative::Second(d1, d2), value.eps1eps2[(0, 0)]);
+            value.eps1eps2[(0, 0)]
+        }
+    }
+
+    pub fn get_or_insert_with_hd364<F: FnOnce() -> Dual3_64>(
+        &mut self,
+        derivative: Derivative,
+        f: F,
+    ) -> f64 {
+        if let Some(&value) = self.map.get(&PartialDerivative::Third(derivative)) {
+            self.hit += 1;
+            value
+        } else {
+            self.miss += 1;
+            let value = f();
+            self.map.insert(PartialDerivative::Zeroth, value.re);
+            self.map
+                .insert(PartialDerivative::First(derivative), value.v1);
+            self.map
+                .insert(PartialDerivative::Second(derivative, derivative), value.v2);
+            self.map
+                .insert(PartialDerivative::Third(derivative), value.v3);
+            value.v3
+        }
+    }
+}

--- a/feos-core/src/state/critical_point.rs
+++ b/feos-core/src/state/critical_point.rs
@@ -1,0 +1,484 @@
+use super::{State, StateHD, TPSpec};
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::phase_equilibria::{SolverOptions, Verbosity};
+use crate::EosUnit;
+use ndarray::{arr1, arr2, Array1, Array2};
+use num_dual::linalg::{norm, smallest_ev, LU};
+use num_dual::{Dual, Dual3, Dual64, DualNum, DualVec64, HyperDual, StaticVec};
+use num_traits::{One, Zero};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::convert::TryFrom;
+use std::rc::Rc;
+
+const MAX_ITER_CRIT_POINT: usize = 50;
+const TOL_CRIT_POINT: f64 = 1e-8;
+
+/// # Critical points
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    /// Calculate the pure component critical point of all components.
+    pub fn critical_point_pure(
+        eos: &Rc<E>,
+        initial_temperature: Option<QuantityScalar<U>>,
+        options: SolverOptions,
+    ) -> EosResult<Vec<Self>>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        (0..eos.components())
+            .map(|i| {
+                Self::critical_point(
+                    &Rc::new(eos.subset(&[i])),
+                    None,
+                    initial_temperature,
+                    options,
+                )
+            })
+            .collect()
+    }
+
+    pub fn critical_point_binary(
+        eos: &Rc<E>,
+        temperature_or_pressure: QuantityScalar<U>,
+        initial_temperature: Option<QuantityScalar<U>>,
+        initial_molefracs: Option<[f64; 2]>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        match TPSpec::try_from(temperature_or_pressure)? {
+            TPSpec::Temperature(t) => {
+                Self::critical_point_binary_t(eos, t, initial_molefracs, options)
+            }
+            TPSpec::Pressure(p) => Self::critical_point_binary_p(
+                eos,
+                p,
+                initial_temperature,
+                initial_molefracs,
+                options,
+            ),
+        }
+    }
+
+    /// Calculate the critical point of a system for given moles.
+    pub fn critical_point(
+        eos: &Rc<E>,
+        moles: Option<&QuantityArray1<U>>,
+        initial_temperature: Option<QuantityScalar<U>>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        let moles = eos.validate_moles(moles)?;
+        let trial_temperatures = [
+            300.0 * U::reference_temperature(),
+            700.0 * U::reference_temperature(),
+            500.0 * U::reference_temperature(),
+        ];
+        if let Some(t) = initial_temperature {
+            return Self::critical_point_hkm(eos, &moles, t, options);
+        }
+        for &t in trial_temperatures.iter() {
+            let s = Self::critical_point_hkm(eos, &moles, t, options);
+            if s.is_ok() {
+                return s;
+            }
+        }
+        Err(EosError::NotConverged(String::from("Critical point")))
+    }
+
+    fn critical_point_hkm(
+        eos: &Rc<E>,
+        moles: &QuantityArray1<U>,
+        initial_temperature: QuantityScalar<U>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_CRIT_POINT, TOL_CRIT_POINT);
+
+        let mut t = initial_temperature.to_reduced(U::reference_temperature())?;
+        let max_density = eos
+            .max_density(Some(moles))?
+            .to_reduced(U::reference_density())?;
+        let mut rho = 0.3 * max_density;
+        let n = moles.to_reduced(U::reference_moles())?;
+
+        log_iter!(
+            verbosity,
+            " iter |    residual    |   temperature   |       density        "
+        );
+        log_iter!(verbosity, "{:-<64}", "");
+        log_iter!(
+            verbosity,
+            " {:4} |                | {:13.8} | {:12.8}",
+            0,
+            t * U::reference_temperature(),
+            rho * U::reference_density(),
+        );
+
+        for i in 1..=max_iter {
+            // calculate residuals and derivatives w.r.t. temperature and density
+            let res_t =
+                critical_point_objective(eos, Dual64::from(t).derive(), Dual64::from(rho), &n)?;
+            let res_r =
+                critical_point_objective(eos, Dual64::from(t), Dual64::from(rho).derive(), &n)?;
+            let res = res_t.map(Dual64::re);
+
+            // calculate Newton step
+            let h = arr2(&[
+                [res_t[0].eps[0], res_r[0].eps[0]],
+                [res_t[1].eps[0], res_r[1].eps[0]],
+            ]);
+            let mut delta = LU::new(h)?.solve(&res);
+
+            // reduce step if necessary
+            if delta[0].abs() > 0.25 * t {
+                delta *= 0.25 * t / delta[0].abs()
+            }
+            if delta[1].abs() > 0.03 * max_density {
+                delta *= 0.03 * max_density / delta[1].abs()
+            }
+
+            // apply step
+            t -= delta[0];
+            rho -= delta[1];
+            rho = f64::max(rho, 1e-4 * max_density);
+
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:13.8} | {:12.8}",
+                i,
+                norm(&res),
+                t * U::reference_temperature(),
+                rho * U::reference_density(),
+            );
+
+            // check convergence
+            if norm(&res) < tol {
+                log_result!(
+                    verbosity,
+                    "Critical point calculation converged in {} step(s)\n",
+                    i
+                );
+                return State::new_nvt(
+                    eos,
+                    t * U::reference_temperature(),
+                    moles.sum() / (rho * U::reference_density()),
+                    moles,
+                );
+            }
+        }
+        Err(EosError::NotConverged(String::from("Critical point")))
+    }
+
+    /// Calculate the critical point of a binary system for given temperature.
+    fn critical_point_binary_t(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        initial_molefracs: Option<[f64; 2]>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_CRIT_POINT, TOL_CRIT_POINT);
+
+        let t = temperature.to_reduced(U::reference_temperature())?;
+        let x = StaticVec::new_vec(initial_molefracs.unwrap_or([0.5, 0.5]));
+        let max_density = eos
+            .max_density(Some(&(arr1(x.raw_array()) * U::reference_moles())))?
+            .to_reduced(U::reference_density())?;
+        let mut rho = x * 0.3 * max_density;
+
+        log_iter!(
+            verbosity,
+            " iter |    residual    |      density 1       |      density 2       "
+        );
+        log_iter!(verbosity, "{:-<69}", "");
+        log_iter!(
+            verbosity,
+            " {:4} |                | {:12.8} | {:12.8}",
+            0,
+            rho[0] * U::reference_density(),
+            rho[1] * U::reference_density(),
+        );
+
+        for i in 1..=max_iter {
+            // calculate residuals and derivatives w.r.t. partial densities
+            let r = StaticVec::new_vec([DualVec64::from_re(rho[0]), DualVec64::from_re(rho[1])])
+                .derive();
+            let res = critical_point_objective_t(eos, t, r)?;
+
+            // calculate Newton step
+            let h = res.jacobian();
+            let res = res.map(|r| r.re);
+            let mut delta = StaticVec::new_vec([
+                h[(1, 1)] * res[0] - h[(0, 1)] * res[1],
+                h[(0, 0)] * res[1] - h[(1, 0)] * res[0],
+            ]) / (h[(0, 0)] * h[(1, 1)] - h[(0, 1)] * h[(1, 0)]);
+
+            // reduce step if necessary
+            for i in 0..2 {
+                if delta[i].abs() > 0.03 * max_density {
+                    delta *= 0.03 * max_density / delta[i].abs()
+                }
+            }
+
+            // apply step
+            rho -= delta;
+            rho[0] = f64::max(rho[0], 1e-4 * max_density);
+            rho[1] = f64::max(rho[1], 1e-4 * max_density);
+
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:12.8} | {:12.8}",
+                i,
+                res.norm(),
+                rho[0] * U::reference_density(),
+                rho[1] * U::reference_density(),
+            );
+
+            // check convergence
+            if res.norm() < tol {
+                log_result!(
+                    verbosity,
+                    "Critical point calculation converged in {} step(s)\n",
+                    i
+                );
+                return State::new_nvt(
+                    eos,
+                    t * U::reference_temperature(),
+                    U::reference_volume(),
+                    &(arr1(rho.raw_array()) * U::reference_moles()),
+                );
+            }
+        }
+        Err(EosError::NotConverged(String::from("Critical point")))
+    }
+
+    /// Calculate the critical point of a binary system for given pressure.
+    fn critical_point_binary_p(
+        eos: &Rc<E>,
+        pressure: QuantityScalar<U>,
+        initial_temperature: Option<QuantityScalar<U>>,
+        initial_molefracs: Option<[f64; 2]>,
+        options: SolverOptions,
+    ) -> EosResult<Self>
+    where
+        QuantityScalar<U>: std::fmt::Display,
+    {
+        let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_CRIT_POINT, TOL_CRIT_POINT);
+
+        let p = pressure.to_reduced(U::reference_pressure())?;
+        let mut t = initial_temperature
+            .map(|t| t.to_reduced(U::reference_temperature()))
+            .transpose()?
+            .unwrap_or(300.0);
+        let x = StaticVec::new_vec(initial_molefracs.unwrap_or([0.5, 0.5]));
+        let max_density = eos
+            .max_density(Some(&(arr1(x.raw_array()) * U::reference_moles())))?
+            .to_reduced(U::reference_density())?;
+        let mut rho = x * 0.3 * max_density;
+
+        log_iter!(
+            verbosity,
+            " iter |    residual    |   temperature   |      density 1       |      density 2       "
+        );
+        log_iter!(verbosity, "{:-<87}", "");
+        log_iter!(
+            verbosity,
+            " {:4} |                | {:13.8} | {:12.8} | {:12.8}",
+            0,
+            t * U::reference_temperature(),
+            rho[0] * U::reference_density(),
+            rho[1] * U::reference_density(),
+        );
+
+        for i in 1..=max_iter {
+            // calculate residuals and derivatives w.r.t. temperature and partial densities
+            let x = StaticVec::new_vec([
+                DualVec64::from_re(t),
+                DualVec64::from_re(rho[0]),
+                DualVec64::from_re(rho[1]),
+            ])
+            .derive();
+            let r = StaticVec::new_vec([x[1], x[2]]);
+            let res = critical_point_objective_p(eos, p, x[0], r)?;
+
+            // calculate Newton step
+            let h = arr2(res.jacobian().raw_data());
+            let res = arr1(res.map(|r| r.re).raw_array());
+            let mut delta = LU::new(h)?.solve(&res);
+
+            // reduce step if necessary
+            if delta[0].abs() > 0.25 * t {
+                delta *= 0.25 * t / delta[0].abs()
+            }
+            if delta[1].abs() > 0.03 * max_density {
+                delta *= 0.03 * max_density / delta[1].abs()
+            }
+            if delta[2].abs() > 0.03 * max_density {
+                delta *= 0.03 * max_density / delta[2].abs()
+            }
+
+            // apply step
+            t -= delta[0];
+            rho[0] -= delta[1];
+            rho[1] -= delta[2];
+            rho[0] = f64::max(rho[0], 1e-4 * max_density);
+            rho[1] = f64::max(rho[1], 1e-4 * max_density);
+
+            log_iter!(
+                verbosity,
+                " {:4} | {:14.8e} | {:13.8} | {:12.8} | {:12.8}",
+                i,
+                norm(&res),
+                t * U::reference_temperature(),
+                rho[0] * U::reference_density(),
+                rho[1] * U::reference_density(),
+            );
+
+            // check convergence
+            if norm(&res) < tol {
+                log_result!(
+                    verbosity,
+                    "Critical point calculation converged in {} step(s)\n",
+                    i
+                );
+                return State::new_nvt(
+                    eos,
+                    t * U::reference_temperature(),
+                    U::reference_volume(),
+                    &(arr1(rho.raw_array()) * U::reference_moles()),
+                );
+            }
+        }
+        Err(EosError::NotConverged(String::from("Critical point")))
+    }
+}
+
+pub fn critical_point_objective<E: EquationOfState>(
+    eos: &Rc<E>,
+    temperature: Dual64,
+    density: Dual64,
+    moles: &Array1<f64>,
+) -> EosResult<Array1<Dual64>> {
+    // calculate second partial derivatives w.r.t. moles
+    let t = HyperDual::from_re(temperature);
+    let v = HyperDual::from_re(density.recip() * moles.sum());
+    let qij = Array2::from_shape_fn((eos.components(), eos.components()), |(i, j)| {
+        let mut m = moles.mapv(HyperDual::from);
+        m[i].eps1[0] = Dual64::one();
+        m[j].eps2[0] = Dual64::one();
+        let state = StateHD::new(t, v, m);
+        (eos.evaluate_residual(&state).eps1eps2[(0, 0)]
+            + eos.ideal_gas().evaluate(&state).eps1eps2[(0, 0)])
+            * (moles[i] * moles[j]).sqrt()
+    });
+
+    // calculate smallest eigenvalue and corresponding eigenvector of q
+    let (eval, evec) = smallest_ev(qij);
+
+    // evaluate third partial derivative w.r.t. s
+    let moles_hd = Array1::from_shape_fn(eos.components(), |i| {
+        Dual3::new(
+            Dual64::from(moles[i]),
+            evec[i] * moles[i].sqrt(),
+            Dual64::zero(),
+            Dual64::zero(),
+        )
+    });
+    let state_s = StateHD::new(
+        Dual3::from_re(temperature),
+        Dual3::from_re(density.recip() * moles.sum()),
+        moles_hd,
+    );
+    let res = eos.evaluate_residual(&state_s) + eos.ideal_gas().evaluate(&state_s);
+    Ok(arr1(&[eval, res.v3]))
+}
+
+fn critical_point_objective_t<E: EquationOfState>(
+    eos: &Rc<E>,
+    temperature: f64,
+    density: StaticVec<DualVec64<2>, 2>,
+) -> EosResult<StaticVec<DualVec64<2>, 2>> {
+    // calculate second partial derivatives w.r.t. moles
+    let t = HyperDual::from(temperature);
+    let v = HyperDual::from(1.0);
+    let qij = Array2::from_shape_fn((eos.components(), eos.components()), |(i, j)| {
+        let mut m = density.map(HyperDual::from_re);
+        m[i].eps1[0] = DualVec64::one();
+        m[j].eps2[0] = DualVec64::one();
+        let state = StateHD::new(t, v, arr1(&[m[0], m[1]]));
+        (eos.evaluate_residual(&state).eps1eps2[(0, 0)]
+            + eos.ideal_gas().evaluate(&state).eps1eps2[(0, 0)])
+            * (density[i] * density[j]).sqrt()
+    });
+
+    // calculate smallest eigenvalue and corresponding eigenvector of q
+    let (eval, evec) = smallest_ev(qij);
+
+    // evaluate third partial derivative w.r.t. s
+    let moles_hd = Array1::from_shape_fn(eos.components(), |i| {
+        Dual3::new(
+            density[i],
+            evec[i] * density[i].sqrt(),
+            DualVec64::zero(),
+            DualVec64::zero(),
+        )
+    });
+    let state_s = StateHD::new(Dual3::from(temperature), Dual3::from(1.0), moles_hd);
+    let res = eos.evaluate_residual(&state_s) + eos.ideal_gas().evaluate(&state_s);
+    Ok(StaticVec::new_vec([eval, res.v3]))
+}
+
+fn critical_point_objective_p<E: EquationOfState>(
+    eos: &Rc<E>,
+    pressure: f64,
+    temperature: DualVec64<3>,
+    density: StaticVec<DualVec64<3>, 2>,
+) -> EosResult<StaticVec<DualVec64<3>, 3>> {
+    // calculate second partial derivatives w.r.t. moles
+    let t = HyperDual::from_re(temperature);
+    let v = HyperDual::from(1.0);
+    let qij = Array2::from_shape_fn((eos.components(), eos.components()), |(i, j)| {
+        let mut m = density.map(HyperDual::from_re);
+        m[i].eps1[0] = DualVec64::one();
+        m[j].eps2[0] = DualVec64::one();
+        let state = StateHD::new(t, v, arr1(&[m[0], m[1]]));
+        (eos.evaluate_residual(&state).eps1eps2[(0, 0)]
+            + eos.ideal_gas().evaluate(&state).eps1eps2[(0, 0)])
+            * (density[i] * density[j]).sqrt()
+    });
+
+    // calculate smallest eigenvalue and corresponding eigenvector of q
+    let (eval, evec) = smallest_ev(qij);
+
+    // evaluate third partial derivative w.r.t. s
+    let moles_hd = Array1::from_shape_fn(eos.components(), |i| {
+        Dual3::new(
+            density[i],
+            evec[i] * density[i].sqrt(),
+            DualVec64::zero(),
+            DualVec64::zero(),
+        )
+    });
+    let state_s = StateHD::new(Dual3::from_re(temperature), Dual3::from(1.0), moles_hd);
+    let res = eos.evaluate_residual(&state_s) + eos.ideal_gas().evaluate(&state_s);
+
+    // calculate pressure
+    let v = Dual::from(1.0).derive();
+    let m = arr1(&[Dual::from_re(density[0]), Dual::from_re(density[1])]);
+    let state_p = StateHD::new(Dual::from_re(temperature), v, m);
+    let p = eos.evaluate_residual(&state_p) + eos.ideal_gas().evaluate(&state_p);
+
+    Ok(StaticVec::new_vec([
+        eval,
+        res.v3,
+        p.eps[0] * temperature + pressure,
+    ]))
+}

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -1,0 +1,868 @@
+//! Description of a thermodynamic state.
+//!
+//! A thermodynamic state in SAFT is defined by
+//! * a temperature
+//! * an array of mole numbers
+//! * the volume
+//!
+//! Internally, all properties are computed using such states as input.
+use crate::density_iteration::density_iteration;
+use crate::equation_of_state::EquationOfState;
+use crate::errors::{EosError, EosResult};
+use crate::EosUnit;
+use cache::Cache;
+use ndarray::prelude::*;
+use num_dual::linalg::{norm, LU};
+use num_dual::*;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::cell::RefCell;
+use std::convert::TryFrom;
+use std::fmt;
+use std::rc::Rc;
+
+mod builder;
+mod cache;
+mod properties;
+pub use builder::StateBuilder;
+pub use properties::{Contributions, StateVec};
+
+/// Initial values in a density iteration.
+#[derive(Clone, Copy)]
+pub enum DensityInitialization<U: EosUnit> {
+    /// Calculate a vapor phase by initializing using the ideal gas.
+    Vapor,
+    /// Calculate a liquid phase by using the `max_density`.
+    Liquid,
+    /// Use the given density as initial value.
+    InitialDensity(QuantityScalar<U>),
+    /// Calculate the most stable phase by calculating both a vapor and a liquid
+    /// and return the one with the lower molar Gibbs energy.
+    None,
+}
+
+/// Thermodynamic state of the system in reduced variables
+/// including their derivatives.
+///
+/// Properties are stored as generalized (hyper) dual numbers which allows
+/// for automatic differentiation.
+#[derive(Clone, Debug)]
+pub struct StateHD<D: DualNum<f64>> {
+    /// temperature in Kelvin
+    pub temperature: D,
+    /// volume in Angstrom^3
+    pub volume: D,
+    /// number of particles
+    pub moles: Array1<D>,
+    /// mole fractions
+    pub molefracs: Array1<D>,
+    /// partial number densities in Angstrom^-3
+    pub partial_density: Array1<D>,
+}
+
+impl<D: DualNum<f64>> StateHD<D> {
+    /// Create a new `StateHD` for given temperature volume and moles.
+    pub fn new(temperature: D, volume: D, moles: Array1<D>) -> Self {
+        let total_moles = moles.sum();
+        let partial_density = moles.mapv(|n| n / volume);
+        let molefracs = moles.mapv(|n| n / total_moles);
+
+        Self {
+            temperature,
+            volume,
+            moles,
+            molefracs,
+            partial_density,
+        }
+    }
+
+    // Since the molefracs can not be reproduced from moles if the density is zero,
+    // this constructor exists specifically for these cases.
+    pub(crate) fn new_virial(temperature: D, density: D, molefracs: Array1<f64>) -> Self {
+        let volume = D::one();
+        let partial_density = molefracs.mapv(|x| density * x);
+        let moles = partial_density.mapv(|pd| pd * volume);
+        let molefracs = molefracs.mapv(D::from);
+        Self {
+            temperature,
+            volume,
+            moles,
+            molefracs,
+            partial_density,
+        }
+    }
+}
+
+/// Thermodynamic state of the system.
+///
+/// The state is always specified by the variables of the Helmholtz energy: volume $V$,
+/// temperature $T$ and mole numbers $N_i$. Additional to these variables, the state saves
+/// properties like the density, that can be calculated directly from the basic variables.
+/// The state also contains a reference to the equation of state used to create the state.
+/// Therefore, it can be used directly to calculate all state properties.
+///
+/// Calculated partial derivatives are cached in the state. Therefore, the second evaluation
+/// of a property like the pressure, does not require a recalculation of the equation of state.
+/// This can be used in situations where both lower and higher order derivatives are required, as
+/// in a calculation of a derivative all lower derivatives have to be calculated internally as well.
+/// Since they are cached it is more efficient to calculate the highest derivatives first.
+/// For example during the calculation of the isochoric heat capacity $c_v$, the entropy and the
+/// Helmholtz energy are calculated as well.
+///
+/// `State` objects are meant to be immutable. If individual fields like `volume` are changed, the
+/// calculations are wrong as the internal fields of the state are not updated.
+///
+/// ## Contents
+///
+/// + [State properties](#state-properties)
+/// + [Mass specific state properties](#mass-specific-state-properties)
+/// + [Transport properties](#transport-properties)
+/// + [Critical points](#critical-points)
+/// + [State constructors](#state-constructors)
+/// + [Stability analysis](#stability-analysis)
+/// + [Flash calculations](#flash-calculations)
+#[derive(Debug)]
+pub struct State<U, E> {
+    /// Equation of state
+    pub eos: Rc<E>,
+    /// Temperature $T$
+    pub temperature: QuantityScalar<U>,
+    /// Volume $V$
+    pub volume: QuantityScalar<U>,
+    /// Mole numbers $N_i$
+    pub moles: QuantityArray1<U>,
+    /// Total number of moles $N=\sum_iN_i$
+    pub total_moles: QuantityScalar<U>,
+    /// Partial densities $\rho_i=\frac{N_i}{V}$
+    pub partial_density: QuantityArray1<U>,
+    /// Total density $\rho=\frac{N}{V}=\sum_i\rho_i$
+    pub density: QuantityScalar<U>,
+    /// Mole fractions $x_i=\frac{N_i}{N}=\frac{\rho_i}{\rho}$
+    pub molefracs: Array1<f64>,
+    /// Reduced temperature
+    reduced_temperature: f64,
+    /// Reduced volume,
+    reduced_volume: f64,
+    /// Reduced moles
+    reduced_moles: Array1<f64>,
+    /// Cache
+    cache: RefCell<Cache>,
+}
+
+impl<U: Clone, E> Clone for State<U, E> {
+    fn clone(&self) -> Self {
+        Self {
+            eos: self.eos.clone(),
+            total_moles: self.total_moles.clone(),
+            temperature: self.temperature.clone(),
+            volume: self.volume.clone(),
+            moles: self.moles.clone(),
+            partial_density: self.partial_density.clone(),
+            density: self.density.clone(),
+            molefracs: self.molefracs.clone(),
+            reduced_temperature: self.reduced_temperature,
+            reduced_volume: self.reduced_volume,
+            reduced_moles: self.reduced_moles.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+impl<U, E> fmt::Display for State<U, E>
+where
+    QuantityScalar<U>: fmt::Display,
+    QuantityArray1<U>: fmt::Display,
+    E: EquationOfState,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.eos.components() == 1 {
+            write!(f, "T = {:.5}, ρ = {:.5}", self.temperature, self.density)
+        } else {
+            write!(
+                f,
+                "T = {:.5}, ρ = {:.5}, x = {:.5}",
+                self.temperature, self.density, self.molefracs
+            )
+        }
+    }
+}
+
+/// Derivatives of the helmholtz energy.
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Debug, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub(crate) enum Derivative {
+    /// Derivative with respect to system volume.
+    DV,
+    /// Derivative with respect to temperature.
+    DT,
+    /// Derivative with respect to component `i`.
+    DN(usize),
+}
+
+impl Derivative {
+    pub fn reference<U: EosUnit>(&self) -> QuantityScalar<U> {
+        match self {
+            Derivative::DV => U::reference_volume(),
+            Derivative::DT => U::reference_temperature(),
+            Derivative::DN(_) => U::reference_moles(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Debug)]
+pub(crate) enum PartialDerivative {
+    Zeroth,
+    First(Derivative),
+    Second(Derivative, Derivative),
+    Third(Derivative),
+}
+
+/// # State constructors
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    /// Return a new `State` given a temperature, an array of mole numbers and a volume.
+    ///
+    /// This function will perform a validation of the given properties, i.e. test for signs
+    /// and if values are finite. It will **not** validate physics, i.e. if the resulting
+    /// densities are below the maximum packing fraction.
+    pub fn new_nvt(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        volume: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+    ) -> EosResult<Self> {
+        eos.validate_moles(Some(moles))?;
+        validate(temperature, volume, moles)?;
+
+        let t = temperature.to_reduced(U::reference_temperature())?;
+        let v = volume.to_reduced(U::reference_volume())?;
+        let m = moles.to_reduced(U::reference_moles())?;
+
+        let total_moles = moles.sum();
+        let partial_density = moles / volume;
+        let density = total_moles / volume;
+        let molefracs = &m / total_moles.to_reduced(U::reference_moles())?;
+
+        Ok(State {
+            eos: eos.clone(),
+            total_moles,
+            temperature,
+            volume,
+            moles: moles.to_owned(),
+            partial_density,
+            density,
+            molefracs,
+            reduced_temperature: t,
+            reduced_volume: v,
+            reduced_moles: m,
+            cache: RefCell::new(Cache::with_capacity(eos.components())),
+        })
+    }
+
+    /// Return a new `State` for a pure component given a temperature and a density. The moles
+    /// are set to the reference value for each component.
+    ///
+    /// This function will perform a validation of the given properties, i.e. test for signs
+    /// and if values are finite. It will **not** validate physics, i.e. if the resulting
+    /// densities are below the maximum packing fraction.
+    pub fn new_pure(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        density: QuantityScalar<U>,
+    ) -> EosResult<Self> {
+        let moles = arr1(&[1.0]) * U::reference_moles();
+        Self::new_nvt(eos, temperature, U::reference_moles() / density, &moles)
+    }
+
+    /// Return a new `State` for the combination of inputs.
+    ///
+    /// The function attempts to create a new state using the given input values. If the state
+    /// is overdetermined, it will choose a method based on the following hierarchy.
+    /// 1. Create a state non-iteratively from the set of $T$, $V$, $\rho$, $\rho_i$, $N$, $N_i$ and $x_i$.
+    /// 2. Use a density iteration for a given pressure.
+    /// 3. Determine the state using a Newton iteration from (in this order): $(p, h)$, $(p, s)$, $(T, h)$, $(T, s)$, $(V, u)$
+    ///
+    /// The [StateBuilder] provides a convenient way of calling this function without the need to provide
+    /// all the optional input values.
+    ///
+    /// # Errors
+    ///
+    /// When the state cannot be created using the combination of inputs.
+    pub fn new(
+        eos: &Rc<E>,
+        temperature: Option<QuantityScalar<U>>,
+        volume: Option<QuantityScalar<U>>,
+        density: Option<QuantityScalar<U>>,
+        partial_density: Option<&QuantityArray1<U>>,
+        total_moles: Option<QuantityScalar<U>>,
+        moles: Option<&QuantityArray1<U>>,
+        molefracs: Option<&Array1<f64>>,
+        pressure: Option<QuantityScalar<U>>,
+        molar_enthalpy: Option<QuantityScalar<U>>,
+        molar_entropy: Option<QuantityScalar<U>>,
+        molar_internal_energy: Option<QuantityScalar<U>>,
+        density_initialization: DensityInitialization<U>,
+        initial_temperature: Option<QuantityScalar<U>>,
+    ) -> EosResult<Self> {
+        // Check if the provided densities have correct units.
+        if let DensityInitialization::InitialDensity(rho0) = density_initialization {
+            if !rho0.has_unit(&U::reference_density()) {
+                return Err(EosError::UndeterminedState(String::from(
+                    "The provided initial density has to be the molar density",
+                )));
+            }
+        }
+        if let Some(rho) = density {
+            if !rho.has_unit(&U::reference_density()) {
+                return Err(EosError::UndeterminedState(String::from(
+                    "The provided density has to be the molar density",
+                )));
+            }
+        }
+        if let Some(rho) = partial_density {
+            if !rho.has_unit(&U::reference_density()) {
+                return Err(EosError::UndeterminedState(String::from(
+                    "The provided partial density has to be the molar density",
+                )));
+            }
+        }
+
+        // check for density
+        if density.and(partial_density).is_some() {
+            return Err(EosError::UndeterminedState(String::from(
+                "Both density and partial density given.",
+            )));
+        }
+        let rho = density.or_else(|| partial_density.map(|pd| pd.sum()));
+
+        // check for total moles
+        if moles.and(total_moles).is_some() {
+            return Err(EosError::UndeterminedState(String::from(
+                "Both moles and total moles given.",
+            )));
+        }
+        let mut n = total_moles.or_else(|| moles.map(|m| m.sum()));
+
+        // check if total moles can be inferred from volume
+        if rho.and(n).and(volume).is_some() {
+            return Err(EosError::UndeterminedState(String::from(
+                "Density is overdetermined.",
+            )));
+        }
+        n = n.or_else(|| rho.and_then(|d| volume.map(|v| v * d)));
+
+        // check for composition
+        if partial_density.and(moles).is_some() {
+            return Err(EosError::UndeterminedState(String::from(
+                "Composition is overdetermined.",
+            )));
+        }
+        let x = partial_density
+            .map(|pd| pd.to_reduced(pd.sum()))
+            .or_else(|| moles.map(|ms| ms.to_reduced(ms.sum())))
+            .transpose()?;
+        let x_u = match (x, molefracs, eos.components()) {
+            (Some(_), Some(_), _) => {
+                return Err(EosError::UndeterminedState(String::from(
+                    "Composition is overdetermined.",
+                )))
+            }
+            (Some(x), None, _) => x,
+            (None, Some(x), _) => x.clone(),
+            (None, None, 1) => arr1(&[1.0]),
+            _ => {
+                return Err(EosError::UndeterminedState(String::from(
+                    "Missing composition.",
+                )))
+            }
+        };
+
+        // If no extensive property is given, moles is set to the reference value.
+        if let (None, None) = (volume, n) {
+            n = Some(U::reference_moles())
+        }
+        let n_i = n.map(|n| &x_u * n);
+        let v = volume.or_else(|| rho.and_then(|d| n.map(|n| n / d)));
+
+        // check if new state can be created using default constructor
+        if let (Some(v), Some(t), Some(n_i)) = (v, temperature, &n_i) {
+            return State::new_nvt(eos, t, v, n_i);
+        }
+
+        // Check if new state can be created using density iteration
+        if let (Some(p), Some(t), Some(n_i)) = (pressure, temperature, &n_i) {
+            return State::new_npt(eos, t, p, n_i, density_initialization);
+        }
+        if let (Some(p), Some(t), Some(v)) = (pressure, temperature, v) {
+            return State::new_npvx(eos, t, p, v, &x_u, density_initialization);
+        }
+
+        // Check if new state can be created using molar_enthalpy and temperature
+        if let (Some(p), Some(h), Some(n_i)) = (pressure, molar_enthalpy, &n_i) {
+            return State::new_nph(eos, p, h, n_i, density_initialization, initial_temperature);
+        }
+        if let (Some(p), Some(s), Some(n_i)) = (pressure, molar_entropy, &n_i) {
+            return State::new_nps(eos, p, s, n_i, density_initialization, initial_temperature);
+        }
+        if let (Some(t), Some(h), Some(n_i)) = (temperature, molar_enthalpy, &n_i) {
+            return State::new_nth(eos, t, h, n_i, density_initialization);
+        }
+        if let (Some(t), Some(s), Some(n_i)) = (temperature, molar_entropy, &n_i) {
+            return State::new_nts(eos, t, s, n_i, density_initialization);
+        }
+        if let (Some(u), Some(v), Some(n_i)) = (molar_internal_energy, volume, &n_i) {
+            return State::new_nvu(eos, v, u, n_i, initial_temperature);
+        }
+        Err(EosError::UndeterminedState(String::from(
+            "Missing input parameters.",
+        )))
+    }
+
+    /// Return a new `State` using a density iteration. [DensityInitialization] is used to
+    /// influence the calculation with respect to the possible solutions.
+    pub fn new_npt(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        pressure: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+        density_initialization: DensityInitialization<U>,
+    ) -> EosResult<Self> {
+        // calculate state from initial density or given phase
+        match density_initialization {
+            DensityInitialization::InitialDensity(rho0) => {
+                return density_iteration(eos, temperature, pressure, moles, rho0)
+            }
+            DensityInitialization::Vapor => {
+                return density_iteration(
+                    eos,
+                    temperature,
+                    pressure,
+                    moles,
+                    pressure / temperature / U::gas_constant(),
+                )
+            }
+            DensityInitialization::Liquid => {
+                return density_iteration(
+                    eos,
+                    temperature,
+                    pressure,
+                    moles,
+                    eos.max_density(Some(moles))?,
+                )
+            }
+            DensityInitialization::None => (),
+        }
+
+        // calculate stable phase
+        let max_density = eos.max_density(Some(moles))?;
+        let liquid = density_iteration(eos, temperature, pressure, moles, max_density);
+
+        if pressure < max_density * temperature * U::gas_constant() {
+            let vapor = density_iteration(
+                eos,
+                temperature,
+                pressure,
+                moles,
+                pressure / temperature / U::gas_constant(),
+            );
+            match (&liquid, &vapor) {
+                (Ok(_), Err(_)) => liquid,
+                (Err(_), Ok(_)) => vapor,
+                (Ok(l), Ok(v)) => {
+                    if l.molar_gibbs_energy(Contributions::Total)
+                        > v.molar_gibbs_energy(Contributions::Total)
+                    {
+                        vapor
+                    } else {
+                        liquid
+                    }
+                }
+                _ => Err(EosError::UndeterminedState(String::from(
+                    "Density iteration did not find a solution.",
+                ))),
+            }
+        } else {
+            liquid
+        }
+    }
+
+    /// Return a new `State` for given pressure $p$, volume $V$, temperature $T$ and composition $x_i$.
+    pub fn new_npvx(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        pressure: QuantityScalar<U>,
+        volume: QuantityScalar<U>,
+        molefracs: &Array1<f64>,
+        density_initialization: DensityInitialization<U>,
+    ) -> EosResult<Self> {
+        let moles = molefracs * U::reference_moles();
+        let state = Self::new_npt(eos, temperature, pressure, &moles, density_initialization)?;
+        let moles = state.partial_density * volume;
+        Self::new_nvt(eos, temperature, volume, &moles)
+    }
+
+    /// Return a new `State` for given pressure $p$ and molar enthalpy $h$.
+    pub fn new_nph(
+        eos: &Rc<E>,
+        pressure: QuantityScalar<U>,
+        molar_enthalpy: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+        density_initialization: DensityInitialization<U>,
+        initial_temperature: Option<QuantityScalar<U>>,
+    ) -> EosResult<Self> {
+        let t0 = initial_temperature.unwrap_or(298.15 * U::reference_temperature());
+        let mut density = density_initialization;
+        let f = |x0| {
+            let s = State::new_npt(eos, x0, pressure, moles, density)?;
+            let dfx = s.c_p(Contributions::Total);
+            let fx = s.molar_enthalpy(Contributions::Total) - molar_enthalpy;
+            density = DensityInitialization::InitialDensity(s.density);
+            Ok((fx, dfx, s))
+        };
+        newton(t0, f, 1.0e-8 * U::reference_temperature())
+    }
+
+    /// Return a new `State` for given temperature $T$ and molar enthalpy $h$.
+    pub fn new_nth(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        molar_enthalpy: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+        density_initialization: DensityInitialization<U>,
+    ) -> EosResult<Self> {
+        let rho0 = match density_initialization {
+            DensityInitialization::InitialDensity(r) => r,
+            DensityInitialization::Liquid => eos.max_density(Some(moles))?,
+            DensityInitialization::Vapor => 1.0e-5 * eos.max_density(Some(moles))?,
+            DensityInitialization::None => 0.01 * eos.max_density(Some(moles))?,
+        };
+        let n_inv = 1.0 / moles.sum();
+        let f = |x0| {
+            let s = State::new_nvt(eos, temperature, moles.sum() / x0, moles)?;
+            let dfx = -s.volume / s.density
+                * n_inv
+                * (s.volume * s.dp_dv(Contributions::Total)
+                    + temperature * s.dp_dt(Contributions::Total));
+            let fx = s.molar_enthalpy(Contributions::Total) - molar_enthalpy;
+            Ok((fx, dfx, s))
+        };
+        newton(rho0, f, 1.0e-12 * U::reference_density())
+    }
+
+    /// Return a new `State` for given temperature $T$ and molar entropy $s$.
+    pub fn new_nts(
+        eos: &Rc<E>,
+        temperature: QuantityScalar<U>,
+        molar_entropy: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+        density_initialization: DensityInitialization<U>,
+    ) -> EosResult<Self> {
+        let rho0 = match density_initialization {
+            DensityInitialization::InitialDensity(r) => r,
+            DensityInitialization::Liquid => eos.max_density(Some(moles))?,
+            DensityInitialization::Vapor => 1.0e-5 * eos.max_density(Some(moles))?,
+            DensityInitialization::None => 0.01 * eos.max_density(Some(moles))?,
+        };
+        let n_inv = 1.0 / moles.sum();
+        let f = |x0| {
+            let s = State::new_nvt(eos, temperature, moles.sum() / x0, moles)?;
+            let dfx = -n_inv * s.volume / s.density * s.dp_dt(Contributions::Total);
+            let fx = s.molar_entropy(Contributions::Total) - molar_entropy;
+            Ok((fx, dfx, s))
+        };
+        newton(rho0, f, 1.0e-12 * U::reference_density())
+    }
+
+    /// Return a new `State` for given pressure $p$ and molar entropy $s$.
+    pub fn new_nps(
+        eos: &Rc<E>,
+        pressure: QuantityScalar<U>,
+        molar_entropy: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+        density_initialization: DensityInitialization<U>,
+        initial_temperature: Option<QuantityScalar<U>>,
+    ) -> EosResult<Self> {
+        let t0 = initial_temperature.unwrap_or(298.15 * U::reference_temperature());
+        let mut density = density_initialization;
+        let f = |x0| {
+            let s = State::new_npt(eos, x0, pressure, moles, density)?;
+            let dfx = s.c_p(Contributions::Total) / s.temperature;
+            let fx = s.molar_entropy(Contributions::Total) - molar_entropy;
+            density = DensityInitialization::InitialDensity(s.density);
+            Ok((fx, dfx, s))
+        };
+        newton(t0, f, 1.0e-8 * U::reference_temperature())
+    }
+
+    /// Return a new `State` for given volume $V$ and molar internal energy $u$.
+    pub fn new_nvu(
+        eos: &Rc<E>,
+        volume: QuantityScalar<U>,
+        molar_internal_energy: QuantityScalar<U>,
+        moles: &QuantityArray1<U>,
+        initial_temperature: Option<QuantityScalar<U>>,
+    ) -> EosResult<Self> {
+        let t0 = initial_temperature.unwrap_or(298.15 * U::reference_temperature());
+        let f = |x0| {
+            let s = State::new_nvt(eos, x0, volume, moles)?;
+            let fx = s.molar_internal_energy(Contributions::Total) - molar_internal_energy;
+            let dfx = s.c_v(Contributions::Total);
+            Ok((fx, dfx, s))
+        };
+        newton(t0, f, 1.0e-8 * U::reference_temperature())
+    }
+
+    /// Update the state with the given temperature
+    pub fn update_temperature(&self, temperature: QuantityScalar<U>) -> EosResult<Self> {
+        Self::new_nvt(&self.eos, temperature, self.volume, &self.moles)
+    }
+
+    /// Update the state with the given chemical potential.
+    pub fn update_chemical_potential(
+        &mut self,
+        chemical_potential: &QuantityArray1<U>,
+    ) -> EosResult<()> {
+        for _ in 0..50 {
+            let dmu_drho = self.dmu_dni(Contributions::Total) * self.volume;
+            let f = self.chemical_potential(Contributions::Total) - chemical_potential;
+            let dmu_drho_r =
+                dmu_drho.to_reduced(U::reference_molar_energy() / U::reference_density())?;
+            let f_r = f.to_reduced(U::reference_molar_energy())?;
+            let rho = &self.partial_density
+                - &(LU::new(dmu_drho_r)?.solve(&f_r) * U::reference_density());
+            *self = State::new_nvt(
+                &self.eos,
+                self.temperature,
+                self.volume,
+                &(rho * self.volume),
+            )?;
+            if norm(&f.to_reduced(U::reference_molar_energy())?) < 1e-8 {
+                return Ok(());
+            }
+        }
+        Err(EosError::NotConverged(
+            "State::update_chemical_potential".into(),
+        ))
+    }
+
+    /// Update the state with the given molar Gibbs energy.
+    pub fn update_gibbs_energy(mut self, molar_gibbs_energy: QuantityScalar<U>) -> EosResult<Self> {
+        for _ in 0..50 {
+            let df = self.volume / self.density * self.dp_dv(Contributions::Total);
+            let f = self.molar_gibbs_energy(Contributions::Total) - molar_gibbs_energy;
+            let rho = self.density * (f.to_reduced(df)?).exp();
+            self = State::new_nvt(
+                &self.eos,
+                self.temperature,
+                self.total_moles / rho,
+                &self.moles,
+            )?;
+            if f.to_reduced(U::reference_molar_energy())?.abs() < 1e-8 {
+                return Ok(self);
+            }
+        }
+        Err(EosError::NotConverged("State::update_gibbs_energy".into()))
+    }
+
+    fn derive0(&self) -> StateHD<f64> {
+        StateHD::new(
+            self.reduced_temperature,
+            self.reduced_volume,
+            self.reduced_moles.clone(),
+        )
+    }
+
+    fn derive1(&self, derivative: Derivative) -> StateHD<Dual64> {
+        let mut t = Dual64::from(self.reduced_temperature);
+        let mut v = Dual64::from(self.reduced_volume);
+        let mut n = self.reduced_moles.mapv(Dual64::from);
+        match derivative {
+            Derivative::DT => t.eps[0] = 1.0,
+            Derivative::DV => v.eps[0] = 1.0,
+            Derivative::DN(i) => n[i].eps[0] = 1.0,
+        }
+        StateHD::new(t, v, n)
+    }
+
+    fn derive2(&self, derivative1: Derivative, derivative2: Derivative) -> StateHD<HyperDual64> {
+        let mut t = HyperDual64::from(self.reduced_temperature);
+        let mut v = HyperDual64::from(self.reduced_volume);
+        let mut n = self.reduced_moles.mapv(HyperDual64::from);
+        match derivative1 {
+            Derivative::DT => t.eps1[0] = 1.0,
+            Derivative::DV => v.eps1[0] = 1.0,
+            Derivative::DN(i) => n[i].eps1[0] = 1.0,
+        }
+        match derivative2 {
+            Derivative::DT => t.eps2[0] = 1.0,
+            Derivative::DV => v.eps2[0] = 1.0,
+            Derivative::DN(i) => n[i].eps2[0] = 1.0,
+        }
+        StateHD::new(t, v, n)
+    }
+
+    fn derive3(&self, derivative: Derivative) -> StateHD<Dual3_64> {
+        let mut t = Dual3_64::from(self.reduced_temperature);
+        let mut v = Dual3_64::from(self.reduced_volume);
+        let mut n = self.reduced_moles.mapv(Dual3_64::from);
+        match derivative {
+            Derivative::DT => t = t.derive(),
+            Derivative::DV => v = v.derive(),
+            Derivative::DN(i) => n[i] = n[i].derive(),
+        };
+        StateHD::new(t, v, n)
+    }
+}
+
+fn is_close<U: EosUnit>(
+    x: QuantityScalar<U>,
+    y: QuantityScalar<U>,
+    atol: QuantityScalar<U>,
+    rtol: f64,
+) -> bool {
+    (x - y).abs() <= atol + rtol * y.abs()
+}
+
+fn newton<U: EosUnit, E: EquationOfState, F>(
+    mut x0: QuantityScalar<U>,
+    mut f: F,
+    atol: QuantityScalar<U>,
+) -> EosResult<State<U, E>>
+where
+    F: FnMut(QuantityScalar<U>) -> EosResult<(QuantityScalar<U>, QuantityScalar<U>, State<U, E>)>,
+{
+    let rtol = 1e-10;
+    let maxiter = 50;
+
+    for _ in 0..maxiter {
+        let (fx, dfx, state) = f(x0)?;
+        let x = x0 - fx / dfx;
+        if is_close(x, x0, atol, rtol) {
+            return Ok(state);
+        }
+        x0 = x;
+    }
+    Err(EosError::NotConverged("newton".to_owned()))
+}
+
+/// Validate the given temperature, mole numbers and volume.
+///
+/// Properties are valid if
+/// * they are finite
+/// * they have a positive sign
+///
+/// There is no validation of the physical state, e.g.
+/// if resulting densities are below maximum packing fraction.
+fn validate<U: EosUnit>(
+    temperature: QuantityScalar<U>,
+    volume: QuantityScalar<U>,
+    moles: &QuantityArray1<U>,
+) -> EosResult<()> {
+    let t = temperature.to_reduced(U::reference_temperature())?;
+    let v = volume.to_reduced(U::reference_volume())?;
+    let m = moles.to_reduced(U::reference_moles())?;
+    if !t.is_finite() || t.is_sign_negative() {
+        return Err(EosError::InvalidState(
+            String::from("validate"),
+            String::from("temperature"),
+            t,
+        ));
+    }
+    if !v.is_finite() || v.is_sign_negative() {
+        return Err(EosError::InvalidState(
+            String::from("validate"),
+            String::from("volume"),
+            v,
+        ));
+    }
+    for &n in m.iter() {
+        if !n.is_finite() || n.is_sign_negative() {
+            return Err(EosError::InvalidState(
+                String::from("validate"),
+                String::from("moles"),
+                n,
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+pub enum TPSpec<U> {
+    Temperature(QuantityScalar<U>),
+    Pressure(QuantityScalar<U>),
+}
+
+impl<U: EosUnit> TryFrom<QuantityScalar<U>> for TPSpec<U>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    type Error = EosError;
+    fn try_from(quantity: QuantityScalar<U>) -> EosResult<Self> {
+        if quantity.has_unit(&U::reference_temperature()) {
+            Ok(Self::Temperature(quantity))
+        } else if quantity.has_unit(&U::reference_pressure()) {
+            Ok(Self::Pressure(quantity))
+        } else {
+            Err(EosError::WrongUnits(
+                "temperature or pressure".into(),
+                format!("{}", quantity),
+            ))
+        }
+    }
+}
+
+mod critical_point;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quantity::si::*;
+    use std::f64::NAN;
+
+    #[test]
+    fn test_validate() {
+        let temperature = 298.15 * KELVIN;
+        let volume = 3000.0 * METER.powi(3);
+        let moles = arr1(&[0.03, 0.02, 0.05]) * MOL;
+        assert!(validate(temperature, volume, &moles).is_ok());
+    }
+
+    #[test]
+    fn test_negative_temperature() {
+        let temperature = -298.15 * KELVIN;
+        let volume = 3000.0 * METER.powi(3);
+        let moles = arr1(&[0.03, 0.02, 0.05]) * MOL;
+        assert!(validate(temperature, volume, &moles).is_err());
+    }
+
+    #[test]
+    fn test_nan_temperature() {
+        let temperature = NAN * KELVIN;
+        let volume = 3000.0 * METER.powi(3);
+        let moles = arr1(&[0.03, 0.02, 0.05]) * MOL;
+        assert!(validate(temperature, volume, &moles).is_err());
+    }
+
+    #[test]
+    fn test_negative_mole_number() {
+        let temperature = 298.15 * KELVIN;
+        let volume = 3000.0 * METER.powi(3);
+        let moles = arr1(&[-0.03, 0.02, 0.05]) * MOL;
+        assert!(validate(temperature, volume, &moles).is_err());
+    }
+
+    #[test]
+    fn test_nan_mole_number() {
+        let temperature = 298.15 * KELVIN;
+        let volume = 3000.0 * METER.powi(3);
+        let moles = arr1(&[NAN, 0.02, 0.05]) * MOL;
+        assert!(validate(temperature, volume, &moles).is_err());
+    }
+
+    #[test]
+    fn test_negative_volume() {
+        let temperature = 298.15 * KELVIN;
+        let volume = -3000.0 * METER.powi(3);
+        let moles = arr1(&[0.01, 0.02, 0.05]) * MOL;
+        assert!(validate(temperature, volume, &moles).is_err());
+    }
+}

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -1,0 +1,825 @@
+use super::{Derivative::*, PartialDerivative, State};
+use crate::equation_of_state::{EntropyScaling, EquationOfState, MolarWeight};
+use crate::errors::EosResult;
+use crate::EosUnit;
+use ndarray::{arr1, Array1, Array2};
+use num_dual::DualNum;
+use quantity::{QuantityArray, QuantityArray1, QuantityArray2, QuantityScalar};
+use std::iter::FromIterator;
+use std::ops::{Add, Deref, Sub};
+use std::rc::Rc;
+
+#[derive(Clone, Copy)]
+pub(crate) enum Evaluate {
+    IdealGas,
+    Residual,
+    Total,
+    IdealGasDelta,
+}
+
+/// Possible contributions that can be computed.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub enum Contributions {
+    /// Only compute the ideal gas contribution
+    IdealGas,
+    /// Only compute the difference between the total and the ideal gas contribution
+    ResidualNvt,
+    /// Compute the differnce between the total and the ideal gas contribution for a (N,p,T) reference state
+    ResidualNpt,
+    /// Compute ideal gas and residual contributions
+    Total,
+}
+
+/// # State properties
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    fn get_or_compute_derivative(
+        &self,
+        derivative: PartialDerivative,
+        evaluate: Evaluate,
+    ) -> QuantityScalar<U> {
+        if let Evaluate::IdealGasDelta = evaluate {
+            return match derivative {
+                PartialDerivative::Zeroth => {
+                    let new_state = self.derive0();
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
+                        * U::reference_energy()
+                }
+                PartialDerivative::First(v) => {
+                    let new_state = self.derive1(v);
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln()).eps[0]
+                        * (U::reference_energy() / v.reference())
+                }
+                PartialDerivative::Second(v1, v2) => {
+                    let new_state = self.derive2(v1, v2);
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
+                        .eps1eps2[(0, 0)]
+                        * (U::reference_energy() / (v1.reference() * v2.reference()))
+                }
+                PartialDerivative::Third(v) => {
+                    let new_state = self.derive3(v);
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln()).v3
+                        * (U::reference_energy() / (v.reference() * v.reference() * v.reference()))
+                }
+            };
+        }
+
+        let mut cache = self.cache.borrow_mut();
+
+        let residual = match evaluate {
+            Evaluate::IdealGas => None,
+            _ => Some(match derivative {
+                PartialDerivative::Zeroth => {
+                    let new_state = self.derive0();
+                    let computation =
+                        || self.eos.evaluate_residual(&new_state) * new_state.temperature;
+                    cache.get_or_insert_with_f64(&computation) * U::reference_energy()
+                }
+                PartialDerivative::First(v) => {
+                    let new_state = self.derive1(v);
+                    let computation =
+                        || self.eos.evaluate_residual(&new_state) * new_state.temperature;
+                    cache.get_or_insert_with_d64(v, &computation) * U::reference_energy()
+                        / v.reference()
+                }
+                PartialDerivative::Second(v1, v2) => {
+                    let new_state = self.derive2(v1, v2);
+                    let computation =
+                        || self.eos.evaluate_residual(&new_state) * new_state.temperature;
+                    cache.get_or_insert_with_hd64(v1, v2, &computation) * U::reference_energy()
+                        / (v1.reference() * v2.reference())
+                }
+                PartialDerivative::Third(v) => {
+                    let new_state = self.derive3(v);
+                    let computation =
+                        || self.eos.evaluate_residual(&new_state) * new_state.temperature;
+                    cache.get_or_insert_with_hd364(v, &computation) * U::reference_energy()
+                        / (v.reference() * v.reference() * v.reference())
+                }
+            }),
+        };
+
+        let ideal_gas = match evaluate {
+            Evaluate::Residual => None,
+            _ => Some(match derivative {
+                PartialDerivative::Zeroth => {
+                    let new_state = self.derive0();
+                    self.eos.ideal_gas().evaluate(&new_state)
+                        * U::reference_energy()
+                        * new_state.temperature
+                }
+                PartialDerivative::First(v) => {
+                    let new_state = self.derive1(v);
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).eps[0]
+                        * U::reference_energy()
+                        / v.reference()
+                }
+                PartialDerivative::Second(v1, v2) => {
+                    let new_state = self.derive2(v1, v2);
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).eps1eps2
+                        [(0, 0)]
+                        * U::reference_energy()
+                        / (v1.reference() * v2.reference())
+                }
+                PartialDerivative::Third(v) => {
+                    let new_state = self.derive3(v);
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).v3
+                        * U::reference_energy()
+                        / (v.reference() * v.reference() * v.reference())
+                }
+            }),
+        };
+
+        match (ideal_gas, residual) {
+            (Some(i), Some(r)) => i + r,
+            (Some(i), None) => i,
+            (None, Some(r)) => r,
+            (None, None) => unreachable!(),
+        }
+    }
+
+    fn evaluate_property<R, F>(&self, f: F, contributions: Contributions, additive: bool) -> R
+    where
+        R: Add<Output = R> + Sub<Output = R>,
+        F: Fn(&Self, Evaluate) -> R,
+    {
+        match contributions {
+            Contributions::IdealGas => f(self, Evaluate::IdealGas),
+            Contributions::Total => f(self, Evaluate::Total),
+            Contributions::ResidualNvt => {
+                if additive {
+                    f(self, Evaluate::Residual)
+                } else {
+                    f(self, Evaluate::Total) - f(self, Evaluate::IdealGas)
+                }
+            }
+            Contributions::ResidualNpt => {
+                let p = self.pressure_(Evaluate::Total);
+                let state_p = Self::new_nvt(
+                    &self.eos,
+                    self.temperature,
+                    self.total_moles * U::gas_constant() * self.temperature / p,
+                    &self.moles,
+                )
+                .unwrap();
+                if additive {
+                    f(self, Evaluate::Residual) + f(self, Evaluate::IdealGasDelta)
+                        - f(&state_p, Evaluate::IdealGasDelta)
+                } else {
+                    f(self, Evaluate::Total) - f(&state_p, Evaluate::IdealGas)
+                }
+            }
+        }
+    }
+
+    fn helmholtz_energy_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        self.get_or_compute_derivative(PartialDerivative::Zeroth, evaluate)
+    }
+
+    fn pressure_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::First(DV), evaluate)
+    }
+
+    fn entropy_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::First(DT), evaluate)
+    }
+
+    fn chemical_potential_(&self, evaluate: Evaluate) -> QuantityArray1<U> {
+        QuantityArray::from_shape_fn(self.eos.components(), |i| {
+            self.get_or_compute_derivative(PartialDerivative::First(DN(i)), evaluate)
+        })
+    }
+
+    fn dp_dv_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::Second(DV, DV), evaluate)
+    }
+
+    fn dp_dt_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::Second(DV, DT), evaluate)
+    }
+
+    fn dp_dni_(&self, evaluate: Evaluate) -> QuantityArray1<U> {
+        QuantityArray::from_shape_fn(self.eos.components(), |i| {
+            -self.get_or_compute_derivative(PartialDerivative::Second(DV, DN(i)), evaluate)
+        })
+    }
+
+    fn d2p_dv2_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::Third(DV), evaluate)
+    }
+
+    fn dmu_dt_(&self, evaluate: Evaluate) -> QuantityArray1<U> {
+        QuantityArray::from_shape_fn(self.eos.components(), |i| {
+            self.get_or_compute_derivative(PartialDerivative::Second(DT, DN(i)), evaluate)
+        })
+    }
+
+    fn dmu_dni_(&self, evaluate: Evaluate) -> QuantityArray2<U> {
+        let n = self.eos.components();
+        QuantityArray::from_shape_fn((n, n), |(i, j)| {
+            self.get_or_compute_derivative(PartialDerivative::Second(DN(i), DN(j)), evaluate)
+        })
+    }
+
+    fn ds_dt_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::Second(DT, DT), evaluate)
+    }
+
+    fn d2s_dt2_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
+        -self.get_or_compute_derivative(PartialDerivative::Third(DT), evaluate)
+    }
+
+    /// Pressure: $p=-\left(\frac{\partial A}{\partial V}\right)_{T,N_i}$
+    pub fn pressure(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::pressure_, contributions, true)
+    }
+
+    /// Compressibility factor: $Z=\frac{pV}{NRT}$
+    pub fn compressibility(&self, contributions: Contributions) -> f64 {
+        (self.pressure(contributions) / (self.density * self.temperature * U::gas_constant()))
+            .into_value()
+            .unwrap()
+    }
+
+    /// Partial derivative of pressure w.r.t. volume: $\left(\frac{\partial p}{\partial V}\right)_{T,N_i}$
+    pub fn dp_dv(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::dp_dv_, contributions, true)
+    }
+
+    /// Partial derivative of pressure w.r.t. density: $\left(\frac{\partial p}{\partial \rho}\right)_{T,N_i}$
+    pub fn dp_drho(&self, contributions: Contributions) -> QuantityScalar<U> {
+        -self.volume / self.density * self.dp_dv(contributions)
+    }
+
+    /// Partial derivative of pressure w.r.t. temperature: $\left(\frac{\partial p}{\partial T}\right)_{V,N_i}$
+    pub fn dp_dt(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::dp_dt_, contributions, true)
+    }
+
+    /// Partial derivative of pressure w.r.t. moles: $\left(\frac{\partial p}{\partial N_i}\right)_{T,V,N_j}$
+    pub fn dp_dni(&self, contributions: Contributions) -> QuantityArray1<U> {
+        self.evaluate_property(Self::dp_dni_, contributions, true)
+    }
+
+    /// Second partial derivative of pressure w.r.t. volume: $\left(\frac{\partial^2 p}{\partial V^2}\right)_{T,N_j}$
+    pub fn d2p_dv2(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::d2p_dv2_, contributions, true)
+    }
+
+    /// Second partial derivative of pressure w.r.t. density: $\left(\frac{\partial^2 p}{\partial \rho^2}\right)_{T,N_j}$
+    pub fn d2p_drho2(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.volume / (self.density * self.density)
+            * (self.volume * self.d2p_dv2(contributions) + 2.0 * self.dp_dv(contributions))
+    }
+
+    /// Partial molar volume: $v_i=\left(\frac{\partial V}{\partial N_i}\right)_{T,p,N_j}$
+    pub fn molar_volume(&self, contributions: Contributions) -> QuantityArray1<U> {
+        let func = |s: &Self, evaluate: Evaluate| -s.dp_dni_(evaluate) / s.dp_dv_(evaluate);
+        self.evaluate_property(func, contributions, false)
+    }
+
+    /// Chemical potential: $\mu_i=\left(\frac{\partial A}{\partial N_i}\right)_{T,V,N_j}$
+    pub fn chemical_potential(&self, contributions: Contributions) -> QuantityArray1<U> {
+        self.evaluate_property(Self::chemical_potential_, contributions, true)
+    }
+
+    /// Partial derivative of chemical potential w.r.t. temperature: $\left(\frac{\partial\mu_i}{\partial T}\right)_{V,N_i}$
+    pub fn dmu_dt(&self, contributions: Contributions) -> QuantityArray1<U> {
+        self.evaluate_property(Self::dmu_dt_, contributions, true)
+    }
+
+    /// Partial derivative of chemical potential w.r.t. moles: $\left(\frac{\partial\mu_i}{\partial \mu_j}\right)_{T,V,N_k}$
+    pub fn dmu_dni(&self, contributions: Contributions) -> QuantityArray2<U> {
+        self.evaluate_property(Self::dmu_dni_, contributions, true)
+    }
+
+    /// Logarithm of the fugacity coefficient: $\ln\varphi_i=\beta\mu_i^\mathrm{res}\left(T,p,\lbrace N_i\rbrace\right)$
+    pub fn ln_phi(&self) -> Array1<f64> {
+        (self.chemical_potential(Contributions::ResidualNpt)
+            / (U::gas_constant() * self.temperature))
+            .into_value()
+            .unwrap()
+    }
+
+    /// Logarithm of the fugacity coefficient of all components treated as pure substance at mixture temperature and pressure.
+    pub fn ln_phi_pure(&self) -> EosResult<Array1<f64>> {
+        let pressure = self.pressure(Contributions::Total);
+        (0..self.eos.components())
+            .map(|i| {
+                let eos = Rc::new(self.eos.subset(&[i]));
+                let state = Self::new_npt(
+                    &eos,
+                    self.temperature,
+                    pressure,
+                    &(arr1(&[1.0]) * U::reference_moles()),
+                    crate::DensityInitialization::Liquid,
+                )?;
+                Ok(state.ln_phi()[0])
+            })
+            .collect()
+    }
+
+    /// Activity coefficient $\ln \gamma_i = \ln \varphi_i(T, p, \mathbf{N}) - \ln \varphi_i(T, p)$
+    pub fn ln_symmetric_activity_coefficient(&self) -> EosResult<Array1<f64>> {
+        match self.eos.components() {
+            1 => Ok(arr1(&[0.0])),
+            _ => Ok(self.ln_phi() - &self.ln_phi_pure()?),
+        }
+    }
+
+    /// Partial derivative of the logarithm of the fugacity coefficient w.r.t. temperature: $\left(\frac{\partial\ln\varphi_i}{\partial T}\right)_{p,N_i}$
+    pub fn dln_phi_dt(&self) -> QuantityArray1<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            (s.dmu_dt_(evaluate) + s.dp_dni_(evaluate) * (s.dp_dt_(evaluate) / s.dp_dv_(evaluate))
+                - s.chemical_potential_(evaluate) / self.temperature)
+                / (U::gas_constant() * self.temperature)
+        };
+        self.evaluate_property(func, Contributions::ResidualNpt, false)
+    }
+
+    /// Partial derivative of the logarithm of the fugacity coefficient w.r.t. pressure: $\left(\frac{\partial\ln\varphi_i}{\partial p}\right)_{T,N_i}$
+    pub fn dln_phi_dp(&self) -> QuantityArray1<U> {
+        self.molar_volume(Contributions::ResidualNpt) / (U::gas_constant() * self.temperature)
+    }
+
+    /// Partial derivative of the logarithm of the fugacity coefficient w.r.t. moles: $\left(\frac{\partial\ln\varphi_i}{\partial N_j}\right)_{T,p,N_k}$
+    pub fn dln_phi_dnj(&self) -> QuantityArray2<U> {
+        let n = self.eos.components();
+        let dmu_dni = self.dmu_dni(Contributions::ResidualNvt);
+        let dp_dni = self.dp_dni(Contributions::Total);
+        let dp_dv = self.dp_dv(Contributions::Total);
+        let dp_dn_2 = QuantityArray::from_shape_fn((n, n), |(i, j)| dp_dni.get(i) * dp_dni.get(j));
+        (dmu_dni + dp_dn_2 / dp_dv) / (U::gas_constant() * self.temperature)
+            + 1.0 / self.total_moles
+    }
+
+    /// Thermodynamic factor: $\Gamma_{ij}=\delta_{ij}+x_i\left(\frac{\partial\ln\varphi_i}{\partial x_j}\right)_{T,p,\Sigma}$
+    pub fn thermodynamic_factor(&self) -> Array2<f64> {
+        let dln_phi_dnj = self
+            .dln_phi_dnj()
+            .to_reduced(U::reference_moles().powi(-1))
+            .unwrap();
+        let moles = self.moles.to_reduced(U::reference_moles()).unwrap();
+        let n = self.eos.components() - 1;
+        Array2::from_shape_fn((n, n), |(i, j)| {
+            moles[i] * (dln_phi_dnj[[i, j]] - dln_phi_dnj[[i, n]]) + if i == j { 1.0 } else { 0.0 }
+        })
+    }
+
+    /// Molar isochoric heat capacity: $c_v=\left(\frac{\partial u}{\partial T}\right)_{V,N_i}$
+    pub fn c_v(&self, contributions: Contributions) -> QuantityScalar<U> {
+        let func =
+            |s: &Self, evaluate: Evaluate| s.temperature * s.ds_dt_(evaluate) / s.total_moles;
+        self.evaluate_property(func, contributions, true)
+    }
+
+    /// Partial derivative of the molar isochoric heat capacity w.r.t. temperature: $\left(\frac{\partial c_V}{\partial T}\right)_{V,N_i}$
+    pub fn dc_v_dt(&self, contributions: Contributions) -> QuantityScalar<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            (s.temperature * s.d2s_dt2_(evaluate) + s.ds_dt_(evaluate)) / s.total_moles
+        };
+        self.evaluate_property(func, contributions, true)
+    }
+
+    /// Molar isobaric heat capacity: $c_p=\left(\frac{\partial h}{\partial T}\right)_{p,N_i}$
+    pub fn c_p(&self, contributions: Contributions) -> QuantityScalar<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            s.temperature / s.total_moles
+                * (s.ds_dt_(evaluate)
+                    - s.dp_dt_(evaluate) * s.dp_dt_(evaluate) / s.dp_dv_(evaluate))
+        };
+        self.evaluate_property(func, contributions, false)
+    }
+
+    /// Entropy: $S=-\left(\frac{\partial A}{\partial T}\right)_{V,N_i}$
+    pub fn entropy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::entropy_, contributions, true)
+    }
+
+    /// Partial derivative of the entropy w.r.t. temperature: $\left(\frac{\partial S}{\partial T}\right)_{V,N_i}$
+    pub fn ds_dt(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::ds_dt_, contributions, true)
+    }
+
+    /// molar entropy: $s=\frac{S}{N}$
+    pub fn molar_entropy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.entropy(contributions) / self.total_moles
+    }
+
+    /// Enthalpy: $H=A+TS+pV$
+    pub fn enthalpy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            s.temperature * s.entropy_(evaluate)
+                + s.helmholtz_energy_(evaluate)
+                + s.pressure_(evaluate) * s.volume
+        };
+        self.evaluate_property(func, contributions, true)
+    }
+
+    /// molar enthalpy: $h=\frac{H}{N}$
+    pub fn molar_enthalpy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.enthalpy(contributions) / self.total_moles
+    }
+
+    /// Helmholtz energy: $A$
+    pub fn helmholtz_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.evaluate_property(Self::helmholtz_energy_, contributions, true)
+    }
+
+    /// molar Helmholtz energy: $a=\frac{A}{N}$
+    pub fn molar_helmholtz_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.helmholtz_energy(contributions) / self.total_moles
+    }
+
+    /// Internal energy: $U=A+TS$
+    pub fn internal_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            s.temperature * s.entropy_(evaluate) + s.helmholtz_energy_(evaluate)
+        };
+        self.evaluate_property(func, contributions, true)
+    }
+
+    /// Molar internal energy: $u=\frac{U}{N}$
+    pub fn molar_internal_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.internal_energy(contributions) / self.total_moles
+    }
+
+    /// Gibbs energy: $G=A+pV$
+    pub fn gibbs_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            s.pressure_(evaluate) * s.volume + s.helmholtz_energy_(evaluate)
+        };
+        self.evaluate_property(func, contributions, true)
+    }
+
+    /// Molar Gibbs energy: $g=\frac{G}{N}$
+    pub fn molar_gibbs_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.gibbs_energy(contributions) / self.total_moles
+    }
+
+    /// Partial molar entropy: $s_i=\left(\frac{\partial S}{\partial N_i}\right)_{T,p,N_j}$
+    pub fn partial_molar_entropy(&self, contributions: Contributions) -> QuantityArray1<U> {
+        let func = |s: &Self, evaluate: Evaluate| {
+            -(s.dmu_dt_(evaluate) + s.dp_dni_(evaluate) * (s.dp_dt_(evaluate) / s.dp_dv_(evaluate)))
+        };
+        self.evaluate_property(func, contributions, false)
+    }
+
+    /// Partial molar enthalpy: $h_i=\left(\frac{\partial H}{\partial N_i}\right)_{T,p,N_j}$
+    pub fn partial_molar_enthalpy(&self, contributions: Contributions) -> QuantityArray1<U> {
+        let s = self.partial_molar_entropy(contributions);
+        let mu = self.chemical_potential(contributions);
+        s * self.temperature + mu
+    }
+
+    /// Joule Thomson coefficient: $\mu_{JT}=\left(\frac{\partial T}{\partial p}\right)_{H,N_i}$
+    pub fn joule_thomson(&self) -> QuantityScalar<U> {
+        let c = Contributions::Total;
+        -(self.volume + self.temperature * self.dp_dt(c) / self.dp_dv(c))
+            / (self.total_moles * self.c_p(c))
+    }
+
+    /// Isentropic compressibility: $\kappa_s=-\frac{1}{V}\left(\frac{\partial V}{\partial p}\right)_{S,N_i}$
+    pub fn isentropic_compressibility(&self) -> QuantityScalar<U> {
+        let c = Contributions::Total;
+        -self.c_v(c) / (self.c_p(c) * self.dp_dv(c) * self.volume)
+    }
+
+    /// Isothermal compressibility: $\kappa_T=-\frac{1}{V}\left(\frac{\partial V}{\partial p}\right)_{T,N_i}$
+    pub fn isothermal_compressibility(&self) -> QuantityScalar<U> {
+        let c = Contributions::Total;
+        -1.0 / (self.dp_dv(c) * self.volume)
+    }
+
+    /// Structure factor: $S(0)=k_BT\left(\frac{\partial\rho}{\partial p}\right)_{T,N_i}$
+    pub fn structure_factor(&self) -> f64 {
+        -(U::gas_constant() * self.temperature * self.density)
+            .to_reduced(self.volume * self.dp_dv(Contributions::Total))
+            .unwrap()
+    }
+
+    /// Helmholtz energy $A$ evaluated for each contribution of the equation of state.
+    pub fn helmholtz_energy_contributions(&self) -> Vec<(String, QuantityScalar<U>)> {
+        let new_state = self.derive0();
+        let contributions = self.eos.evaluate_residual_contributions(&new_state);
+        let mut res = Vec::with_capacity(contributions.len() + 1);
+        let ig = self.eos.ideal_gas();
+        res.push((
+            ig.to_string(),
+            ig.evaluate(&new_state) * new_state.temperature * U::reference_energy(),
+        ));
+        for (s, v) in contributions {
+            res.push((s, v * new_state.temperature * U::reference_energy()));
+        }
+        res
+    }
+
+    /// Pressure $p$ evaluated for each contribution of the equation of state.
+    pub fn pressure_contributions(&self) -> Vec<(String, QuantityScalar<U>)> {
+        let new_state = self.derive1(DV);
+        let contributions = self.eos.evaluate_residual_contributions(&new_state);
+        let mut res = Vec::with_capacity(contributions.len() + 1);
+        let ig = self.eos.ideal_gas();
+        res.push((
+            ig.to_string(),
+            -(ig.evaluate(&new_state) * new_state.temperature).eps[0] * U::reference_pressure(),
+        ));
+        for (s, v) in contributions {
+            res.push((
+                s,
+                -(v * new_state.temperature).eps[0] * U::reference_pressure(),
+            ));
+        }
+        res
+    }
+
+    /// Chemical potential $\mu_i$ evaluated for each contribution of the equation of state.
+    pub fn chemical_potential_contributions(
+        &self,
+        component: usize,
+    ) -> Vec<(String, QuantityScalar<U>)> {
+        let new_state = self.derive1(DN(component));
+        let contributions = self.eos.evaluate_residual_contributions(&new_state);
+        let mut res = Vec::with_capacity(contributions.len() + 1);
+        let ig = self.eos.ideal_gas();
+        res.push((
+            ig.to_string(),
+            (ig.evaluate(&new_state) * new_state.temperature).eps[0] * U::reference_molar_energy(),
+        ));
+        for (s, v) in contributions {
+            res.push((
+                s,
+                (v * new_state.temperature).eps[0] * U::reference_molar_energy(),
+            ));
+        }
+        res
+    }
+}
+
+/// # Mass specific state properties
+///
+/// These properties are available for equations of state
+/// that implement the [MolarWeight] trait.
+impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> State<U, E> {
+    /// Total molar weight: $MW=\sum_ix_iMW_i$
+    pub fn total_molar_weight(&self) -> QuantityScalar<U> {
+        (self.eos.molar_weight() * &self.molefracs).sum()
+    }
+
+    /// Mass of each component: $m_i=n_iMW_i$
+    pub fn mass(&self) -> QuantityArray1<U> {
+        self.moles.clone() * self.eos.molar_weight()
+    }
+
+    /// Total mass: $m=\sum_im_i=nMW$
+    pub fn total_mass(&self) -> QuantityScalar<U> {
+        self.total_moles * self.total_molar_weight()
+    }
+
+    /// Mass density: $\rho^{(m)}=\frac{m}{V}$
+    pub fn mass_density(&self) -> QuantityScalar<U> {
+        self.density * self.total_molar_weight()
+    }
+
+    /// Mass fractions: $w_i=\frac{m_i}{m}$
+    pub fn massfracs(&self) -> Array1<f64> {
+        self.mass().to_reduced(self.total_mass()).unwrap()
+    }
+
+    /// Specific entropy: $s^{(m)}=\frac{S}{m}$
+    pub fn specific_entropy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.molar_entropy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific enthalpy: $h^{(m)}=\frac{H}{m}$
+    pub fn specific_enthalpy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.molar_enthalpy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific Helmholtz energy: $a^{(m)}=\frac{A}{m}$
+    pub fn specific_helmholtz_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.molar_helmholtz_energy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific internal energy: $u^{(m)}=\frac{U}{m}$
+    pub fn specific_internal_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.molar_internal_energy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific Gibbs energy: $g^{(m)}=\frac{G}{m}$
+    pub fn specific_gibbs_energy(&self, contributions: Contributions) -> QuantityScalar<U> {
+        self.molar_gibbs_energy(contributions) / self.total_molar_weight()
+    }
+
+    /// Speed of sound: $c=\sqrt{\left(\frac{\partial p}{\partial\rho}\right)_{S,N_i}}$
+    pub fn speed_of_sound(&self) -> QuantityScalar<U> {
+        (1.0 / (self.density * self.total_molar_weight() * self.isentropic_compressibility()))
+            .sqrt()
+            .unwrap()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> State<U, E> {
+    // This function is designed specifically for use in density iterations
+    pub(crate) fn p_dpdrho(&self) -> (QuantityScalar<U>, QuantityScalar<U>) {
+        let dp_dv = self.dp_dv(Contributions::Total);
+        (
+            self.pressure(Contributions::Total),
+            (-self.volume * dp_dv / self.density),
+        )
+    }
+
+    // This function is designed specifically for use in spinodal iterations
+    pub(crate) fn d2pdrho2(&self) -> (QuantityScalar<U>, QuantityScalar<U>, QuantityScalar<U>) {
+        let d2p_dv2 = self.d2p_dv2(Contributions::Total);
+        let dp_dv = self.dp_dv(Contributions::Total);
+        (
+            self.pressure(Contributions::Total),
+            (-self.volume * dp_dv / self.density),
+            (self.volume / (self.density * self.density) * (2.0 * dp_dv + self.volume * d2p_dv2)),
+        )
+    }
+}
+
+/// # Transport properties
+///
+/// These properties are available for equations of state
+/// that implement the [EntropyScaling] trait.
+impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> State<U, E> {
+    /// Return the viscosity via entropy scaling.
+    pub fn viscosity(&self) -> EosResult<QuantityScalar<U>> {
+        let s = self
+            .molar_entropy(Contributions::ResidualNvt)
+            .to_reduced(U::reference_molar_entropy())?;
+        Ok(self
+            .eos
+            .viscosity_reference(self.temperature, self.volume, &self.moles)?
+            * self.eos.viscosity_correlation(s, &self.molefracs)?.exp())
+    }
+
+    /// Return the logarithm of the reduced viscosity.
+    ///
+    /// This term equals the viscosity correlation function
+    /// that is used for entropy scaling.
+    pub fn ln_viscosity_reduced(&self) -> EosResult<f64> {
+        let s = self
+            .molar_entropy(Contributions::ResidualNvt)
+            .to_reduced(U::reference_molar_entropy())?;
+        self.eos.viscosity_correlation(s, &self.molefracs)
+    }
+
+    /// Return the viscosity reference as used in entropy scaling.
+    pub fn viscosity_reference(&self) -> EosResult<QuantityScalar<U>> {
+        self.eos
+            .viscosity_reference(self.temperature, self.volume, &self.moles)
+    }
+
+    /// Return the diffusion via entropy scaling.
+    pub fn diffusion(&self) -> EosResult<QuantityScalar<U>> {
+        let s = self
+            .molar_entropy(Contributions::ResidualNvt)
+            .to_reduced(U::reference_molar_entropy())?;
+        Ok(self
+            .eos
+            .diffusion_reference(self.temperature, self.volume, &self.moles)?
+            * self.eos.diffusion_correlation(s, &self.molefracs)?.exp())
+    }
+
+    /// Return the logarithm of the reduced diffusion.
+    ///
+    /// This term equals the diffusion correlation function
+    /// that is used for entropy scaling.
+    pub fn ln_diffusion_reduced(&self) -> EosResult<f64> {
+        let s = self
+            .molar_entropy(Contributions::ResidualNvt)
+            .to_reduced(U::reference_molar_entropy())?;
+        self.eos.diffusion_correlation(s, &self.molefracs)
+    }
+
+    /// Return the diffusion reference as used in entropy scaling.
+    pub fn diffusion_reference(&self) -> EosResult<QuantityScalar<U>> {
+        self.eos
+            .diffusion_reference(self.temperature, self.volume, &self.moles)
+    }
+
+    /// Return the thermal conductivity via entropy scaling.
+    pub fn thermal_conductivity(&self) -> EosResult<QuantityScalar<U>> {
+        let s = self
+            .molar_entropy(Contributions::ResidualNvt)
+            .to_reduced(U::reference_molar_entropy())?;
+        Ok(self
+            .eos
+            .thermal_conductivity_reference(self.temperature, self.volume, &self.moles)?
+            * self
+                .eos
+                .thermal_conductivity_correlation(s, &self.molefracs)?
+                .exp())
+    }
+
+    /// Return the logarithm of the reduced thermal conductivity.
+    ///
+    /// This term equals the thermal conductivity correlation function
+    /// that is used for entropy scaling.
+    pub fn ln_thermal_conductivity_reduced(&self) -> EosResult<f64> {
+        let s = self
+            .molar_entropy(Contributions::ResidualNvt)
+            .to_reduced(U::reference_molar_entropy())?;
+        self.eos
+            .thermal_conductivity_correlation(s, &self.molefracs)
+    }
+
+    /// Return the thermal conductivity reference as used in entropy scaling.
+    pub fn thermal_conductivity_reference(&self) -> EosResult<QuantityScalar<U>> {
+        self.eos
+            .thermal_conductivity_reference(self.temperature, self.volume, &self.moles)
+    }
+}
+
+/// A list of states for a simple access to properties
+/// of multiple states.
+pub struct StateVec<'a, U, E>(pub Vec<&'a State<U, E>>);
+
+impl<'a, U, E> FromIterator<&'a State<U, E>> for StateVec<'a, U, E> {
+    fn from_iter<I: IntoIterator<Item = &'a State<U, E>>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'a, U, E> IntoIterator for StateVec<'a, U, E> {
+    type Item = &'a State<U, E>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, U, E> Deref for StateVec<'a, U, E> {
+    type Target = Vec<&'a State<U, E>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, U: EosUnit, E: EquationOfState> StateVec<'a, U, E> {
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| self.0[i].temperature)
+    }
+
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| self.0[i].pressure(Contributions::Total))
+    }
+
+    pub fn compressibility(&self) -> Array1<f64> {
+        Array1::from_shape_fn(self.0.len(), |i| {
+            self.0[i].compressibility(Contributions::Total)
+        })
+    }
+
+    pub fn density(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| self.0[i].density)
+    }
+
+    pub fn molefracs(&self) -> Array2<f64> {
+        Array2::from_shape_fn((self.0.len(), self.0[0].eos.components()), |(i, j)| {
+            self.0[i].molefracs[j]
+        })
+    }
+
+    pub fn molar_enthalpy(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| {
+            self.0[i].molar_enthalpy(Contributions::Total)
+        })
+    }
+
+    pub fn molar_entropy(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| {
+            self.0[i].molar_entropy(Contributions::Total)
+        })
+    }
+}
+
+impl<'a, U: EosUnit, E: EquationOfState + MolarWeight<U>> StateVec<'a, U, E> {
+    pub fn mass_density(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| self.0[i].mass_density())
+    }
+
+    pub fn massfracs(&self) -> Array2<f64> {
+        Array2::from_shape_fn((self.0.len(), self.0[0].eos.components()), |(i, j)| {
+            self.0[i].massfracs()[j]
+        })
+    }
+
+    pub fn specific_enthalpy(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| {
+            self.0[i].specific_enthalpy(Contributions::Total)
+        })
+    }
+
+    pub fn specific_entropy(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.0.len(), |i| {
+            self.0[i].specific_entropy(Contributions::Total)
+        })
+    }
+}

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Added getters for the fields of `Pore1D` in Python. [#30](https://github.com/feos-org/feos-dft/pull/30)
+
+### Changed
+- Made FMT functional more flexible w.r.t. the shape of the weight functions. [#31](https://github.com/feos-org/feos-dft/pull/31)
+- Changed interface of `PairCorrelationFunction` to facilitate the calculation of pair correlation functions in mixtures. [#29](https://github.com/feos-org/feos-dft/pull/29)
+
+## [0.2.0] - 2022-04-12
+### Added
+- Added `grand_potential_density` getter for DFT profiles in Python. [#22](https://github.com/feos-org/feos-dft/pull/22)
+
+### Changed
+- Renamed `AxisGeometry` to `Geometry`. [#19](https://github.com/feos-org/feos-dft/pull/19)
+- Removed `PyGeometry` and `PyFMTVersion` in favor of a simpler implementation using `PyO3`'s new `#[pyclass]` for fieldless enums feature. [#19](https://github.com/feos-org/feos-dft/pull/19)
+- `DFTSolver` now uses `Verbosity` instead of a `bool` to control its output. [#19](https://github.com/feos-org/feos-dft/pull/19)
+- `SurfaceTensionDiagram` now uses the new `StateVec` struct to access properties of the bulk phases. [#19](https://github.com/feos-org/feos-dft/pull/19)
+- `Pore1D::initialize` and `Pore3D::initialize` now accept initial values for the density profiles as optional arguments. [#24](https://github.com/feos-org/feos-dft/pull/24)
+- Internally restructured the `DFT` structure to avoid redundant data. [#24](https://github.com/feos-org/feos-dft/pull/24)
+- Removed the `m` function in `FluidParameters`, it is instead inferred from `HelmholtzEnergyFunctional` which is now a supertrait of `FluidParameters`. [#24](https://github.com/feos-org/feos-dft/pull/24)
+- Added optional field `cutoff_radius` to `ExternalPotential::FreeEnergyAveraged`. [#25](https://github.com/feos-org/feos-dft/pull/25)
+
+### Packaging
+- Updated `pyo3` and `numpy` dependencies to 0.16.
+- Updated `quantity` dependency to 0.5.
+- Updated `num-dual` dependency to 0.5.
+- Updated `feos-core` dependency to 0.2.
+- Updated `ang` dependency to 0.6.
+- Removed `log` dependency.
+
+## [0.1.3] - 2022-02-17
+### Fixed
+- The pore volume for `Pore3D` is now also accesible from Python. [#16](https://github.com/feos-org/feos-dft/pull/16)
+
+## [0.1.2] - 2022-02-16
+### Added
+- The pore volume using Helium at 298 K as reference is now directly accesible from `Pore1D` and `Pore3D`. [#13](https://github.com/feos-org/feos-dft/pull/13)
+
+### Changed
+- Removed the `unsendable` tag from python classes wherever possible. [#14](https://github.com/feos-org/feos-dft/pull/14)
+
+## [0.1.1] - 2022-02-14
+### Added
+- `HelmholtzEnergyFunctional`s can now overwrite the `ideal_gas` method to provide a non-default ideal gas contribution that is accounted for in the calculation of the entropy, the internal energy and other properties. [#10](https://github.com/feos-org/feos-dft/pull/10)
+
+### Changed
+- Removed the `functional` field in `Pore1D` and `Pore3D`. [#9](https://github.com/feos-org/feos-dft/pull/9)
+
+### Fixed
+- Fixed the units of default values for adsorption isotherms. [#8](https://github.com/feos-org/feos-dft/pull/8)
+
+### Packaging
+- Updated `rustdct` dependency to 0.7.
+
+## [0.1.0] - 2021-12-22
+### Added
+- Initial release

--- a/feos-dft/Cargo.toml
+++ b/feos-dft/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "feos-dft"
+version = "0.2.0"
+authors = ["Philipp Rehner <prehner@ethz.ch>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Generic classical DFT implementations for the `feos` project."
+homepage = "https://github.com/feos-org"
+readme = "README.md"
+repository = "https://github.com/feos-org/feos-dft"
+keywords = ["physics", "thermodynamics", "interfaces", "adsorption"]
+categories = ["science"]
+exclude = ["/.github/*", "*.ipynb"]
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "./docs-header.html" ]
+
+[dependencies]
+quantity = { version = "0.5", features = ["linalg"] }
+feos-core = { version = "0.2", path = "../feos-core" }
+num-dual = "0.5"
+ndarray = { version = "0.15", features = ["serde", "rayon"] }
+ndarray-stats = "0.5"
+rustdct = "0.7"
+rustfft = "6.0"
+ang = "0.6"
+num-traits = "0.2"
+libc = "0.2"
+gauss-quad = "0.1"
+petgraph = "0.6"
+numpy = { version = "0.16", optional = true }
+pyo3 = { version = "0.16", optional = true }
+
+[features]
+default = []
+python = ["pyo3", "numpy", "feos-core/python"]

--- a/feos-dft/README.md
+++ b/feos-dft/README.md
@@ -1,0 +1,24 @@
+# FeOs-DFT
+
+[![crate](https://img.shields.io/crates/v/feos-dft.svg)](https://crates.io/crates/feos-dft)
+[![documentation](https://docs.rs/feos-dft/badge.svg)](https://docs.rs/feos-dft)
+[![minimum rustc 1.51](https://img.shields.io/badge/rustc-1.51+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+
+Generic classical DFT implementations for the `feos` project.
+
+## Installation
+
+Add this to your `Cargo.toml`
+
+```toml
+[dependencies]
+feos-dft = "0.2"
+```
+
+## Test building python wheel
+
+From within a Python virtual environment with `maturin` installed, type
+
+```
+maturin build --release --out dist --no-sdist -m build_wheel/Cargo.toml
+```

--- a/feos-dft/docs-header.html
+++ b/feos-dft/docs-header.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js"                  integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js"    integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "\\(", right: "\\)", display: false},
+                {left: "$", right: "$", display: false},
+                {left: "\\[", right: "\\]", display: true}
+            ]
+        });
+    });
+</script>

--- a/feos-dft/license-apache
+++ b/feos-dft/license-apache
@@ -1,0 +1,1 @@
+license-apache

--- a/feos-dft/license-mit
+++ b/feos-dft/license-mit
@@ -1,0 +1,1 @@
+license-mit

--- a/feos-dft/src/adsorption/external_potential.rs
+++ b/feos-dft/src/adsorption/external_potential.rs
@@ -1,0 +1,583 @@
+use crate::adsorption::fea_potential::calculate_fea_potential;
+use crate::functional::HelmholtzEnergyFunctional;
+use crate::geometry::Geometry;
+use feos_core::EosUnit;
+use libc::c_double;
+use ndarray::{Array1, Array2, Axis as Axis_nd};
+use quantity::{QuantityArray2, QuantityScalar};
+use std::f64::consts::PI;
+
+const DELTA_STEELE: f64 = 3.35;
+
+/// A collection of external potentials.
+#[derive(Clone)]
+pub enum ExternalPotential<U> {
+    /// Hard wall potential: $V_i^\mathrm{ext}(z)=\begin{cases}\infty&z\leq\sigma_{si}\\\\0&z>\sigma_{si}\end{cases},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)$
+    HardWall { sigma_ss: f64 },
+    /// 9-3 Lennard-Jones potential: $V_i^\mathrm{ext}(z)=\frac{2\pi}{45} m_i\varepsilon_{si}\sigma_{si}^3\rho_s\left(2\left(\frac{\sigma_{si}}{z}\right)^9-15\left(\frac{\sigma_{si}}{z}\right)^3\right),~~~~\varepsilon_{si}=\sqrt{\varepsilon_{ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)$
+    LJ93 {
+        sigma_ss: f64,
+        epsilon_k_ss: f64,
+        rho_s: f64,
+    },
+    /// Simple 9-3 Lennard-Jones potential: $V_i^\mathrm{ext}(z)=\varepsilon_{si}\left(\left(\frac{\sigma_{si}}{z}\right)^9-\left(\frac{\sigma_{si}}{z}\right)^3\right),~~~~\varepsilon_{si}=\sqrt{\varepsilon_{ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)$
+    SimpleLJ93 { sigma_ss: f64, epsilon_k_ss: f64 },
+    /// Custom 9-3 Lennard-Jones potential: $V_i^\mathrm{ext}(z)=\varepsilon_{si}\left(\left(\frac{\sigma_{si}}{z}\right)^9-\left(\frac{\sigma_{si}}{z}\right)^3\right)$
+    CustomLJ93 {
+        sigma_sf: Array1<f64>,
+        epsilon_k_sf: Array1<f64>,
+    },
+    /// Steele potential: $V_i^\mathrm{ext}(z)=2\pi m_i\xi\varepsilon_{si}\sigma_{si}^2\Delta\rho_s\left(0.4\left(\frac{\sigma_{si}}{z}\right)^{10}-\left(\frac{\sigma_{si}}{z}\right)^4-\frac{\sigma_{si}^4}{3\Delta\left(z+0.61\Delta\right)^3}\right),~~~~\varepsilon_{si}=\sqrt{\varepsilon_{ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right),~~~~\Delta=3.35$
+    Steele {
+        sigma_ss: f64,
+        epsilon_k_ss: f64,
+        rho_s: f64,
+        xi: Option<f64>,
+    },
+    /// Double well potential: $V_i^\mathrm{ext}(z)=\mathrm{min}\left(\frac{2\pi}{45} m_i\varepsilon_{2si}\sigma_{si}^3\rho_s\left(2\left(\frac{2\sigma_{si}}{z}\right)^9-15\left(\frac{2\sigma_{si}}{z}\right)^3\right),0\right)+\frac{2\pi}{45} m_i\varepsilon_{1si}\sigma_{si}^3\rho_s\left(2\left(\frac{\sigma_{si}}{z}\right)^9-15\left(\frac{\sigma_{si}}{z}\right)^3\right),~~~~\varepsilon_{1si}=\sqrt{\varepsilon_{1ss}\varepsilon_{ii}},~~~~\varepsilon_{2si}=\sqrt{\varepsilon_{2ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)$
+    DoubleWell {
+        sigma_ss: f64,
+        epsilon1_k_ss: f64,
+        epsilon2_k_ss: f64,
+        rho_s: f64,
+    },
+    /// Free-energy averaged potential:
+    FreeEnergyAveraged {
+        coordinates: QuantityArray2<U>,
+        sigma_ss: Array1<f64>,
+        epsilon_k_ss: Array1<f64>,
+        pore_center: [f64; 3],
+        system_size: [QuantityScalar<U>; 3],
+        n_grid: [usize; 2],
+        cutoff_radius: Option<f64>,
+    },
+
+    /// Custom potential
+    Custom(Array2<f64>),
+}
+
+/// Parameters of the fluid required to evaluate the external potential.
+pub trait FluidParameters: HelmholtzEnergyFunctional {
+    fn epsilon_k_ff(&self) -> Array1<f64>;
+    fn sigma_ff(&self) -> &Array1<f64>;
+}
+
+impl<U: EosUnit> ExternalPotential<U> {
+    // Evaluate the external potential in cartesian coordinates for a given grid and fluid parameters.
+    pub fn calculate_cartesian_potential<P: FluidParameters>(
+        &self,
+        z_grid: &Array1<f64>,
+        fluid_parameters: &P,
+        temperature: f64,
+    ) -> Array2<f64> {
+        if let ExternalPotential::Custom(potential) = self {
+            return potential.clone();
+        }
+
+        // Allocate external potential
+        let m = fluid_parameters.m();
+        let mut ext_pot = Array2::zeros((m.len(), z_grid.len()));
+
+        for (i, &mi) in m.iter().enumerate() {
+            ext_pot.index_axis_mut(Axis_nd(0), i).assign(&match self {
+                Self::HardWall { sigma_ss } => {
+                    let sigma_sf = (fluid_parameters.sigma_ff()[i] + *sigma_ss) * 0.5;
+                    z_grid.mapv(|z| if z < sigma_sf { f64::INFINITY } else { 0.0 })
+                }
+                Self::LJ93 {
+                    sigma_ss,
+                    epsilon_k_ss,
+                    rho_s,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    2.0 * PI * mi * epsilon_k_sf[i] * sigma_sf[i].powi(3) * rho_s / 45.0
+                        * (2.0 * (sigma_sf[i] / z_grid).mapv(|x| x.powi(9))
+                            - 15.0 * (sigma_sf[i] / z_grid).mapv(|x| x.powi(3)))
+                }
+                Self::SimpleLJ93 {
+                    sigma_ss,
+                    epsilon_k_ss,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    epsilon_k_sf[i]
+                        * ((sigma_sf[i] / z_grid).mapv(|x| x.powi(9))
+                            - (sigma_sf[i] / z_grid).mapv(|x| x.powi(3)))
+                }
+                Self::CustomLJ93 {
+                    sigma_sf,
+                    epsilon_k_sf,
+                } => {
+                    epsilon_k_sf[i]
+                        * ((sigma_sf[i] / z_grid).mapv(|x| x.powi(9))
+                            - (sigma_sf[i] / z_grid).mapv(|x| x.powi(3)))
+                }
+                Self::Steele {
+                    sigma_ss,
+                    epsilon_k_ss,
+                    rho_s,
+                    xi,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    (2.0 * PI * mi * xi.unwrap_or(1.0) * epsilon_k_sf[i])
+                        * (sigma_sf[i].powi(2) * DELTA_STEELE * rho_s)
+                        * (0.4 * (sigma_sf[i] / z_grid).mapv(|x| x.powi(10))
+                            - (sigma_sf[i] / z_grid).mapv(|x| x.powi(4))
+                            - sigma_sf[i].powi(4)
+                                / ((3.0 * DELTA_STEELE)
+                                    * (z_grid + 0.61 * DELTA_STEELE).mapv(|x| x.powi(3))))
+                }
+                Self::DoubleWell {
+                    sigma_ss,
+                    epsilon1_k_ss,
+                    epsilon2_k_ss,
+                    rho_s,
+                } => {
+                    // combining rules
+                    let epsilon1_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon1_k_ss).mapv(|e| e.sqrt());
+                    let epsilon2_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon2_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    let bh_tail = (2.0 * PI * mi * epsilon2_k_sf[i] * sigma_sf[i].powi(3) * rho_s
+                        / 45.0
+                        * (2.0 * (2.0 * sigma_sf[i] / z_grid).mapv(|x| x.powi(9))
+                            - 15.0 * (2.0 * sigma_sf[i] / z_grid).mapv(|x| x.powi(3))))
+                    .mapv(|x| x.min(0.0));
+
+                    bh_tail
+                        + &(2.0 * PI * mi * epsilon1_k_sf[i] * sigma_sf[i].powi(3) * rho_s / 45.0
+                            * (2.0 * (sigma_sf[i] / z_grid).mapv(|x| x.powi(9))
+                                - 15.0 * (sigma_sf[i] / z_grid).mapv(|x| x.powi(3))))
+                }
+                Self::FreeEnergyAveraged {
+                    coordinates,
+                    sigma_ss,
+                    epsilon_k_ss,
+                    pore_center,
+                    system_size,
+                    n_grid,
+                    cutoff_radius,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff()[i] * epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff()[i] + sigma_ss) * 0.5;
+
+                    calculate_fea_potential(
+                        z_grid,
+                        mi,
+                        coordinates,
+                        sigma_sf,
+                        epsilon_k_sf,
+                        pore_center,
+                        system_size,
+                        n_grid,
+                        temperature,
+                        Geometry::Cartesian,
+                        *cutoff_radius,
+                    )
+                }
+                Self::Custom(_) => unreachable!(),
+            });
+        }
+        ext_pot
+    }
+
+    // Evaluate the external potential in cylindrical coordinates for a given grid and fluid parameters.
+    pub fn calculate_cylindrical_potential<P: FluidParameters>(
+        &self,
+        r_grid: &Array1<f64>,
+        pore_size: f64,
+        fluid_parameters: &P,
+        temperature: f64,
+    ) -> Array2<f64> {
+        if let ExternalPotential::Custom(potential) = self {
+            return potential.clone();
+        }
+
+        // Allocate external potential
+        let m = fluid_parameters.m();
+        let mut ext_pot = Array2::zeros((m.len(), r_grid.len()));
+
+        for (i, &mi) in m.iter().enumerate() {
+            ext_pot.index_axis_mut(Axis_nd(0), i).assign(&match self {
+                Self::HardWall { sigma_ss } => {
+                    let sigma_sf = (fluid_parameters.sigma_ff()[i] + *sigma_ss) * 0.5;
+                    r_grid.mapv(|r| {
+                        if r > pore_size - sigma_sf {
+                            f64::INFINITY
+                        } else {
+                            0.0
+                        }
+                    })
+                }
+                Self::LJ93 {
+                    sigma_ss,
+                    epsilon_k_ss,
+                    rho_s,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    (phi(6, &(r_grid / pore_size), sigma_sf[i] / pore_size)
+                        - phi(3, &(r_grid / pore_size), sigma_sf[i] / pore_size))
+                        * 2.0
+                        * PI
+                        * mi
+                        * epsilon_k_sf[i]
+                        * sigma_sf[i].powi(3)
+                        * *rho_s
+                }
+                Self::SimpleLJ93 {
+                    sigma_ss: _,
+                    epsilon_k_ss: _,
+                } => {
+                    unimplemented!()
+                }
+                Self::CustomLJ93 {
+                    sigma_sf: _,
+                    epsilon_k_sf: _,
+                } => {
+                    unimplemented!()
+                }
+                Self::Steele {
+                    sigma_ss,
+                    epsilon_k_ss,
+                    rho_s,
+                    xi,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    (2.0 * PI * mi * xi.unwrap_or(1.0) * epsilon_k_sf[i])
+                        * (sigma_sf[i].powi(2) * DELTA_STEELE * rho_s)
+                        * (psi(6, &(r_grid / pore_size), sigma_sf[i] / pore_size)
+                            - psi(3, &(r_grid / pore_size), sigma_sf[i] / pore_size)
+                            - sigma_sf[i] / DELTA_STEELE
+                                * phi(
+                                    3,
+                                    &(r_grid / (pore_size + DELTA_STEELE * 0.61)),
+                                    sigma_sf[i] / (pore_size + DELTA_STEELE * 0.61),
+                                ))
+                }
+                Self::DoubleWell {
+                    sigma_ss,
+                    epsilon1_k_ss,
+                    epsilon2_k_ss,
+                    rho_s,
+                } => {
+                    // combining rules
+                    let epsilon1_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon1_k_ss).mapv(|e| e.sqrt());
+                    let epsilon2_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon2_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    let bh_tail = ((phi(6, &(r_grid / pore_size), 2.0 * sigma_sf[i] / pore_size)
+                        - phi(3, &(r_grid / pore_size), 2.0 * sigma_sf[i] / pore_size))
+                        * 2.0
+                        * PI
+                        * mi
+                        * epsilon2_k_sf[i]
+                        * sigma_sf[i].powi(3)
+                        * *rho_s)
+                        .mapv(|x| x.min(0.0));
+
+                    bh_tail
+                        + &((phi(6, &(r_grid / pore_size), sigma_sf[i] / pore_size)
+                            - phi(3, &(r_grid / pore_size), sigma_sf[i] / pore_size))
+                            * 2.0
+                            * PI
+                            * mi
+                            * epsilon1_k_sf[i]
+                            * sigma_sf[i].powi(3)
+                            * *rho_s)
+                }
+                Self::FreeEnergyAveraged {
+                    coordinates,
+                    sigma_ss,
+                    epsilon_k_ss,
+                    pore_center,
+                    system_size,
+                    n_grid,
+                    cutoff_radius,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff()[i] * epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff()[i] + sigma_ss) * 0.5;
+
+                    calculate_fea_potential(
+                        r_grid,
+                        mi,
+                        coordinates,
+                        sigma_sf,
+                        epsilon_k_sf,
+                        pore_center,
+                        system_size,
+                        n_grid,
+                        temperature,
+                        Geometry::Cylindrical,
+                        *cutoff_radius,
+                    )
+                }
+                Self::Custom(_) => unreachable!(),
+            });
+        }
+        ext_pot
+    }
+
+    // Evaluate the external potential in spherical coordinates for a given grid and fluid parameters.
+    pub fn calculate_spherical_potential<P: FluidParameters>(
+        &self,
+        r_grid: &Array1<f64>,
+        pore_size: f64,
+        fluid_parameters: &P,
+        temperature: f64,
+    ) -> Array2<f64> {
+        if let ExternalPotential::Custom(potential) = self {
+            return potential.clone();
+        }
+
+        // Allocate external potential
+        let m = fluid_parameters.m();
+        let mut ext_pot = Array2::zeros((m.len(), r_grid.len()));
+
+        for (i, &mi) in m.iter().enumerate() {
+            ext_pot.index_axis_mut(Axis_nd(0), i).assign(&match self {
+                Self::HardWall { sigma_ss } => {
+                    let sigma_sf = (fluid_parameters.sigma_ff()[i] + *sigma_ss) * 0.5;
+                    r_grid.mapv(|r| {
+                        if r > pore_size - sigma_sf {
+                            f64::INFINITY
+                        } else {
+                            0.0
+                        }
+                    })
+                }
+                Self::LJ93 {
+                    sigma_ss,
+                    epsilon_k_ss,
+                    rho_s,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    PI * mi
+                        * epsilon_k_sf[i]
+                        * rho_s
+                        * (sigma_sf[i].powi(12) / 90.
+                            * ((r_grid - 9.0 * pore_size)
+                                / (r_grid - pore_size).mapv(|x| x.powi(9))
+                                - (r_grid + 9.0 * pore_size)
+                                    / (r_grid + pore_size).mapv(|x| x.powi(9)))
+                            - sigma_sf[i].powi(6) / 3.
+                                * ((r_grid - 3.0 * pore_size)
+                                    / (r_grid - pore_size).mapv(|x| x.powi(3))
+                                    - (r_grid + 3.0 * pore_size)
+                                        / (r_grid + pore_size).mapv(|x| x.powi(3))))
+                        / r_grid
+                }
+                Self::SimpleLJ93 {
+                    sigma_ss: _,
+                    epsilon_k_ss: _,
+                } => {
+                    unimplemented!()
+                }
+                Self::CustomLJ93 {
+                    sigma_sf: _,
+                    epsilon_k_sf: _,
+                } => {
+                    unimplemented!()
+                }
+                Self::Steele {
+                    sigma_ss,
+                    epsilon_k_ss,
+                    rho_s,
+                    xi,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    (2.0 * PI * mi * xi.unwrap_or(1.0) * epsilon_k_sf[i])
+                        * (sigma_sf[i].powi(2) * DELTA_STEELE * rho_s)
+                        * (2.0 / 5.0 * sum_n(10, r_grid, sigma_sf[i], pore_size)
+                            - sum_n(4, r_grid, sigma_sf[i], pore_size)
+                            - sigma_sf[i] / (3.0 * DELTA_STEELE)
+                                * (sigma_sf[i].powi(3)
+                                    / r_grid
+                                        .mapv(|r| (pore_size + 0.61 * DELTA_STEELE - r).powi(3))
+                                    + sigma_sf[i].powi(3)
+                                        / r_grid.mapv(|r| {
+                                            (pore_size + 0.61 * DELTA_STEELE + r).powi(3)
+                                        })
+                                    + 1.5
+                                        * sum_n(
+                                            3,
+                                            r_grid,
+                                            sigma_sf[i],
+                                            pore_size + 0.61 * DELTA_STEELE,
+                                        )))
+                }
+                Self::DoubleWell {
+                    sigma_ss,
+                    epsilon1_k_ss,
+                    epsilon2_k_ss,
+                    rho_s,
+                } => {
+                    // combining rules
+                    let epsilon1_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon1_k_ss).mapv(|e| e.sqrt());
+                    let epsilon2_k_sf =
+                        (fluid_parameters.epsilon_k_ff() * *epsilon2_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff() + *sigma_ss) * 0.5;
+
+                    let bh_tail = (2.0
+                        * PI
+                        * mi
+                        * epsilon2_k_sf[i]
+                        * sigma_sf[i].powi(2)
+                        * rho_s
+                        * (2.0 / 5.0 * sum_n(10, r_grid, 2.0 * sigma_sf[i], pore_size)
+                            - sum_n(4, r_grid, 2.0 * sigma_sf[i], pore_size)))
+                    .mapv(|x| x.min(0.0));
+
+                    bh_tail
+                        + &(2.0
+                            * PI
+                            * mi
+                            * epsilon1_k_sf[i]
+                            * sigma_sf[i].powi(2)
+                            * rho_s
+                            * (2.0 / 5.0 * sum_n(10, r_grid, sigma_sf[i], pore_size)
+                                - sum_n(4, r_grid, sigma_sf[i], pore_size)))
+                }
+                Self::FreeEnergyAveraged {
+                    coordinates,
+                    sigma_ss,
+                    epsilon_k_ss,
+                    pore_center,
+                    system_size,
+                    n_grid,
+                    cutoff_radius,
+                } => {
+                    // combining rules
+                    let epsilon_k_sf =
+                        (fluid_parameters.epsilon_k_ff()[i] * epsilon_k_ss).mapv(|e| e.sqrt());
+                    let sigma_sf = (fluid_parameters.sigma_ff()[i] + sigma_ss) * 0.5;
+
+                    calculate_fea_potential(
+                        r_grid,
+                        mi,
+                        coordinates,
+                        sigma_sf,
+                        epsilon_k_sf,
+                        pore_center,
+                        system_size,
+                        n_grid,
+                        temperature,
+                        Geometry::Spherical,
+                        *cutoff_radius,
+                    )
+                }
+                Self::Custom(_) => unreachable!(),
+            });
+        }
+        ext_pot
+    }
+}
+
+fn phi(n: i32, r_r: &Array1<f64>, sigma_r: f64) -> Array1<f64> {
+    let m3n2 = 3.0 - 2.0 * n as f64;
+    let n2m3 = 2.0 * n as f64 - 3.0;
+
+    (1.0 - &r_r.mapv(|r| r.powi(2))).mapv(|r| r.powf(m3n2)) * 4.0 * PI.sqrt() / n2m3
+        * sigma_r.powf(n2m3)
+        * gamma(n as f64 - 0.5)
+        / gamma(n as f64)
+        * taylor_2f1_phi(r_r, n)
+}
+
+fn psi(n: i32, r_r: &Array1<f64>, sigma_r: f64) -> Array1<f64> {
+    (1.0 - &r_r.mapv(|r| r.powi(2))).mapv(|r| r.powf(2.0 - 2.0 * n as f64))
+        * 4.0
+        * PI.sqrt()
+        * gamma(n as f64 - 0.5)
+        / gamma(n as f64)
+        * sigma_r.powf(2.0 * n as f64 - 2.0)
+        * taylor_2f1_psi(r_r, n)
+}
+
+fn sum_n(n: i32, r_grid: &Array1<f64>, sigma: f64, pore_size: f64) -> Array1<f64> {
+    let mut result = Array1::zeros(r_grid.len());
+    for i in 0..n {
+        result = result
+            + sigma.powi(n) / (pore_size.powi(i) * r_grid.mapv(|r| (pore_size - r).powi(n - i)))
+            + sigma.powi(n) / (pore_size.powi(i) * r_grid.mapv(|r| (pore_size + r).powi(n - i)));
+    }
+    result
+}
+
+fn taylor_2f1_phi(x: &Array1<f64>, n: i32) -> Array1<f64> {
+    match n {
+        3 => {
+            1.0 + 3.0 / 4.0 * x.mapv(|x| x.powi(2)) + 3.0 / 64.0 * x.mapv(|x| x.powi(4))
+                - 1.0 / 256.0 * x.mapv(|x| x.powi(6))
+                - 15.0 / 16384.0 * x.mapv(|x| x.powi(8))
+        }
+        6 => {
+            1.0 + 63.0 / 4.0 * x.mapv(|x| x.powi(2))
+                + 2205.0 / 64.0 * x.mapv(|x| x.powi(4))
+                + 3675.0 / 256.0 * x.mapv(|x| x.powi(6))
+                + 11025.0 / 16384.0 * x.mapv(|x| x.powi(8))
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn taylor_2f1_psi(x: &Array1<f64>, n: i32) -> Array1<f64> {
+    match n {
+        3 => {
+            1.0 + 9.0 / 4.0 * x.mapv(|x| x.powi(2))
+                + 9.0 / 64.0 * x.mapv(|x| x.powi(4))
+                + 1.0 / 256.0 * x.mapv(|x| x.powi(6))
+                + 9.0 / 16384.0 * x.mapv(|x| x.powi(8))
+        }
+        6 => {
+            1.0 + 81.0 / 4.0 * x.mapv(|x| x.powi(2))
+                + 3969.0 / 64.0 * x.mapv(|x| x.powi(4))
+                + 11025.0 / 256.0 * x.mapv(|x| x.powi(6))
+                + 99125.0 / 16384.0 * x.mapv(|x| x.powi(8))
+        }
+        _ => unreachable!(),
+    }
+}
+
+extern "C" {
+    fn tgamma(x: c_double) -> c_double;
+}
+
+fn gamma(x: f64) -> f64 {
+    unsafe { tgamma(x) }
+}

--- a/feos-dft/src/adsorption/fea_potential.rs
+++ b/feos-dft/src/adsorption/fea_potential.rs
@@ -1,0 +1,168 @@
+use crate::profile::{CUTOFF_RADIUS, MAX_POTENTIAL};
+use crate::Geometry;
+use feos_core::EosUnit;
+use gauss_quad::GaussLegendre;
+use ndarray::{Array1, Array2, Zip};
+use ndarray_stats::SummaryStatisticsExt;
+use quantity::{QuantityArray2, QuantityScalar};
+use std::f64::consts::PI;
+use std::usize;
+
+// Calculate free-energy average potential for given solid structure.
+pub fn calculate_fea_potential<U: EosUnit>(
+    grid: &Array1<f64>,
+    mi: f64,
+    coordinates: &QuantityArray2<U>,
+    sigma_sf: Array1<f64>,
+    epsilon_k_sf: Array1<f64>,
+    pore_center: &[f64; 3],
+    system_size: &[QuantityScalar<U>; 3],
+    n_grid: &[usize; 2],
+    temperature: f64,
+    geometry: Geometry,
+    cutoff_radius: Option<f64>,
+) -> Array1<f64> {
+    // allocate external potential
+    let mut potential: Array1<f64> = Array1::zeros(grid.len());
+
+    // calculate squared cutoff radius
+    let cutoff_radius2 = cutoff_radius.unwrap_or(CUTOFF_RADIUS).powi(2);
+
+    // dimensionless solid coordinates
+    let coordinates = Array2::from_shape_fn(coordinates.raw_dim(), |(i, j)| {
+        (coordinates.get((i, j)))
+            .to_reduced(U::reference_length())
+            .unwrap()
+    });
+
+    let system_size = [
+        system_size[0].to_reduced(U::reference_length()).unwrap(),
+        system_size[1].to_reduced(U::reference_length()).unwrap(),
+        system_size[2].to_reduced(U::reference_length()).unwrap(),
+    ];
+
+    // Create secondary axis:
+    // Cartesian coordinates => y
+    // Cylindrical coordinates => phi
+    // Spherical coordinates => phi
+    let (nodes1, weights1) = match geometry {
+        Geometry::Cartesian => {
+            let nodes = Array1::linspace(
+                0.5 * system_size[1] / n_grid[0] as f64,
+                system_size[1] - 0.5 * system_size[1] / n_grid[0] as f64,
+                n_grid[0],
+            );
+            let weights = Array1::from_elem(n_grid[0], system_size[1] / n_grid[0] as f64);
+            (nodes, weights)
+        }
+        Geometry::Spherical | Geometry::Cylindrical => {
+            let nodes = PI + Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[0]).0) * PI;
+            let weights = Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[0]).1) * PI;
+            (nodes, weights)
+        }
+    };
+
+    // Create tertiary axis
+    // Cartesian coordinates => z
+    // Cylindrical coordinates => z
+    // Spherical coordinates => theta
+    let (nodes2, weights2) = match geometry {
+        Geometry::Cylindrical | Geometry::Cartesian => {
+            let nodes = Array1::linspace(
+                0.5 * system_size[2] / n_grid[1] as f64,
+                system_size[2] - 0.5 * system_size[2] / n_grid[1] as f64,
+                n_grid[1],
+            );
+            let weights = Array1::from_elem(n_grid[1], system_size[2] / n_grid[1] as f64);
+            (nodes, weights)
+        }
+        Geometry::Spherical => {
+            let nodes = PI / 2.0
+                + Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[1]).0) * PI / 2.0;
+            let weights = Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[1]).1) * PI
+                / 2.0
+                * Array1::from_shape_fn(n_grid[1], |i| nodes[i].sin());
+            (nodes, weights)
+        }
+    };
+
+    // calculate weights
+    let weights = Array2::from_shape_fn((n_grid[0], n_grid[1]), |(i, j)| weights1[i] * weights2[j]);
+
+    // calculate sum of weights
+    let weights_sum = weights.sum();
+
+    // calculate FEA potential
+    Zip::indexed(&mut potential).par_for_each(|i0, f| {
+        let mut potential_2d: Array2<f64> = Array2::zeros((n_grid[0], n_grid[1]));
+        for (i1, &n1) in nodes1.iter().enumerate() {
+            for (i2, &n2) in nodes2.iter().enumerate() {
+                let point = match geometry {
+                    Geometry::Cartesian => [grid[i0], n1, n2],
+                    Geometry::Cylindrical => [
+                        pore_center[0] + grid[i0] * n1.cos(),
+                        pore_center[1] + grid[i0] * n1.sin(),
+                        n2,
+                    ],
+                    Geometry::Spherical => [
+                        pore_center[0] + grid[i0] * n2.sin() * n1.cos(),
+                        pore_center[1] + grid[i0] * n2.sin() * n1.sin(),
+                        pore_center[2] + grid[i0] * n2.cos(),
+                    ],
+                };
+
+                let distance2 = calculate_distance2(point, &coordinates, system_size);
+                let potential_sum: f64 = (0..sigma_sf.len())
+                    .map(|alpha| {
+                        mi * evaluate(
+                            distance2[alpha],
+                            sigma_sf[alpha],
+                            epsilon_k_sf[alpha],
+                            cutoff_radius2,
+                        ) / temperature
+                    })
+                    .sum();
+                potential_2d[[i1, i2]] = (-potential_sum.min(MAX_POTENTIAL)).exp();
+            }
+        }
+        *f = potential_2d.weighted_sum(&weights).unwrap();
+    });
+
+    -temperature * potential.map(|p| (p / weights_sum).ln())
+}
+
+// -temperature * potential.map(|p| (p / weights_sum).ln())
+
+/// Evaluate LJ12-6 potential between solid site "alpha" and fluid segment
+fn evaluate(distance2: f64, sigma: f64, epsilon: f64, cutoff_radius2: f64) -> f64 {
+    let sigma_r = sigma.powi(2) / distance2;
+
+    let potential: f64 = if distance2 > cutoff_radius2 {
+        0.0
+    } else if distance2 == 0.0 {
+        f64::INFINITY
+    } else {
+        4.0 * epsilon * (sigma_r.powi(6) - sigma_r.powi(3))
+    };
+
+    potential
+}
+
+/// Evaluate the squared euclidian distance between a point and the coordinates of all solid atoms.
+fn calculate_distance2(
+    point: [f64; 3],
+    coordinates: &Array2<f64>,
+    system_size: [f64; 3],
+) -> Array1<f64> {
+    Array1::from_shape_fn(coordinates.ncols(), |i| {
+        let mut rx = coordinates[[0, i]] - point[0];
+        let mut ry = coordinates[[1, i]] - point[1];
+        let mut rz = coordinates[[2, i]] - point[2];
+
+        rx = rx - system_size[0] * (rx / system_size[0]).round();
+        ry = ry - system_size[1] * (ry / system_size[1]).round();
+        rz = rz - system_size[2] * (rz / system_size[2]).round();
+
+        rx.powi(2) + ry.powi(2) + rz.powi(2)
+    })
+}

--- a/feos-dft/src/adsorption/mod.rs
+++ b/feos-dft/src/adsorption/mod.rs
@@ -1,0 +1,479 @@
+//! Adsorption profiles and isotherms.
+use super::functional::{HelmholtzEnergyFunctional, DFT};
+use super::solver::DFTSolver;
+use feos_core::{
+    Contributions, EosError, EosResult, EosUnit, EquationOfState, SolverOptions, StateBuilder,
+};
+use ndarray::{arr1, Array1, Dimension, Ix1, Ix3, RemoveAxis};
+use quantity::{QuantityArray1, QuantityArray2, QuantityScalar};
+use std::rc::Rc;
+
+mod external_potential;
+mod fea_potential;
+mod pore;
+pub use external_potential::{ExternalPotential, FluidParameters};
+pub use pore::{Pore1D, Pore3D, PoreProfile, PoreProfile1D, PoreProfile3D, PoreSpecification};
+
+const MAX_ITER_ADSORPTION_EQUILIBRIUM: usize = 50;
+const TOL_ADSORPTION_EQUILIBRIUM: f64 = 1e-8;
+
+/// Possible inputs for the pressure grid of adsorption isotherms.
+pub enum PressureSpecification<U> {
+    /// Specify the minimal and maximal pressure, and the number of points
+    Plim {
+        p_min: QuantityScalar<U>,
+        p_max: QuantityScalar<U>,
+        points: usize,
+    },
+    /// Provide a custom array of pressure points.
+    Pvec(QuantityArray1<U>),
+}
+
+impl<U: EosUnit> PressureSpecification<U>
+where
+    QuantityScalar<U>: std::fmt::Display,
+{
+    fn p_min_max(&self) -> (QuantityScalar<U>, QuantityScalar<U>) {
+        match self {
+            Self::Plim {
+                p_min,
+                p_max,
+                points: _,
+            } => (*p_min, *p_max),
+            Self::Pvec(pressure) => (pressure.get(0), pressure.get(pressure.len() - 1)),
+        }
+    }
+
+    fn to_vec(&self) -> EosResult<QuantityArray1<U>> {
+        Ok(match self {
+            Self::Plim {
+                p_min,
+                p_max,
+                points,
+            } => QuantityArray1::linspace(*p_min, *p_max, *points)?,
+            Self::Pvec(pressure) => pressure.clone(),
+        })
+    }
+
+    fn equilibrium<
+        D: Dimension + RemoveAxis + 'static,
+        F: HelmholtzEnergyFunctional + FluidParameters,
+    >(
+        &self,
+        equilibrium: &Adsorption<U, D, F>,
+    ) -> EosResult<(QuantityArray1<U>, QuantityArray1<U>)>
+    where
+        D::Larger: Dimension<Smaller = D>,
+        D::Smaller: Dimension<Larger = D>,
+        <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+    {
+        let p_eq = equilibrium.pressure().get(0);
+        match self {
+            Self::Plim {
+                p_min,
+                p_max,
+                points,
+            } => Ok((
+                QuantityArray1::linspace(*p_min, p_eq, points / 2)?,
+                QuantityArray1::linspace(*p_max, p_eq, points - points / 2)?,
+            )),
+            Self::Pvec(pressure) => {
+                let index = (0..pressure.len()).find(|&i| pressure.get(i) > p_eq);
+                Ok(if let Some(index) = index {
+                    (
+                        QuantityArray1::from_shape_fn(index + 1, |i| {
+                            if i == index {
+                                p_eq
+                            } else {
+                                pressure.get(i)
+                            }
+                        }),
+                        QuantityArray1::from_shape_fn(pressure.len() - index + 1, |i| {
+                            if i == pressure.len() - index {
+                                p_eq
+                            } else {
+                                pressure.get(pressure.len() - i - 1)
+                            }
+                        }),
+                    )
+                } else {
+                    (pressure.clone(), arr1(&[]) * U::reference_pressure())
+                })
+            }
+        }
+    }
+}
+
+/// Container structure for the calculation of adsorption isotherms.
+pub struct Adsorption<U, D: Dimension, F> {
+    components: usize,
+    dimension: i32,
+    pub profiles: Vec<EosResult<PoreProfile<U, D, F>>>,
+}
+
+/// Container structure for adsorption isotherms in 1D pores.
+pub type Adsorption1D<U, F> = Adsorption<U, Ix1, F>;
+/// Container structure for adsorption isotherms in 3D pores.
+pub type Adsorption3D<U, F> = Adsorption<U, Ix3, F>;
+
+impl<
+        U: EosUnit,
+        D: Dimension + RemoveAxis + 'static,
+        F: HelmholtzEnergyFunctional + FluidParameters,
+    > Adsorption<U, D, F>
+where
+    QuantityScalar<U>: std::fmt::Display,
+    D::Larger: Dimension<Smaller = D>,
+    D::Smaller: Dimension<Larger = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    fn new<S: PoreSpecification<U, D>>(
+        functional: &Rc<DFT<F>>,
+        pore: &S,
+        profiles: Vec<EosResult<PoreProfile<U, D, F>>>,
+    ) -> Self {
+        Self {
+            components: functional.components(),
+            dimension: pore.dimension(),
+            profiles,
+        }
+    }
+
+    /// Calculate an adsorption isotherm (starting at low pressure)
+    pub fn adsorption_isotherm<S: PoreSpecification<U, D>>(
+        functional: &Rc<DFT<F>>,
+        temperature: QuantityScalar<U>,
+        pressure: &PressureSpecification<U>,
+        pore: &S,
+        molefracs: Option<&Array1<f64>>,
+        solver: Option<&DFTSolver>,
+    ) -> EosResult<Adsorption<U, D, F>> {
+        let pressure = pressure.to_vec()?;
+        Self::isotherm(functional, temperature, &pressure, pore, molefracs, solver)
+    }
+
+    /// Calculate an desorption isotherm (starting at high pressure)
+    pub fn desorption_isotherm<S: PoreSpecification<U, D>>(
+        functional: &Rc<DFT<F>>,
+        temperature: QuantityScalar<U>,
+        pressure: &PressureSpecification<U>,
+        pore: &S,
+        molefracs: Option<&Array1<f64>>,
+        solver: Option<&DFTSolver>,
+    ) -> EosResult<Adsorption<U, D, F>> {
+        let pressure = pressure.to_vec()?;
+        let pressure =
+            QuantityArray1::from_shape_fn(pressure.len(), |i| pressure.get(pressure.len() - i - 1));
+        let isotherm = Self::isotherm(functional, temperature, &pressure, pore, molefracs, solver)?;
+        Ok(Adsorption::new(
+            functional,
+            pore,
+            isotherm.profiles.into_iter().rev().collect(),
+        ))
+    }
+
+    /// Calculate an equilibrium isotherm
+    pub fn equilibrium_isotherm<S: PoreSpecification<U, D>>(
+        functional: &Rc<DFT<F>>,
+        temperature: QuantityScalar<U>,
+        pressure: &PressureSpecification<U>,
+        pore: &S,
+        molefracs: Option<&Array1<f64>>,
+        solver: Option<&DFTSolver>,
+    ) -> EosResult<Adsorption<U, D, F>> {
+        let (p_min, p_max) = pressure.p_min_max();
+        let equilibrium = Self::phase_equilibrium(
+            functional,
+            temperature,
+            p_min,
+            p_max,
+            pore,
+            molefracs,
+            solver,
+            SolverOptions::default(),
+        );
+        if let Ok(equilibrium) = equilibrium {
+            let pressure = pressure.equilibrium(&equilibrium)?;
+            let adsorption = Self::isotherm(
+                functional,
+                temperature,
+                &pressure.0,
+                pore,
+                molefracs,
+                solver,
+            )?
+            .profiles;
+            let desorption = Self::isotherm(
+                functional,
+                temperature,
+                &pressure.1,
+                pore,
+                molefracs,
+                solver,
+            )?
+            .profiles;
+            Ok(Adsorption {
+                profiles: adsorption
+                    .into_iter()
+                    .chain(desorption.into_iter().rev())
+                    .collect(),
+                components: functional.components(),
+                dimension: pore.dimension(),
+            })
+        } else {
+            let adsorption = Self::adsorption_isotherm(
+                functional,
+                temperature,
+                pressure,
+                pore,
+                molefracs,
+                solver,
+            )?;
+            let desorption = Self::desorption_isotherm(
+                functional,
+                temperature,
+                pressure,
+                pore,
+                molefracs,
+                solver,
+            )?;
+            let omega_a = adsorption.grand_potential();
+            let omega_d = desorption.grand_potential();
+            let is_ads = Array1::from_shape_fn(adsorption.profiles.len(), |i| {
+                omega_d.get(i).is_nan() || omega_a.get(i) < omega_d.get(i)
+            });
+            let profiles = is_ads
+                .into_iter()
+                .zip(adsorption.profiles.into_iter())
+                .zip(desorption.profiles.into_iter())
+                .map(|((is_ads, a), d)| if is_ads { a } else { d })
+                .collect();
+            Ok(Adsorption::new(functional, pore, profiles))
+        }
+    }
+
+    fn isotherm<S: PoreSpecification<U, D>>(
+        functional: &Rc<DFT<F>>,
+        temperature: QuantityScalar<U>,
+        pressure: &QuantityArray1<U>,
+        pore: &S,
+        molefracs: Option<&Array1<f64>>,
+        solver: Option<&DFTSolver>,
+    ) -> EosResult<Adsorption<U, D, F>> {
+        let moles =
+            functional.validate_moles(molefracs.map(|x| x * U::reference_moles()).as_ref())?;
+        let mut profiles: Vec<EosResult<PoreProfile<U, D, F>>> = Vec::with_capacity(pressure.len());
+
+        // Calculate the external potential once
+        let mut bulk = StateBuilder::new(functional)
+            .temperature(temperature)
+            .pressure(pressure.get(0))
+            .moles(&moles)
+            .build()?;
+        if functional.components() > 1 && !bulk.is_stable(SolverOptions::default())? {
+            bulk = bulk
+                .tp_flash(None, SolverOptions::default(), None)?
+                .vapor()
+                .clone();
+        }
+        let external_potential = pore
+            .initialize(&bulk, None, None)?
+            .profile
+            .external_potential;
+
+        for i in 0..pressure.len() {
+            let mut bulk = StateBuilder::new(functional)
+                .temperature(temperature)
+                .pressure(pressure.get(i))
+                .moles(&moles)
+                .build()?;
+            if functional.components() > 1 && !bulk.is_stable(SolverOptions::default())? {
+                bulk = bulk
+                    .tp_flash(None, SolverOptions::default(), None)?
+                    .vapor()
+                    .clone();
+            }
+            let old_density = if let Some(Ok(l)) = profiles.last() {
+                Some(&l.profile.density)
+            } else {
+                None
+            };
+
+            let p = pore.initialize(&bulk, old_density, Some(&external_potential))?;
+            let p2 = pore.initialize(&bulk, None, Some(&external_potential))?;
+            profiles.push(p.solve(solver).or_else(|_| p2.solve(solver)));
+        }
+
+        Ok(Adsorption::new(functional, pore, profiles))
+    }
+
+    /// Calculate the phase transition from an empty to a filled pore.
+    pub fn phase_equilibrium<S: PoreSpecification<U, D>>(
+        functional: &Rc<DFT<F>>,
+        temperature: QuantityScalar<U>,
+        p_min: QuantityScalar<U>,
+        p_max: QuantityScalar<U>,
+        pore: &S,
+        molefracs: Option<&Array1<f64>>,
+        solver: Option<&DFTSolver>,
+        options: SolverOptions,
+    ) -> EosResult<Adsorption<U, D, F>> {
+        let moles =
+            functional.validate_moles(molefracs.map(|x| x * U::reference_moles()).as_ref())?;
+
+        // calculate density profiles for the minimum and maximum pressure
+        let vapor_bulk = StateBuilder::new(functional)
+            .temperature(temperature)
+            .pressure(p_min)
+            .moles(&moles)
+            .vapor()
+            .build()?;
+        let liquid_bulk = StateBuilder::new(functional)
+            .temperature(temperature)
+            .pressure(p_max)
+            .moles(&moles)
+            .liquid()
+            .build()?;
+
+        let mut vapor = pore.initialize(&vapor_bulk, None, None)?.solve(None)?;
+        let mut liquid = pore.initialize(&liquid_bulk, None, None)?.solve(solver)?;
+
+        // calculate initial value for the molar gibbs energy
+        let nv = vapor.profile.bulk.density
+            * (vapor.profile.moles() * vapor.profile.bulk.molar_volume(Contributions::Total)).sum();
+        let nl = liquid.profile.bulk.density
+            * (liquid.profile.moles() * liquid.profile.bulk.molar_volume(Contributions::Total))
+                .sum();
+        let f = |s: &mut PoreProfile<U, D, F>, n: QuantityScalar<U>| -> EosResult<_> {
+            Ok(s.grand_potential.unwrap()
+                + s.profile.bulk.molar_gibbs_energy(Contributions::Total) * n)
+        };
+        let mut g = (f(&mut liquid, nl)? - f(&mut vapor, nv)?) / (nl - nv);
+
+        // update filled pore with limited step size
+        let mut bulk = StateBuilder::new(functional)
+            .temperature(temperature)
+            .pressure(p_max)
+            .moles(&moles)
+            .vapor()
+            .build()?;
+        let g_liquid = liquid.profile.bulk.molar_gibbs_energy(Contributions::Total);
+        let steps = (10.0 * (g - g_liquid)).to_reduced(g_liquid)?.abs().ceil() as usize;
+        let delta_g = (g - g_liquid) / steps as f64;
+        for i in 1..=steps {
+            let g_i = g_liquid + i as f64 * delta_g;
+            bulk = bulk.update_gibbs_energy(g_i)?;
+            liquid = liquid.update_bulk(&bulk).solve(solver)?;
+        }
+
+        for _ in 0..options.max_iter.unwrap_or(MAX_ITER_ADSORPTION_EQUILIBRIUM) {
+            // update empty pore
+            vapor = vapor.update_bulk(&bulk).solve(None)?;
+
+            // update filled pore
+            liquid = liquid.update_bulk(&bulk).solve(solver)?;
+
+            // calculate moles
+            let nv = vapor.profile.bulk.density
+                * (vapor.profile.moles() * vapor.profile.bulk.molar_volume(Contributions::Total))
+                    .sum();
+            let nl = liquid.profile.bulk.density
+                * (liquid.profile.moles() * liquid.profile.bulk.molar_volume(Contributions::Total))
+                    .sum();
+
+            // check for a trivial solution
+            if nl.to_reduced(nv)? - 1.0 < 1e-5 {
+                return Err(EosError::TrivialSolution);
+            }
+
+            // Newton step
+            let delta_g =
+                (vapor.grand_potential.unwrap() - liquid.grand_potential.unwrap()) / (nv - nl);
+            if delta_g.to_reduced(U::reference_molar_energy())?.abs()
+                < options.tol.unwrap_or(TOL_ADSORPTION_EQUILIBRIUM)
+            {
+                return Ok(Adsorption::new(
+                    functional,
+                    pore,
+                    vec![Ok(vapor), Ok(liquid)],
+                ));
+            }
+            g += delta_g;
+
+            // update bulk phase
+            bulk = bulk.update_gibbs_energy(g)?;
+        }
+        Err(EosError::NotConverged(
+            "Adsorption::phase_equilibrium".into(),
+        ))
+    }
+
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.profiles.len(), |i| match &self.profiles[i] {
+            Ok(p) => {
+                if p.profile.bulk.eos.components() > 1
+                    && !p.profile.bulk.is_stable(SolverOptions::default()).unwrap()
+                {
+                    p.profile
+                        .bulk
+                        .tp_flash(None, SolverOptions::default(), None)
+                        .unwrap()
+                        .vapor()
+                        .pressure(Contributions::Total)
+                } else {
+                    p.profile.bulk.pressure(Contributions::Total)
+                }
+            }
+            Err(_) => f64::NAN * U::reference_pressure(),
+        })
+    }
+
+    pub fn molar_gibbs_energy(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.profiles.len(), |i| match &self.profiles[i] {
+            Ok(p) => {
+                if p.profile.bulk.eos.components() > 1
+                    && !p.profile.bulk.is_stable(SolverOptions::default()).unwrap()
+                {
+                    p.profile
+                        .bulk
+                        .tp_flash(None, SolverOptions::default(), None)
+                        .unwrap()
+                        .vapor()
+                        .molar_gibbs_energy(Contributions::Total)
+                } else {
+                    p.profile.bulk.molar_gibbs_energy(Contributions::Total)
+                }
+            }
+            Err(_) => f64::NAN * U::reference_molar_energy(),
+        })
+    }
+
+    pub fn adsorption(&self) -> QuantityArray2<U> {
+        QuantityArray2::from_shape_fn((self.components, self.profiles.len()), |(j, i)| match &self
+            .profiles[i]
+        {
+            Ok(p) => p.profile.moles().get(j),
+            Err(_) => {
+                f64::NAN * U::reference_density() * U::reference_length().powi(self.dimension)
+            }
+        })
+    }
+
+    pub fn total_adsorption(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.profiles.len(), |i| match &self.profiles[i] {
+            Ok(p) => p.profile.total_moles(),
+            Err(_) => {
+                f64::NAN * U::reference_density() * U::reference_length().powi(self.dimension)
+            }
+        })
+    }
+
+    pub fn grand_potential(&self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.profiles.len(), |i| match &self.profiles[i] {
+            Ok(p) => p.grand_potential.unwrap(),
+            Err(_) => {
+                f64::NAN * U::reference_pressure() * U::reference_length().powi(self.dimension)
+            }
+        })
+    }
+}

--- a/feos-dft/src/adsorption/pore.rs
+++ b/feos-dft/src/adsorption/pore.rs
@@ -1,0 +1,481 @@
+use crate::adsorption::{ExternalPotential, FluidParameters};
+use crate::convolver::ConvolverFFT;
+use crate::functional::{HelmholtzEnergyFunctional, MoleculeShape, DFT};
+use crate::functional_contribution::FunctionalContribution;
+use crate::geometry::{Axis, Geometry, Grid};
+use crate::profile::{DFTProfile, CUTOFF_RADIUS, MAX_POTENTIAL};
+use crate::solver::DFTSolver;
+use feos_core::{Contributions, EosResult, EosUnit, State, StateBuilder};
+use ndarray::prelude::*;
+use ndarray::Axis as Axis_nd;
+use ndarray::{RemoveAxis, Zip};
+use ndarray_stats::QuantileExt;
+use quantity::{QuantityArray, QuantityArray2, QuantityArray4, QuantityScalar};
+use std::rc::Rc;
+
+const POTENTIAL_OFFSET: f64 = 2.0;
+const DEFAULT_GRID_POINTS: usize = 2048;
+
+/// Parameters required to specify a 1D pore.
+pub struct Pore1D<U> {
+    pub geometry: Geometry,
+    pub pore_size: QuantityScalar<U>,
+    pub potential: ExternalPotential<U>,
+    pub n_grid: Option<usize>,
+    pub potential_cutoff: Option<f64>,
+}
+
+impl<U: EosUnit> Pore1D<U> {
+    pub fn new(
+        geometry: Geometry,
+        pore_size: QuantityScalar<U>,
+        potential: ExternalPotential<U>,
+        n_grid: Option<usize>,
+        potential_cutoff: Option<f64>,
+    ) -> Self {
+        Self {
+            geometry,
+            pore_size,
+            potential,
+            n_grid,
+            potential_cutoff,
+        }
+    }
+}
+
+/// Parameters required to specify a 3D pore.
+pub struct Pore3D<U> {
+    system_size: [QuantityScalar<U>; 3],
+    n_grid: [usize; 3],
+    coordinates: QuantityArray2<U>,
+    sigma_ss: Array1<f64>,
+    epsilon_k_ss: Array1<f64>,
+    potential_cutoff: Option<f64>,
+    cutoff_radius: Option<QuantityScalar<U>>,
+}
+
+impl<U> Pore3D<U> {
+    pub fn new(
+        system_size: [QuantityScalar<U>; 3],
+        n_grid: [usize; 3],
+        coordinates: QuantityArray2<U>,
+        sigma_ss: Array1<f64>,
+        epsilon_k_ss: Array1<f64>,
+        potential_cutoff: Option<f64>,
+        cutoff_radius: Option<QuantityScalar<U>>,
+    ) -> Self {
+        Self {
+            system_size,
+            n_grid,
+            coordinates,
+            sigma_ss,
+            epsilon_k_ss,
+            potential_cutoff,
+            cutoff_radius,
+        }
+    }
+}
+
+/// Trait for the generic implementation of adsorption applications.
+pub trait PoreSpecification<U: EosUnit, D: Dimension> {
+    /// Initialize a new single pore.
+    fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
+        &self,
+        bulk: &State<U, DFT<F>>,
+        density: Option<&QuantityArray<U, D::Larger>>,
+        external_potential: Option<&Array<f64, D::Larger>>,
+    ) -> EosResult<PoreProfile<U, D, F>>;
+
+    /// Return the number of spatial dimensions of the pore.
+    fn dimension(&self) -> i32;
+
+    /// Return the pore volume using Helium at 298 K as reference.
+    fn pore_volume(&self) -> EosResult<QuantityScalar<U>>
+    where
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let bulk = StateBuilder::new(&Rc::new(Helium::new()))
+            .temperature(298.0 * U::reference_temperature())
+            .density(U::reference_density())
+            .build()?;
+        let pore = self.initialize(&bulk, None, None)?;
+        let pot = pore
+            .profile
+            .external_potential
+            .index_axis(Axis(0), 0)
+            .mapv(|v| (-v).exp())
+            * U::reference_temperature()
+            / U::reference_temperature();
+        Ok(pore.profile.integrate(&pot))
+    }
+}
+
+/// Density profile and properties of a confined system in arbitrary dimensions.
+pub struct PoreProfile<U, D: Dimension, F> {
+    pub profile: DFTProfile<U, D, F>,
+    pub grand_potential: Option<QuantityScalar<U>>,
+    pub interfacial_tension: Option<QuantityScalar<U>>,
+}
+
+/// Density profile and properties of a 1D confined system.
+pub type PoreProfile1D<U, F> = PoreProfile<U, Ix1, F>;
+/// Density profile and properties of a 3D confined system.
+pub type PoreProfile3D<U, F> = PoreProfile<U, Ix3, F>;
+
+impl<U: Copy, D: Dimension, F> Clone for PoreProfile<U, D, F> {
+    fn clone(&self) -> Self {
+        Self {
+            profile: self.profile.clone(),
+            grand_potential: self.grand_potential,
+            interfacial_tension: self.interfacial_tension,
+        }
+    }
+}
+
+impl<U: EosUnit, D: Dimension + RemoveAxis + 'static, F: HelmholtzEnergyFunctional>
+    PoreProfile<U, D, F>
+where
+    D::Larger: Dimension<Smaller = D>,
+    D::Smaller: Dimension<Larger = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    pub fn solve_inplace(&mut self, solver: Option<&DFTSolver>, debug: bool) -> EosResult<()> {
+        // Solve the profile
+        self.profile.solve(solver, debug)?;
+
+        // calculate grand potential density
+        let omega = self.profile.grand_potential()?;
+        self.grand_potential = Some(omega);
+
+        // calculate interfacial tension
+        self.interfacial_tension =
+            Some(omega + self.profile.bulk.pressure(Contributions::Total) * self.profile.volume());
+
+        Ok(())
+    }
+
+    pub fn solve(mut self, solver: Option<&DFTSolver>) -> EosResult<Self> {
+        self.solve_inplace(solver, false)?;
+        Ok(self)
+    }
+
+    pub fn update_bulk(mut self, bulk: &State<U, DFT<F>>) -> Self {
+        self.profile.bulk = bulk.clone();
+        self.grand_potential = None;
+        self.interfacial_tension = None;
+        self
+    }
+}
+
+impl<U: EosUnit> PoreSpecification<U, Ix1> for Pore1D<U> {
+    fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
+        &self,
+        bulk: &State<U, DFT<F>>,
+        density: Option<&QuantityArray2<U>>,
+        external_potential: Option<&Array2<f64>>,
+    ) -> EosResult<PoreProfile1D<U, F>> {
+        let dft: &F = &bulk.eos;
+        let n_grid = self.n_grid.unwrap_or(DEFAULT_GRID_POINTS);
+
+        let axis = match self.geometry {
+            Geometry::Cartesian => {
+                let potential_offset = POTENTIAL_OFFSET * bulk.eos.sigma_ff().max().unwrap();
+                Axis::new_cartesian(n_grid, 0.5 * self.pore_size, Some(potential_offset))?
+            }
+            Geometry::Cylindrical => Axis::new_polar(n_grid, self.pore_size)?,
+            Geometry::Spherical => Axis::new_spherical(n_grid, self.pore_size)?,
+        };
+
+        // calculate external potential
+        let external_potential = external_potential.map_or_else(
+            || {
+                external_potential_1d(
+                    self.pore_size,
+                    bulk.temperature,
+                    &self.potential,
+                    dft,
+                    &axis,
+                    self.potential_cutoff,
+                )
+            },
+            |e| Ok(e.clone()),
+        )?;
+
+        // initialize convolver
+        let grid = Grid::new_1d(axis);
+        let t = bulk.temperature.to_reduced(U::reference_temperature())?;
+        let weight_functions = dft.weight_functions(t);
+        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
+
+        Ok(PoreProfile {
+            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), density)?,
+            grand_potential: None,
+            interfacial_tension: None,
+        })
+    }
+
+    fn dimension(&self) -> i32 {
+        self.geometry.dimension()
+    }
+}
+
+impl<U: EosUnit> PoreSpecification<U, Ix3> for Pore3D<U> {
+    fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
+        &self,
+        bulk: &State<U, DFT<F>>,
+        density: Option<&QuantityArray4<U>>,
+        external_potential: Option<&Array4<f64>>,
+    ) -> EosResult<PoreProfile3D<U, F>> {
+        let dft: &F = &bulk.eos;
+
+        // generate grid
+        let x = Axis::new_cartesian(self.n_grid[0], self.system_size[0], None)?;
+        let y = Axis::new_cartesian(self.n_grid[1], self.system_size[1], None)?;
+        let z = Axis::new_cartesian(self.n_grid[2], self.system_size[2], None)?;
+
+        // move center of geometry of solute to box center
+        let coordinates = Array2::from_shape_fn(self.coordinates.raw_dim(), |(i, j)| {
+            (self.coordinates.get((i, j)))
+                .to_reduced(U::reference_length())
+                .unwrap()
+        });
+
+        // temperature
+        let t = bulk.temperature.to_reduced(U::reference_temperature())?;
+
+        // calculate external potential
+        let external_potential = external_potential.map_or_else(
+            || {
+                external_potential_3d(
+                    dft,
+                    [&x, &y, &z],
+                    self.system_size,
+                    coordinates,
+                    &self.sigma_ss,
+                    &self.epsilon_k_ss,
+                    self.cutoff_radius,
+                    self.potential_cutoff,
+                    t,
+                )
+            },
+            |e| Ok(e.clone()),
+        )?;
+
+        // initialize convolver
+        let grid = Grid::Periodical3(x, y, z);
+        let weight_functions = dft.weight_functions(t);
+        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
+
+        Ok(PoreProfile {
+            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), density)?,
+            grand_potential: None,
+            interfacial_tension: None,
+        })
+    }
+
+    fn dimension(&self) -> i32 {
+        3
+    }
+}
+
+fn external_potential_1d<U: EosUnit, P: FluidParameters>(
+    pore_width: QuantityScalar<U>,
+    temperature: QuantityScalar<U>,
+    potential: &ExternalPotential<U>,
+    fluid_parameters: &P,
+    axis: &Axis,
+    potential_cutoff: Option<f64>,
+) -> EosResult<Array2<f64>> {
+    let potential_cutoff = potential_cutoff.unwrap_or(MAX_POTENTIAL);
+    let effective_pore_size = match axis.geometry {
+        Geometry::Spherical => pore_width.to_reduced(U::reference_length())?,
+        Geometry::Cylindrical => pore_width.to_reduced(U::reference_length())?,
+        Geometry::Cartesian => 0.5 * pore_width.to_reduced(U::reference_length())?,
+    };
+    let t = temperature.to_reduced(U::reference_temperature())?;
+    let mut external_potential = match &axis.geometry {
+        Geometry::Cartesian => {
+            potential.calculate_cartesian_potential(
+                &(effective_pore_size + &axis.grid),
+                fluid_parameters,
+                t,
+            ) + &potential.calculate_cartesian_potential(
+                &(effective_pore_size - &axis.grid),
+                fluid_parameters,
+                t,
+            )
+        }
+        Geometry::Spherical => potential.calculate_spherical_potential(
+            &axis.grid,
+            effective_pore_size,
+            fluid_parameters,
+            t,
+        ),
+        Geometry::Cylindrical => potential.calculate_cylindrical_potential(
+            &axis.grid,
+            effective_pore_size,
+            fluid_parameters,
+            t,
+        ),
+    } / t;
+
+    for (i, &z) in axis.grid.iter().enumerate() {
+        if z > effective_pore_size {
+            external_potential
+                .index_axis_mut(Axis_nd(1), i)
+                .fill(potential_cutoff);
+        }
+    }
+    external_potential.map_inplace(|x| {
+        if *x > potential_cutoff {
+            *x = potential_cutoff
+        }
+    });
+    Ok(external_potential)
+}
+
+pub fn external_potential_3d<U: EosUnit, F: FluidParameters>(
+    functional: &F,
+    axis: [&Axis; 3],
+    system_size: [QuantityScalar<U>; 3],
+    coordinates: Array2<f64>,
+    sigma_ss: &Array1<f64>,
+    epsilon_ss: &Array1<f64>,
+    cutoff_radius: Option<QuantityScalar<U>>,
+    potential_cutoff: Option<f64>,
+    reduced_temperature: f64,
+) -> EosResult<Array4<f64>> {
+    // allocate external potential
+    let m = functional.m();
+    let mut external_potential = Array4::zeros((
+        m.len(),
+        axis[0].grid.len(),
+        axis[1].grid.len(),
+        axis[2].grid.len(),
+    ));
+
+    let system_size = [
+        system_size[0].to_reduced(U::reference_length())?,
+        system_size[1].to_reduced(U::reference_length())?,
+        system_size[2].to_reduced(U::reference_length())?,
+    ];
+
+    let cutoff_radius = cutoff_radius
+        .unwrap_or(CUTOFF_RADIUS * U::reference_length())
+        .to_reduced(U::reference_length())?;
+
+    // square cut-off radius
+    let cutoff_radius2 = cutoff_radius.powi(2);
+
+    // calculate external potential
+    let sigma_ff = functional.sigma_ff();
+    let epsilon_k_ff = functional.epsilon_k_ff();
+
+    Zip::indexed(&mut external_potential).par_for_each(|(i, ix, iy, iz), u| {
+        let distance2 = calculate_distance2(
+            [&axis[0].grid[ix], &axis[1].grid[iy], &axis[2].grid[iz]],
+            &coordinates,
+            system_size,
+        );
+        let sigma_sf = sigma_ss.mapv(|s| (s + sigma_ff[i]) / 2.0);
+        let epsilon_sf = epsilon_ss.mapv(|e| (e * epsilon_k_ff[i]).sqrt());
+        *u = (0..sigma_ss.len())
+            .map(|alpha| {
+                m[i] * evaluate(
+                    distance2[alpha],
+                    sigma_sf[alpha],
+                    epsilon_sf[alpha],
+                    cutoff_radius2,
+                )
+            })
+            .sum::<f64>()
+            / reduced_temperature
+    });
+
+    let potential_cutoff = potential_cutoff.unwrap_or(MAX_POTENTIAL);
+    external_potential.map_inplace(|x| {
+        if *x > potential_cutoff {
+            *x = potential_cutoff
+        }
+    });
+
+    Ok(external_potential)
+}
+
+/// Evaluate LJ12-6 potential between solid site "alpha" and fluid segment
+fn evaluate(distance2: f64, sigma: f64, epsilon: f64, cutoff_radius2: f64) -> f64 {
+    let sigma_r = sigma.powi(2) / distance2;
+
+    let potential: f64 = if distance2 > cutoff_radius2 {
+        0.0
+    } else if distance2 == 0.0 {
+        f64::INFINITY
+    } else {
+        4.0 * epsilon * (sigma_r.powi(6) - sigma_r.powi(3))
+    };
+
+    potential
+}
+
+/// Evaluate the squared euclidian distance between a point and the coordinates of all solid atoms.
+fn calculate_distance2(
+    point: [&f64; 3],
+    coordinates: &Array2<f64>,
+    system_size: [f64; 3],
+) -> Array1<f64> {
+    Array1::from_shape_fn(coordinates.ncols(), |i| {
+        let mut rx = coordinates[[0, i]] - point[0];
+        let mut ry = coordinates[[1, i]] - point[1];
+        let mut rz = coordinates[[2, i]] - point[2];
+
+        rx -= system_size[0] * (rx / system_size[0]).round();
+        ry -= system_size[1] * (ry / system_size[1]).round();
+        rz -= system_size[2] * (rz / system_size[2]).round();
+
+        rx.powi(2) + ry.powi(2) + rz.powi(2)
+    })
+}
+
+const EPSILON_HE: f64 = 10.9;
+const SIGMA_HE: f64 = 2.64;
+
+struct Helium {
+    epsilon: Array1<f64>,
+    sigma: Array1<f64>,
+}
+
+impl Helium {
+    fn new() -> DFT<Self> {
+        let epsilon = arr1(&[EPSILON_HE]);
+        let sigma = arr1(&[SIGMA_HE]);
+        (Self { epsilon, sigma }).into()
+    }
+}
+
+impl HelmholtzEnergyFunctional for Helium {
+    fn contributions(&self) -> &[Box<dyn FunctionalContribution>] {
+        &[]
+    }
+
+    fn subset(&self, _: &[usize]) -> DFT<Self> {
+        Self::new()
+    }
+
+    fn compute_max_density(&self, _: &Array1<f64>) -> f64 {
+        1.0
+    }
+
+    fn molecule_shape(&self) -> MoleculeShape {
+        MoleculeShape::Spherical(1)
+    }
+}
+
+impl FluidParameters for Helium {
+    fn epsilon_k_ff(&self) -> Array1<f64> {
+        self.epsilon.clone()
+    }
+
+    fn sigma_ff(&self) -> &Array1<f64> {
+        &self.sigma
+    }
+}

--- a/feos-dft/src/convolver/mod.rs
+++ b/feos-dft/src/convolver/mod.rs
@@ -1,0 +1,641 @@
+use crate::geometry::{Axis, Geometry, Grid};
+use crate::weight_functions::*;
+use ndarray::prelude::*;
+use ndarray::{Axis as Axis_nd, RemoveAxis, ScalarOperand, Slice};
+use num_dual::*;
+use rustdct::DctNum;
+use std::ops::{AddAssign, MulAssign, SubAssign};
+use std::rc::Rc;
+
+mod periodic_convolver;
+mod transform;
+pub use periodic_convolver::PeriodicConvolver;
+use transform::*;
+
+/// Trait for numerical convolutions for DFT.
+///
+/// Covers calculation of weighted densities & functional derivatives
+/// from density profiles & profiles of the partial derivatives of the
+/// Helmholtz energy functional.
+///
+/// Parametrized over data types `T` and dimension of the problem `D`.
+pub trait Convolver<T, D: Dimension> {
+    /// Convolve the profile with the given weight function.
+    fn convolve(&self, profile: Array<T, D>, weight_function: &WeightFunction<T>) -> Array<T, D>;
+
+    /// Calculate weighted densities via convolution from density profiles.
+    fn weighted_densities(&self, density: &Array<T, D::Larger>) -> Vec<Array<T, D::Larger>>;
+
+    /// Calculate the functional derivative via convolution from partial derivatives
+    /// of the Helmholtz energy functional.
+    fn functional_derivative(
+        &self,
+        partial_derivatives: &[Array<T, D::Larger>],
+    ) -> Array<T, D::Larger>;
+}
+
+/// Base structure to hold either information about the weight function through
+/// `WeightFunctionInfo` or the weight functions themselves via
+/// `FFTWeightFunctions`.
+#[derive(Debug, Clone)]
+struct FFTWeightFunctions<T, D: Dimension> {
+    /// Either number of components for simple functionals
+    /// or idividual segments for group contribution methods
+    pub(crate) segments: usize,
+    /// Flag if local density is required in the functional
+    pub(crate) local_density: bool,
+    /// Container for scalar component-wise weighted densities
+    pub(crate) scalar_component_weighted_densities: Vec<Array<T, D::Larger>>,
+    /// Container for vector component-wise weighted densities
+    pub(crate) vector_component_weighted_densities: Vec<Array<T, <D::Larger as Dimension>::Larger>>,
+    /// Container for scalar FMT weighted densities
+    pub(crate) scalar_fmt_weighted_densities: Vec<Array<T, D::Larger>>,
+    /// Container for vector FMT weighted densities
+    pub(crate) vector_fmt_weighted_densities: Vec<Array<T, <D::Larger as Dimension>::Larger>>,
+}
+
+impl<T, D: Dimension> FFTWeightFunctions<T, D> {
+    /// Calculates the total number of weighted densities for each functional
+    /// from multiple weight functions depending on dimension.
+    pub fn n_weighted_densities(&self, dimensions: usize) -> usize {
+        (if self.local_density { self.segments } else { 0 })
+            + self.scalar_component_weighted_densities.len() * self.segments
+            + self.vector_component_weighted_densities.len() * self.segments * dimensions
+            + self.scalar_fmt_weighted_densities.len()
+            + self.vector_fmt_weighted_densities.len() * dimensions
+    }
+}
+
+/// Convolver for 1-D, 2-D & 3-D systems using FFT algorithms to efficiently
+/// compute convolutions in Fourier space.
+///
+/// Parametrized over the data type `T` and the dimension `D`.
+#[derive(Clone)]
+pub struct ConvolverFFT<T, D: Dimension> {
+    /// k vectors
+    k_abs: Array<f64, D>,
+    /// Vector of weight functions for each component in multiple dimensions.
+    weight_functions: Vec<FFTWeightFunctions<T, D>>,
+    /// Lanczos sigma factor
+    lanczos_sigma: Option<Array<f64, D>>,
+    /// Possibly curvilinear Fourier transform in the first dimension
+    transform: Rc<dyn FourierTransform<T>>,
+    /// Vector of additional cartesian Fourier transforms in the other dimensions
+    cartesian_transforms: Vec<Rc<CartesianTransform<T>>>,
+}
+
+impl<T, D: Dimension + RemoveAxis + 'static> ConvolverFFT<T, D>
+where
+    T: DctNum + DualNum<f64> + ScalarOperand,
+    D::Larger: Dimension<Smaller = D>,
+    D::Smaller: Dimension<Larger = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    /// Create the appropriate FFT convolver for the given grid.
+    pub fn plan(
+        grid: &Grid,
+        weight_functions: &[WeightFunctionInfo<T>],
+        lanczos: Option<i32>,
+    ) -> Rc<dyn Convolver<T, D>> {
+        match grid {
+            Grid::Polar(r) => CurvilinearConvolver::new(r, &[], weight_functions, lanczos),
+            Grid::Spherical(r) => CurvilinearConvolver::new(r, &[], weight_functions, lanczos),
+            Grid::Cartesian1(z) => Self::new(Some(z), &[], weight_functions, lanczos),
+            Grid::Cylindrical { r, z } => {
+                CurvilinearConvolver::new(r, &[z], weight_functions, lanczos)
+            }
+            Grid::Cartesian2(x, y) => Self::new(Some(x), &[y], weight_functions, lanczos),
+            Grid::Periodical2(x, y) => PeriodicConvolver::new(&[x, y], weight_functions, lanczos),
+            Grid::Cartesian3(x, y, z) => Self::new(Some(x), &[y, z], weight_functions, lanczos),
+            Grid::Periodical3(x, y, z) => {
+                PeriodicConvolver::new(&[x, y, z], weight_functions, lanczos)
+            }
+        }
+    }
+}
+
+impl<T, D: Dimension + 'static> ConvolverFFT<T, D>
+where
+    T: DctNum + DualNum<f64> + ScalarOperand,
+    D::Larger: Dimension<Smaller = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    fn new(
+        axis: Option<&Axis>,
+        cartesian_axes: &[&Axis],
+        weight_functions: &[WeightFunctionInfo<T>],
+        lanczos: Option<i32>,
+    ) -> Rc<dyn Convolver<T, D>> {
+        // initialize the Fourier transform
+        let mut cartesian_transforms = Vec::with_capacity(cartesian_axes.len());
+        let mut k_vec = Vec::with_capacity(cartesian_axes.len() + 1);
+        let mut lengths = Vec::with_capacity(cartesian_axes.len() + 1);
+        let (transform, k_x) = match axis {
+            Some(axis) => match axis.geometry {
+                Geometry::Cartesian => CartesianTransform::new(axis),
+                Geometry::Cylindrical => PolarTransform::new(axis),
+                Geometry::Spherical => SphericalTransform::new(axis),
+            },
+            None => NoTransform::new(),
+        };
+        k_vec.push(k_x);
+        lengths.push(axis.map_or(1.0, |axis| axis.length()));
+        for ax in cartesian_axes {
+            let (transform, k_x) = CartesianTransform::new_cartesian(ax);
+            cartesian_transforms.push(transform);
+            k_vec.push(k_x);
+            lengths.push(ax.length());
+        }
+
+        // Calculate the full k vectors
+        let mut dim = vec![k_vec.len()];
+        k_vec.iter().for_each(|k_x| dim.push(k_x.len()));
+        let mut k: Array<_, D::Larger> = Array::zeros(dim).into_dimensionality().unwrap();
+        let mut k_abs = Array::zeros(k.raw_dim().remove_axis(Axis(0)));
+        for (i, (mut k_i, k_x)) in k.outer_iter_mut().zip(k_vec.iter()).enumerate() {
+            k_i.lanes_mut(Axis_nd(i))
+                .into_iter()
+                .for_each(|mut l| l.assign(k_x));
+            k_abs.add_assign(&k_i.mapv(|k| k.powi(2)));
+        }
+        k_abs.map_inplace(|k| *k = k.sqrt());
+
+        // Lanczos sigma factor
+        let lanczos_sigma = lanczos.map(|exp| {
+            let mut lanczos = Array::ones(k_abs.raw_dim());
+            for (i, (k_x, &l)) in k_vec.iter().zip(lengths.iter()).enumerate() {
+                let points = k_x.len();
+                let m2 = if points % 2 == 0 {
+                    points as f64 + 2.0
+                } else {
+                    points as f64 + 1.0
+                };
+                let l_x = k_x.mapv(|k| (k * l / m2).sph_j0().powi(exp));
+                for mut l in lanczos.lanes_mut(Axis_nd(i)) {
+                    l.mul_assign(&l_x);
+                }
+            }
+            lanczos
+        });
+
+        // calculate weight functions in Fourier space and weight constants
+        let mut fft_weight_functions = Vec::with_capacity(weight_functions.len());
+        for wf in weight_functions {
+            // Calculates the weight functions values from `k_abs`
+            // Pre-allocation of empty `Vec`
+            let mut scal_comp = Vec::with_capacity(wf.scalar_component_weighted_densities.len());
+            // Filling array with scalar component-wise weight functions
+            for wf_i in &wf.scalar_component_weighted_densities {
+                scal_comp.push(wf_i.fft_scalar_weight_functions(&k_abs, &lanczos_sigma));
+            }
+
+            // Pre-allocation of empty `Vec`
+            let mut vec_comp = Vec::with_capacity(wf.vector_component_weighted_densities.len());
+            // Filling array with vector-valued component-wise weight functions
+            for wf_i in &wf.vector_component_weighted_densities {
+                vec_comp.push(wf_i.fft_vector_weight_functions(&k_abs, &k, &lanczos_sigma));
+            }
+
+            // Pre-allocation of empty `Vec`
+            let mut scal_fmt = Vec::with_capacity(wf.scalar_fmt_weighted_densities.len());
+            // Filling array with scalar FMT weight functions
+            for wf_i in &wf.scalar_fmt_weighted_densities {
+                scal_fmt.push(wf_i.fft_scalar_weight_functions(&k_abs, &lanczos_sigma));
+            }
+
+            // Pre-allocation of empty `Vec`
+            let mut vec_fmt = Vec::with_capacity(wf.vector_fmt_weighted_densities.len());
+            // Filling array with vector-valued FMT weight functions
+            for wf_i in &wf.vector_fmt_weighted_densities {
+                vec_fmt.push(wf_i.fft_vector_weight_functions(&k_abs, &k, &lanczos_sigma));
+            }
+
+            // Initializing `FFTWeightFunctions` structure
+            fft_weight_functions.push(FFTWeightFunctions::<_, D> {
+                segments: wf.component_index.len(),
+                local_density: wf.local_density,
+                scalar_component_weighted_densities: scal_comp,
+                vector_component_weighted_densities: vec_comp,
+                scalar_fmt_weighted_densities: scal_fmt,
+                vector_fmt_weighted_densities: vec_fmt,
+            });
+        }
+
+        // Return `FFTConvolver<T, D>`
+        Rc::new(Self {
+            k_abs,
+            weight_functions: fft_weight_functions,
+            lanczos_sigma,
+            transform,
+            cartesian_transforms,
+        })
+    }
+}
+
+impl<T, D: Dimension> ConvolverFFT<T, D>
+where
+    T: DctNum + DualNum<f64> + ScalarOperand,
+    D::Larger: Dimension<Smaller = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    fn forward_transform(&self, f: ArrayView<T, D>, vector_index: Option<usize>) -> Array<T, D> {
+        let mut dim = vec![self.k_abs.shape()[0]];
+        f.shape().iter().skip(1).for_each(|&d| dim.push(d));
+        let mut result: Array<_, D> = Array::zeros(dim.clone()).into_dimensionality().unwrap();
+        for (f, r) in f
+            .lanes(Axis_nd(0))
+            .into_iter()
+            .zip(result.lanes_mut(Axis_nd(0)))
+        {
+            self.transform
+                .forward_transform(f, r, vector_index.map_or(true, |ind| ind != 0));
+        }
+        for (i, transform) in self.cartesian_transforms.iter().enumerate() {
+            dim[i + 1] = self.k_abs.shape()[i + 1];
+            let mut res: Array<_, D> = Array::zeros(dim.clone()).into_dimensionality().unwrap();
+            for (f, r) in result
+                .lanes(Axis_nd(i + 1))
+                .into_iter()
+                .zip(res.lanes_mut(Axis_nd(i + 1)))
+            {
+                transform.forward_transform(f, r, vector_index.map_or(true, |ind| ind != i + 1));
+            }
+            result = res;
+        }
+
+        result
+    }
+
+    fn forward_transform_comps(
+        &self,
+        f: ArrayView<T, D::Larger>,
+        vector_index: Option<usize>,
+    ) -> Array<T, D::Larger> {
+        let mut dim = vec![f.shape()[0]];
+        self.k_abs.shape().iter().for_each(|&d| dim.push(d));
+        let mut result = Array::zeros(dim).into_dimensionality().unwrap();
+        for (f, mut r) in f.outer_iter().zip(result.outer_iter_mut()) {
+            r.assign(&self.forward_transform(f, vector_index));
+        }
+        result
+    }
+
+    fn back_transform(
+        &self,
+        mut f: ArrayViewMut<T, D>,
+        mut result: ArrayViewMut<T, D>,
+        vector_index: Option<usize>,
+    ) {
+        let mut dim = vec![result.shape()[0]];
+        f.shape().iter().skip(1).for_each(|&d| dim.push(d));
+        let mut res: Array<_, D> = Array::zeros(dim.clone()).into_dimensionality().unwrap();
+        for (f, r) in f
+            .lanes_mut(Axis_nd(0))
+            .into_iter()
+            .zip(res.lanes_mut(Axis_nd(0)))
+        {
+            self.transform
+                .back_transform(f, r, vector_index.map_or(true, |ind| ind != 0));
+        }
+        for (i, transform) in self.cartesian_transforms.iter().enumerate() {
+            dim[i + 1] = result.shape()[i + 1];
+            let mut res2: Array<_, D> = Array::zeros(dim.clone()).into_dimensionality().unwrap();
+            for (f, r) in res
+                .lanes_mut(Axis_nd(i + 1))
+                .into_iter()
+                .zip(res2.lanes_mut(Axis_nd(i + 1)))
+            {
+                transform.back_transform(f, r, vector_index.map_or(true, |ind| ind != i + 1));
+            }
+            res = res2;
+        }
+
+        result.assign(&res);
+    }
+
+    fn back_transform_comps(
+        &self,
+        mut f: Array<T, D::Larger>,
+        mut result: ArrayViewMut<T, D::Larger>,
+        vector_index: Option<usize>,
+    ) {
+        for (f, r) in f.outer_iter_mut().zip(result.outer_iter_mut()) {
+            self.back_transform(f, r, vector_index);
+        }
+    }
+}
+
+impl<T, D: Dimension> Convolver<T, D> for ConvolverFFT<T, D>
+where
+    T: DctNum + ScalarOperand + DualNum<f64>,
+    D::Larger: Dimension<Smaller = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    fn convolve(&self, profile: Array<T, D>, weight_function: &WeightFunction<T>) -> Array<T, D> {
+        // Forward transform
+        let f_k = self.forward_transform(profile.view(), None);
+
+        // calculate weight function
+        let w = weight_function
+            .fft_scalar_weight_functions(&self.k_abs, &self.lanczos_sigma)
+            .index_axis_move(Axis(0), 0);
+
+        // Inverse transform
+        let mut result = Array::zeros(profile.raw_dim());
+        self.back_transform((f_k * w).view_mut(), result.view_mut(), None);
+        result
+    }
+
+    fn weighted_densities(&self, density: &Array<T, D::Larger>) -> Vec<Array<T, D::Larger>> {
+        // Applying FFT to each row of the matrix `rho` saving the result in `rho_k`
+        let rho_k = self.forward_transform_comps(density.view(), None);
+
+        // Iterate over all contributions
+        let mut weighted_densities_vec = Vec::with_capacity(self.weight_functions.len());
+        for wf in &self.weight_functions {
+            // number of weighted densities
+            let n_wd = wf.n_weighted_densities(density.ndim() - 1);
+
+            // Allocating new array for intended weighted densities
+            let mut dim = vec![n_wd];
+            density.shape().iter().skip(1).for_each(|&d| dim.push(d));
+            let mut weighted_densities = Array::zeros(dim).into_dimensionality().unwrap();
+
+            // Initilaizing row index for non-local weighted densities
+            let mut k = 0;
+
+            // Assigning possible local densities to the front of the array
+            if wf.local_density {
+                weighted_densities
+                    .slice_axis_mut(Axis(0), Slice::from(0..wf.segments))
+                    .assign(density);
+                k += wf.segments;
+            }
+
+            // Calculating weighted densities {scalar, component}
+            for wf_i in &wf.scalar_component_weighted_densities {
+                self.back_transform_comps(
+                    &rho_k * wf_i,
+                    weighted_densities.slice_axis_mut(Axis(0), Slice::from(k..k + wf.segments)),
+                    None,
+                );
+                k += wf.segments;
+            }
+
+            // Calculating weighted densities {vector, component}
+            for wf_i in &wf.vector_component_weighted_densities {
+                for (i, wf_i) in wf_i.outer_iter().enumerate() {
+                    self.back_transform_comps(
+                        &rho_k * &wf_i,
+                        weighted_densities.slice_axis_mut(Axis(0), Slice::from(k..k + wf.segments)),
+                        Some(i),
+                    );
+                    k += wf.segments;
+                }
+            }
+
+            // Calculating weighted densities {scalar, FMT}
+            for wf_i in &wf.scalar_fmt_weighted_densities {
+                self.back_transform(
+                    (&rho_k * wf_i).sum_axis(Axis(0)).view_mut(),
+                    weighted_densities.index_axis_mut(Axis(0), k),
+                    None,
+                );
+                k += 1;
+            }
+
+            // Calculating weighted densities {vector, FMT}
+            for wf_i in &wf.vector_fmt_weighted_densities {
+                for (i, wf_i) in wf_i.outer_iter().enumerate() {
+                    self.back_transform(
+                        (&rho_k * &wf_i).sum_axis(Axis(0)).view_mut(),
+                        weighted_densities.index_axis_mut(Axis(0), k),
+                        Some(i),
+                    );
+                    k += 1;
+                }
+            }
+
+            // add weighted densities for this contribution to the result
+            weighted_densities_vec.push(weighted_densities);
+        }
+        // Return
+        weighted_densities_vec
+    }
+
+    fn functional_derivative(
+        &self,
+        partial_derivatives: &[Array<T, D::Larger>],
+    ) -> Array<T, D::Larger> {
+        // Allocate arrays for the result, the local contribution to the functional derivative,
+        // the functional derivative in Fourier space, and the bulk contributions
+        let mut dim = vec![self.weight_functions[0].segments];
+        partial_derivatives[0]
+            .shape()
+            .iter()
+            .skip(1)
+            .for_each(|&d| dim.push(d));
+        let mut functional_deriv = Array::zeros(dim).into_dimensionality().unwrap();
+        let mut functional_deriv_local = Array::zeros(functional_deriv.raw_dim());
+        let mut dim = vec![self.weight_functions[0].segments];
+        self.k_abs.shape().iter().for_each(|&d| dim.push(d));
+        let mut functional_deriv_k = Array::zeros(dim).into_dimensionality().unwrap();
+
+        // Iterate over all contributions
+        for (pd, wf) in partial_derivatives.iter().zip(&self.weight_functions) {
+            // Multiplication of `partial_derivatives` with the weight functions in
+            // Fourier space (convolution in real space); summation leads to
+            // functional derivative: the rows in the array are selected from the
+            // running variable `k` with the number of rows needed for this
+            // particular contribution
+            let mut k = 0;
+
+            // If local densities are present, their contributions are added directly
+            if wf.local_density {
+                functional_deriv_local += &pd.slice_axis(Axis(0), Slice::from(..wf.segments));
+                k += wf.segments;
+            }
+
+            // Convolution of functional derivatives {scalar, component}
+            for wf_i in &wf.scalar_component_weighted_densities {
+                let pd_k = self.forward_transform_comps(
+                    pd.slice_axis(Axis(0), Slice::from(k..k + wf.segments)),
+                    None,
+                );
+                functional_deriv_k.add_assign(&(&pd_k * wf_i));
+                k += wf.segments;
+            }
+
+            // Convolution of functional derivatives {vector, component}
+            for wf_i in &wf.vector_component_weighted_densities {
+                for (i, wf_i) in wf_i.outer_iter().enumerate() {
+                    let pd_k = self.forward_transform_comps(
+                        pd.slice_axis(Axis(0), Slice::from(k..k + wf.segments)),
+                        Some(i),
+                    );
+                    functional_deriv_k.add_assign(&(pd_k * &wf_i));
+                    k += wf.segments;
+                }
+            }
+
+            // Convolution of functional derivatives {scalar, FMT}
+            for wf_i in &wf.scalar_fmt_weighted_densities {
+                let pd_k = self.forward_transform(pd.index_axis(Axis(0), k), None);
+                functional_deriv_k.add_assign(&(wf_i * &pd_k));
+                k += 1;
+            }
+
+            // Convolution of functional derivatives {vector, FMT}
+            for wf_i in &wf.vector_fmt_weighted_densities {
+                for (i, wf_i) in wf_i.outer_iter().enumerate() {
+                    let pd_k = self.forward_transform(pd.index_axis(Axis(0), k), Some(i));
+                    functional_deriv_k.add_assign(&(&wf_i * &pd_k));
+                    k += 1;
+                }
+            }
+        }
+
+        // Backward transform of the non-local part of the functional derivative
+        self.back_transform_comps(functional_deriv_k, functional_deriv.view_mut(), None);
+
+        // Return sum over non-local and local contributions
+        functional_deriv + functional_deriv_local
+    }
+}
+
+/// The curvilinear convolver accounts for the shift that has to be performed
+/// for spherical and polar transforms.
+struct CurvilinearConvolver<T, D> {
+    convolver: Rc<dyn Convolver<T, D>>,
+    convolver_boundary: Rc<dyn Convolver<T, D>>,
+}
+
+impl<T, D: Dimension + RemoveAxis + 'static> CurvilinearConvolver<T, D>
+where
+    T: DctNum + ScalarOperand + DualNum<f64>,
+    D::Larger: Dimension<Smaller = D>,
+    D::Smaller: Dimension<Larger = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    fn new(
+        r: &Axis,
+        z: &[&Axis],
+        weight_functions: &[WeightFunctionInfo<T>],
+        lanczos: Option<i32>,
+    ) -> Rc<dyn Convolver<T, D>> {
+        Rc::new(Self {
+            convolver: ConvolverFFT::new(Some(r), z, weight_functions, lanczos),
+            convolver_boundary: ConvolverFFT::new(None, z, weight_functions, lanczos),
+        })
+    }
+}
+
+impl<T, D: Dimension + RemoveAxis> Convolver<T, D> for CurvilinearConvolver<T, D>
+where
+    T: DctNum + ScalarOperand + DualNum<f64>,
+    D::Smaller: Dimension<Larger = D>,
+    D::Larger: Dimension<Smaller = D>,
+{
+    fn convolve(
+        &self,
+        mut profile: Array<T, D>,
+        weight_function: &WeightFunction<T>,
+    ) -> Array<T, D> {
+        // subtract boundary profile from full profile
+        let profile_boundary = profile
+            .index_axis(Axis(0), profile.shape()[0] - 1)
+            .into_owned();
+        for mut lane in profile.outer_iter_mut() {
+            lane.sub_assign(&profile_boundary);
+        }
+
+        // convolve full profile
+        let mut result = self.convolver.convolve(profile, weight_function);
+
+        // convolve boundary profile
+        let profile_boundary = profile_boundary.insert_axis(Axis(0));
+        let result_boundary = self
+            .convolver_boundary
+            .convolve(profile_boundary, weight_function);
+
+        // Add boundary result back to full result
+        let result_boundary = result_boundary.index_axis(Axis(0), 0);
+        for mut lane in result.outer_iter_mut() {
+            lane.add_assign(&result_boundary);
+        }
+        result
+    }
+
+    /// Calculates weighted densities via convolution from density profiles.
+    fn weighted_densities(&self, density: &Array<T, D::Larger>) -> Vec<Array<T, D::Larger>> {
+        // subtract boundary profile from full profile
+        let density_boundary = density.index_axis(Axis(1), density.shape()[1] - 1);
+        let mut density = density.to_owned();
+        for mut lane in density.axis_iter_mut(Axis(1)) {
+            lane.sub_assign(&density_boundary);
+        }
+
+        // convolve full profile
+        let mut wd = self.convolver.weighted_densities(&density);
+
+        // convolve boundary profile
+        let density_boundary = density_boundary.insert_axis(Axis(1));
+        let wd_boundary = self
+            .convolver_boundary
+            .weighted_densities(&density_boundary.to_owned());
+
+        // Add boundary result back to full result
+        for (wd, wd_boundary) in wd.iter_mut().zip(wd_boundary.iter()) {
+            let wd_view = wd_boundary.index_axis(Axis(1), 0);
+            for mut lane in wd.axis_iter_mut(Axis(1)) {
+                lane.add_assign(&wd_view);
+            }
+        }
+
+        wd
+    }
+
+    /// Calculates the functional derivative via convolution from partial derivatives
+    /// of the Helmholtz energy functional.
+    fn functional_derivative(
+        &self,
+        partial_derivatives: &[Array<T, D::Larger>],
+    ) -> Array<T, D::Larger> {
+        // subtract boundary profile from full profile
+        let mut partial_derivatives_full = Vec::new();
+        let mut partial_derivatives_boundary = Vec::new();
+        for pd in partial_derivatives {
+            let pd_boundary = pd.index_axis(Axis(1), pd.shape()[1] - 1).to_owned();
+            let mut pd_full = pd.to_owned();
+            for mut lane in pd_full.axis_iter_mut(Axis(1)) {
+                lane.sub_assign(&pd_boundary);
+            }
+            partial_derivatives_full.push(pd_full);
+            partial_derivatives_boundary.push(pd_boundary);
+        }
+
+        // convolve full profile
+        let mut functional_derivative = self
+            .convolver
+            .functional_derivative(&partial_derivatives_full);
+
+        // convolve boundary profile
+        let mut partial_derivatives_boundary = Vec::new();
+        for pd in partial_derivatives {
+            let mut pd_boundary = pd.view();
+            pd_boundary.collapse_axis(Axis(1), pd.shape()[1] - 1);
+            partial_derivatives_boundary.push(pd_boundary.to_owned());
+        }
+        let functional_derivative_boundary = self
+            .convolver_boundary
+            .functional_derivative(&partial_derivatives_boundary);
+
+        // Add boundary result back to full result
+        let functional_derivative_view = functional_derivative_boundary.index_axis(Axis(1), 0);
+        for mut lane in functional_derivative.axis_iter_mut(Axis(1)) {
+            lane.add_assign(&functional_derivative_view);
+        }
+
+        functional_derivative
+    }
+}

--- a/feos-dft/src/convolver/periodic_convolver.rs
+++ b/feos-dft/src/convolver/periodic_convolver.rs
@@ -1,0 +1,344 @@
+use super::{Convolver, FFTWeightFunctions};
+use crate::geometry::Axis;
+use crate::weight_functions::{WeightFunction, WeightFunctionInfo};
+use ndarray::Axis as Axis_nd;
+use ndarray::*;
+use num_dual::DualNum;
+use rustfft::num_complex::Complex;
+use rustfft::{Fft, FftDirection, FftNum, FftPlanner};
+use std::f64::consts::PI;
+use std::ops::AddAssign;
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct PeriodicConvolver<T, D: Dimension> {
+    /// k vectors
+    k_abs: Array<f64, D>,
+    /// Vector of weight functions for each component in multiple dimensions.
+    weight_functions: Vec<FFTWeightFunctions<T, D>>,
+    /// Lanczos sigma factor
+    lanczos_sigma: Option<Array<f64, D>>,
+    /// Vector of forward Fourier transforms in each dimensions
+    forward_transforms: Vec<Arc<dyn Fft<T>>>,
+    /// Vector of inverse Fourier transforms in each dimensions
+    inverse_transforms: Vec<Arc<dyn Fft<T>>>,
+}
+
+impl<T, D: Dimension + 'static> PeriodicConvolver<T, D>
+where
+    T: FftNum + DualNum<f64>,
+    D::Larger: Dimension<Smaller = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    pub fn new(
+        axes: &[&Axis],
+        weight_functions: &[WeightFunctionInfo<T>],
+        lanczos: Option<i32>,
+    ) -> Rc<dyn Convolver<T, D>> {
+        // initialize the Fourier transform
+        let mut planner = FftPlanner::new();
+        let mut forward_transforms = Vec::with_capacity(axes.len());
+        let mut inverse_transforms = Vec::with_capacity(axes.len());
+        let mut k_vec = Vec::with_capacity(axes.len());
+        let mut lengths = Vec::with_capacity(axes.len());
+        for ax in axes {
+            let points = ax.grid.len();
+            forward_transforms.push(planner.plan_fft_forward(points));
+            inverse_transforms.push(planner.plan_fft_inverse(points));
+            let (min, max) = (-(points as isize / 2), (points as isize - 1) / 2);
+            let k_x: Array1<_> = (0..=max)
+                .chain(min..0)
+                .map(|i| 2.0 * PI * i as f64 / ax.length())
+                .collect();
+
+            k_vec.push(k_x);
+            lengths.push(ax.length());
+        }
+
+        // Calculate the full k vectors
+        let mut dim = vec![k_vec.len()];
+        k_vec.iter().for_each(|k_x| dim.push(k_x.len()));
+        let mut k: Array<_, D::Larger> = Array::zeros(dim).into_dimensionality().unwrap();
+        let mut k_abs = Array::zeros(k.raw_dim().remove_axis(Axis_nd(0)));
+        for (i, (mut k_i, k_x)) in k.outer_iter_mut().zip(k_vec.iter()).enumerate() {
+            k_i.lanes_mut(Axis_nd(i))
+                .into_iter()
+                .for_each(|mut l| l.assign(k_x));
+            k_abs.add_assign(&k_i.mapv(|k| k.powi(2)));
+        }
+        k_abs.map_inplace(|k| *k = k.sqrt());
+
+        // Lanczos sigma factor
+        let lanczos_sigma = lanczos.map(|exp| {
+            let mut lanczos = Array::ones(k_abs.raw_dim());
+            for (i, (k_x, &l)) in k_vec.iter().zip(lengths.iter()).enumerate() {
+                let points = k_x.len();
+                let m2 = if points % 2 == 0 {
+                    points as f64 + 2.0
+                } else {
+                    points as f64 + 1.0
+                };
+                let l_x = k_x.mapv(|k| (k * l / m2).sph_j0().powi(exp));
+                for mut l in lanczos.lanes_mut(Axis_nd(i)) {
+                    l *= &l_x;
+                }
+            }
+            lanczos
+        });
+
+        // calculate weight functions in Fourier space and weight constants
+        let mut fft_weight_functions = Vec::with_capacity(weight_functions.len());
+        for wf in weight_functions {
+            // Calculates the weight functions values from `k_abs`
+            // Pre-allocation of empty `Vec`
+            let mut scal_comp = Vec::with_capacity(wf.scalar_component_weighted_densities.len());
+            // Filling array with scalar component-wise weight functions
+            for wf_i in &wf.scalar_component_weighted_densities {
+                scal_comp.push(wf_i.fft_scalar_weight_functions(&k_abs, &lanczos_sigma));
+            }
+
+            // Pre-allocation of empty `Vec`
+            let mut vec_comp = Vec::with_capacity(wf.vector_component_weighted_densities.len());
+            // Filling array with vector-valued component-wise weight functions
+            for wf_i in &wf.vector_component_weighted_densities {
+                vec_comp.push(wf_i.fft_vector_weight_functions(&k_abs, &k, &lanczos_sigma));
+            }
+
+            // Pre-allocation of empty `Vec`
+            let mut scal_fmt = Vec::with_capacity(wf.scalar_fmt_weighted_densities.len());
+            // Filling array with scalar FMT weight functions
+            for wf_i in &wf.scalar_fmt_weighted_densities {
+                scal_fmt.push(wf_i.fft_scalar_weight_functions(&k_abs, &lanczos_sigma));
+            }
+
+            // Pre-allocation of empty `Vec`
+            let mut vec_fmt = Vec::with_capacity(wf.vector_fmt_weighted_densities.len());
+            // Filling array with vector-valued FMT weight functions
+            for wf_i in &wf.vector_fmt_weighted_densities {
+                vec_fmt.push(wf_i.fft_vector_weight_functions(&k_abs, &k, &lanczos_sigma));
+            }
+
+            // Initializing `FFTWeightFunctions` structure
+            fft_weight_functions.push(FFTWeightFunctions::<_, D> {
+                segments: wf.component_index.len(),
+                local_density: wf.local_density,
+                scalar_component_weighted_densities: scal_comp,
+                vector_component_weighted_densities: vec_comp,
+                scalar_fmt_weighted_densities: scal_fmt,
+                vector_fmt_weighted_densities: vec_fmt,
+            });
+        }
+
+        Rc::new(Self {
+            k_abs,
+            weight_functions: fft_weight_functions,
+            lanczos_sigma,
+            forward_transforms,
+            inverse_transforms,
+        })
+    }
+}
+
+impl<T: FftNum, D: Dimension> PeriodicConvolver<T, D> {
+    fn transform(&self, transform: &Arc<dyn Fft<T>>, mut f: ArrayViewMut1<Complex<T>>) {
+        if let Some(f) = f.as_slice_mut() {
+            transform.process(f);
+        } else {
+            let mut f_cont = f.to_owned();
+            transform.process(f_cont.as_slice_mut().unwrap());
+            f.assign(&f_cont);
+        }
+        if let FftDirection::Inverse = transform.fft_direction() {
+            let points = T::from_usize(transform.len()).unwrap();
+            f.mapv_inplace(|x| x / points);
+        }
+    }
+
+    fn forward_transform<D2: Dimension>(&self, f: ArrayView<T, D2>) -> Array<Complex<T>, D2> {
+        let offset = D2::NDIM.unwrap() - D::NDIM.unwrap();
+        let mut result = f.mapv(Complex::from);
+        for (i, transform) in self.forward_transforms.iter().enumerate() {
+            for r in result.lanes_mut(Axis_nd(i + offset)).into_iter() {
+                self.transform(transform, r);
+            }
+        }
+        result
+    }
+
+    fn inverse_transform<D2: Dimension>(&self, mut f: Array<Complex<T>, D2>) -> Array<T, D2> {
+        let offset = D2::NDIM.unwrap() - D::NDIM.unwrap();
+        for (i, transform) in self.inverse_transforms.iter().enumerate() {
+            for r in f.lanes_mut(Axis_nd(i + offset)).into_iter() {
+                self.transform(transform, r);
+            }
+        }
+        f.mapv(|x| x.re)
+    }
+}
+
+impl<T, D: Dimension> Convolver<T, D> for PeriodicConvolver<T, D>
+where
+    T: FftNum + DualNum<f64>,
+    D::Larger: Dimension<Smaller = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    fn convolve(&self, profile: Array<T, D>, weight_function: &WeightFunction<T>) -> Array<T, D> {
+        // Forward transform
+        let f_k = self.forward_transform(profile.view());
+
+        // calculate weight function
+        let w = weight_function
+            .fft_scalar_weight_functions(&self.k_abs, &self.lanczos_sigma)
+            .index_axis_move(Axis_nd(0), 0);
+
+        // Inverse transform
+        self.inverse_transform(f_k * w)
+    }
+
+    fn weighted_densities(&self, density: &Array<T, D::Larger>) -> Vec<Array<T, D::Larger>> {
+        // Applying FFT to each row of the matrix `rho` saving the result in `rho_k`
+        let rho_k = self.forward_transform(density.view());
+
+        // Iterate over all contributions
+        let mut weighted_densities_vec = Vec::with_capacity(self.weight_functions.len());
+        for wf in &self.weight_functions {
+            // number of weighted densities
+            let n_wd = wf.n_weighted_densities(density.ndim() - 1);
+
+            // Allocating new array for intended weighted densities
+            let mut dim = vec![n_wd];
+            density.shape().iter().skip(1).for_each(|&d| dim.push(d));
+            let mut weighted_densities = Array::zeros(dim).into_dimensionality().unwrap();
+
+            // Initilaizing row index for non-local weighted densities
+            let mut k = 0;
+
+            // Assigning possible local densities to the front of the array
+            if wf.local_density {
+                weighted_densities
+                    .slice_axis_mut(Axis_nd(0), Slice::from(0..wf.segments))
+                    .assign(density);
+                k += wf.segments;
+            }
+
+            // Calculating weighted densities {scalar, component}
+            for wf_i in &wf.scalar_component_weighted_densities {
+                weighted_densities
+                    .slice_axis_mut(Axis_nd(0), Slice::from(k..k + wf.segments))
+                    .assign(&self.inverse_transform(&rho_k * wf_i));
+                k += wf.segments;
+            }
+
+            // Calculating weighted densities {vector, component}
+            for wf_i in &wf.vector_component_weighted_densities {
+                for wf_i in wf_i.outer_iter() {
+                    weighted_densities
+                        .slice_axis_mut(Axis_nd(0), Slice::from(k..k + wf.segments))
+                        .assign(
+                            &self.inverse_transform((&rho_k * &wf_i).mapv(|x| x * Complex::i())),
+                        );
+                    k += wf.segments;
+                }
+            }
+
+            // Calculating weighted densities {scalar, FMT}
+            for wf_i in &wf.scalar_fmt_weighted_densities {
+                weighted_densities
+                    .index_axis_mut(Axis_nd(0), k)
+                    .assign(&self.inverse_transform((&rho_k * wf_i).sum_axis(Axis_nd(0))));
+                k += 1;
+            }
+
+            // Calculating weighted densities {vector, FMT}
+            for wf_i in &wf.vector_fmt_weighted_densities {
+                for wf_i in wf_i.outer_iter() {
+                    weighted_densities.index_axis_mut(Axis_nd(0), k).assign(
+                        &self.inverse_transform(
+                            (&rho_k * &wf_i)
+                                .sum_axis(Axis_nd(0))
+                                .mapv(|x| x * Complex::i()),
+                        ),
+                    );
+                    k += 1;
+                }
+            }
+
+            // add weighted densities for this contribution to the result
+            weighted_densities_vec.push(weighted_densities);
+        }
+        // Return
+        weighted_densities_vec
+    }
+
+    fn functional_derivative(
+        &self,
+        partial_derivatives: &[Array<T, D::Larger>],
+    ) -> Array<T, D::Larger> {
+        // Allocate arrays for the the local contribution to the functional derivative
+        // and the functional derivative in Fourier space
+        let mut dim = vec![self.weight_functions[0].segments];
+        partial_derivatives[0]
+            .shape()
+            .iter()
+            .skip(1)
+            .for_each(|&d| dim.push(d));
+        let mut functional_deriv_local: Array<_, D::Larger> =
+            Array::zeros(dim).into_dimensionality().unwrap();
+        let mut functional_deriv_k = Array::zeros(functional_deriv_local.raw_dim());
+
+        // Iterate over all contributions
+        for (pd, wf) in partial_derivatives.iter().zip(&self.weight_functions) {
+            // Multiplication of `partial_derivatives` with the weight functions in
+            // Fourier space (convolution in real space); summation leads to
+            // functional derivative: the rows in the array are selected from the
+            // running variable `k` with the number of rows needed for this
+            // particular contribution
+            let mut k = 0;
+
+            // If local densities are present, their contributions are added directly
+            if wf.local_density {
+                functional_deriv_local += &pd.slice_axis(Axis_nd(0), Slice::from(..wf.segments));
+                k += wf.segments;
+            }
+
+            // Convolution of functional derivatives {scalar, component}
+            for wf_i in &wf.scalar_component_weighted_densities {
+                let pd_k = self
+                    .forward_transform(pd.slice_axis(Axis_nd(0), Slice::from(k..k + wf.segments)));
+                functional_deriv_k += &(&pd_k * wf_i);
+                k += wf.segments;
+            }
+
+            // Convolution of functional derivatives {vector, component}
+            for wf_i in &wf.vector_component_weighted_densities {
+                for wf_i in wf_i.outer_iter() {
+                    let pd_k = self.forward_transform(
+                        pd.slice_axis(Axis_nd(0), Slice::from(k..k + wf.segments)),
+                    );
+                    functional_deriv_k -= &(pd_k * &wf_i).mapv(|x| x * Complex::i());
+                    k += wf.segments;
+                }
+            }
+
+            // Convolution of functional derivatives {scalar, FMT}
+            for wf_i in &wf.scalar_fmt_weighted_densities {
+                let pd_k = self.forward_transform(pd.index_axis(Axis_nd(0), k));
+                functional_deriv_k += &(pd_k * wf_i);
+                k += 1;
+            }
+
+            // Convolution of functional derivatives {vector, FMT}
+            for wf_i in &wf.vector_fmt_weighted_densities {
+                for wf_i in wf_i.outer_iter() {
+                    let pd_k = self.forward_transform(pd.index_axis(Axis_nd(0), k));
+                    functional_deriv_k -= &(pd_k * wf_i).mapv(|x| x * Complex::i());
+                    k += 1;
+                }
+            }
+        }
+
+        // Return sum over non-local and local contributions
+        self.inverse_transform(functional_deriv_k) + functional_deriv_local
+    }
+}

--- a/feos-dft/src/convolver/transform.rs
+++ b/feos-dft/src/convolver/transform.rs
@@ -1,0 +1,345 @@
+use crate::geometry::Axis;
+use ndarray::prelude::*;
+use ndarray::*;
+use num_dual::*;
+use rustdct::{DctNum, DctPlanner, TransformType2And3};
+use rustfft::{num_complex::Complex, Fft, FftPlanner};
+use std::f64::consts::PI;
+use std::ops::{DivAssign, SubAssign};
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(Clone, Copy)]
+enum SinCosTransform {
+    SinForward,
+    SinReverse,
+    CosForward,
+    CosReverse,
+}
+
+impl SinCosTransform {
+    fn is_reverse(&self) -> bool {
+        match self {
+            Self::CosForward | Self::SinForward => false,
+            Self::CosReverse | Self::SinReverse => true,
+        }
+    }
+}
+
+pub(super) trait FourierTransform<T: DualNum<f64>> {
+    fn forward_transform(&self, f_r: ArrayView1<T>, f_k: ArrayViewMut1<T>, scalar: bool);
+
+    fn back_transform(&self, f_k: ArrayViewMut1<T>, f_r: ArrayViewMut1<T>, scalar: bool);
+}
+
+pub(super) struct CartesianTransform<T> {
+    dct: Arc<dyn TransformType2And3<T>>,
+}
+
+impl<T: DualNum<f64> + DctNum + ScalarOperand> CartesianTransform<T> {
+    pub(super) fn new(axis: &Axis) -> (Rc<dyn FourierTransform<T>>, Array1<f64>) {
+        let (s, k) = Self::init(axis);
+        (Rc::new(s), k)
+    }
+
+    pub(super) fn new_cartesian(axis: &Axis) -> (Rc<Self>, Array1<f64>) {
+        let (s, k) = Self::init(axis);
+        (Rc::new(s), k)
+    }
+
+    fn init(axis: &Axis) -> (Self, Array1<f64>) {
+        let points = axis.grid.len();
+        let length = axis.length();
+        let k_grid = (0..=points).map(|v| PI * v as f64 / length).collect();
+        (
+            Self {
+                dct: DctPlanner::new().plan_dct2(points),
+            },
+            k_grid,
+        )
+    }
+
+    fn calculate_transform(&self, slice: &mut [T], transform: SinCosTransform) {
+        match transform {
+            SinCosTransform::CosForward => self.dct.process_dct2(slice),
+            SinCosTransform::CosReverse => self.dct.process_dct3(slice),
+            SinCosTransform::SinForward => self.dct.process_dst2(slice),
+            SinCosTransform::SinReverse => self.dct.process_dst3(slice),
+        }
+    }
+
+    fn transform(&self, mut f: ArrayViewMut1<T>, transform: SinCosTransform) {
+        let mut f_slice = match transform {
+            SinCosTransform::CosForward | SinCosTransform::CosReverse => f.slice_mut(s![..-1]),
+            SinCosTransform::SinForward | SinCosTransform::SinReverse => f.slice_mut(s![1..]),
+        };
+        match f_slice.as_slice_mut() {
+            Some(slice) => self.calculate_transform(slice, transform),
+            None => {
+                let mut slice = f_slice.to_owned();
+                self.calculate_transform(slice.as_slice_mut().unwrap(), transform);
+                f_slice.assign(&slice);
+            }
+        }
+        if transform.is_reverse() {
+            f.div_assign(T::from_f64(0.5).unwrap() * T::from_usize(self.dct.len()).unwrap())
+        }
+    }
+
+    pub(super) fn forward_transform_inplace(&self, f: ArrayViewMut1<T>, scalar: bool) {
+        if scalar {
+            self.transform(f, SinCosTransform::CosForward);
+        } else {
+            self.transform(f, SinCosTransform::SinForward);
+        }
+    }
+
+    pub(super) fn back_transform_inplace(&self, f: ArrayViewMut1<T>, scalar: bool) {
+        if scalar {
+            self.transform(f, SinCosTransform::CosReverse);
+        } else {
+            self.transform(f, SinCosTransform::SinReverse);
+        }
+    }
+}
+
+impl<T: DualNum<f64> + DctNum + ScalarOperand> FourierTransform<T> for CartesianTransform<T> {
+    fn forward_transform(&self, f_r: ArrayView1<T>, mut f_k: ArrayViewMut1<T>, scalar: bool) {
+        if scalar {
+            f_k.slice_mut(s![..-1]).assign(&f_r);
+        } else {
+            f_k.slice_mut(s![1..]).assign(&f_r);
+        }
+        self.forward_transform_inplace(f_k, scalar);
+    }
+
+    fn back_transform(&self, mut f_k: ArrayViewMut1<T>, mut f_r: ArrayViewMut1<T>, scalar: bool) {
+        self.back_transform_inplace(f_k.view_mut(), scalar);
+        if scalar {
+            f_r.assign(&f_k.slice(s![..-1]));
+        } else {
+            f_r.assign(&f_k.slice(s![1..]));
+        }
+    }
+}
+
+pub(super) struct SphericalTransform<T> {
+    r_grid: Array1<f64>,
+    k_grid: Array1<f64>,
+    dct: Arc<dyn TransformType2And3<T>>,
+}
+
+impl<T: DualNum<f64> + DctNum + ScalarOperand> SphericalTransform<T> {
+    pub(super) fn new(axis: &Axis) -> (Rc<dyn FourierTransform<T>>, Array1<f64>) {
+        let points = axis.grid.len();
+        let length = axis.length();
+        let k_grid: Array1<_> = (0..=points).map(|v| PI * v as f64 / length).collect();
+        (
+            Rc::new(Self {
+                r_grid: axis.grid.clone(),
+                k_grid: k_grid.clone(),
+                dct: DctPlanner::new().plan_dct2(points),
+            }),
+            k_grid,
+        )
+    }
+
+    fn sine_transform<S1, S2>(
+        &self,
+        f_in: ArrayBase<S1, Ix1>,
+        mut f_out: ArrayBase<S2, Ix1>,
+        reverse: bool,
+    ) where
+        S1: Data<Elem = T>,
+        S2: RawData<Elem = T> + DataMut,
+    {
+        if reverse {
+            f_out.assign(&f_in.slice(s![1..]));
+            self.dct.process_dst3(f_out.as_slice_mut().unwrap());
+            f_out.div_assign(T::from_f64(0.5).unwrap() * T::from_usize(f_out.len()).unwrap());
+        } else {
+            let mut f_slice = f_out.slice_mut(s![1..]);
+            f_slice.assign(&f_in);
+            self.dct.process_dst2(f_slice.as_slice_mut().unwrap());
+        }
+    }
+
+    fn cosine_transform<S1, S2>(
+        &self,
+        f_in: ArrayBase<S1, Ix1>,
+        mut f_out: ArrayBase<S2, Ix1>,
+        reverse: bool,
+    ) where
+        S1: Data<Elem = T>,
+        S2: RawData<Elem = T> + DataMut,
+    {
+        if reverse {
+            f_out.assign(&f_in.slice(s![..-1]));
+            self.dct.process_dct3(f_out.as_slice_mut().unwrap());
+            f_out.div_assign(T::from_f64(0.5).unwrap() * T::from_usize(f_out.len()).unwrap());
+        } else {
+            let mut f_slice = f_out.slice_mut(s![..-1]);
+            f_slice.assign(&f_in);
+            self.dct.process_dct2(f_slice.as_slice_mut().unwrap());
+        }
+    }
+}
+
+impl<T: DualNum<f64> + DctNum + ScalarOperand> FourierTransform<T> for SphericalTransform<T> {
+    fn forward_transform(&self, f_r: ArrayView1<T>, mut f_k: ArrayViewMut1<T>, scalar: bool) {
+        if scalar {
+            self.sine_transform(&f_r * &self.r_grid, f_k.view_mut(), false);
+        } else {
+            self.cosine_transform(&f_r * &self.r_grid, f_k.view_mut(), false);
+            let mut f_aux = Array::zeros(f_k.raw_dim());
+            self.sine_transform(f_r, f_aux.view_mut(), false);
+            f_k.sub_assign(&(&f_aux / &self.k_grid));
+        }
+        f_k.assign(&(&f_k / &self.k_grid));
+        f_k[0] = T::zero();
+    }
+
+    fn back_transform(&self, f_k: ArrayViewMut1<T>, mut f_r: ArrayViewMut1<T>, scalar: bool) {
+        if scalar {
+            self.sine_transform(&f_k * &self.k_grid, f_r.view_mut(), true);
+        } else {
+            self.cosine_transform(&f_k * &self.k_grid, f_r.view_mut(), true);
+            let mut f_aux = Array::zeros(f_r.raw_dim());
+            self.sine_transform(f_k, f_aux.view_mut(), true);
+            f_r.sub_assign(&(&f_aux / &self.r_grid));
+        }
+        f_r.assign(&(&f_r / &self.r_grid));
+    }
+}
+
+pub(super) struct PolarTransform<T: DctNum> {
+    r_grid: Array1<f64>,
+    k_grid: Array1<f64>,
+    fft: Arc<dyn Fft<T>>,
+    j: [Array1<Complex<T>>; 2],
+    k0: [f64; 2],
+    alpha: f64,
+    gamma: f64,
+    l: f64,
+}
+
+impl<T: DualNum<f64> + DctNum + ScalarOperand> PolarTransform<T> {
+    pub(super) fn new(axis: &Axis) -> (Rc<dyn FourierTransform<T>>, Array1<f64>) {
+        let points = axis.grid.len();
+
+        let mut alpha = 0.002_f64;
+        for _ in 0..20 {
+            alpha = -(1.0 - (-alpha).exp()).ln() / (points - 1) as f64;
+        }
+        let x0 = 0.5 * ((-alpha * points as f64).exp() + (-alpha * (points - 1) as f64).exp());
+        let gamma = (alpha * (points - 1) as f64).exp();
+
+        let l = axis.length();
+        let k_grid: Array1<_> = (0..points)
+            .map(|i| x0 * (alpha * i as f64).exp() * gamma / l)
+            .collect();
+
+        let k0 = (2.0 * alpha).exp() * (2.0 * alpha.exp() + (2.0 * alpha).exp() - 1.0)
+            / ((1.0 + alpha.exp()).powi(2) * ((2.0 * alpha).exp() - 1.0));
+        let k0v = (2.0 * alpha).exp() * (2.0 * alpha.exp() + (2.0 * alpha).exp() - 5.0 / 3.0)
+            / ((1.0 + alpha.exp()).powi(2) * ((2.0 * alpha).exp() - 1.0));
+
+        let fft = FftPlanner::new().plan_fft_forward(2 * points);
+        let ifft = FftPlanner::new().plan_fft_inverse(2 * points);
+
+        let mut j = Array1::from_shape_fn(2 * points, |i| {
+            Complex::from(T::from(
+                (gamma * x0 * (alpha * ((i + 1) as f64 - points as f64)).exp()).bessel_j1()
+                    / ((2 * points) as f64),
+            ))
+        });
+        ifft.process(j.as_slice_mut().unwrap());
+        let mut jv = Array1::from_shape_fn(2 * points, |i| {
+            Complex::from(T::from(
+                (gamma * x0 * (alpha * ((i + 1) as f64 - points as f64)).exp()).bessel_j2()
+                    / ((2 * points) as f64),
+            ))
+        });
+        ifft.process(jv.as_slice_mut().unwrap());
+
+        (
+            Rc::new(Self {
+                r_grid: axis.grid.clone(),
+                k_grid: k_grid.clone(),
+                fft,
+                j: [j, jv],
+                k0: [k0, k0v],
+                alpha,
+                gamma,
+                l,
+            }),
+            k_grid,
+        )
+    }
+
+    fn transform(
+        &self,
+        f_in: ArrayView1<T>,
+        mut f_out: ArrayViewMut1<T>,
+        scalar: bool,
+        x_in: &Array1<f64>,
+        x_out: &Array1<f64>,
+        mut factor: f64,
+    ) {
+        let n = f_in.len();
+        let (f_in, alpha, k0, j) = if scalar {
+            (f_in.to_owned(), self.alpha, self.k0[0], &self.j[0])
+        } else {
+            factor *= factor;
+            (&f_in / x_in, 2.0 * self.alpha, self.k0[1], &self.j[1])
+        };
+        let mut phi = Array1::from_shape_fn(2 * n, |i| {
+            if i < n - 1 {
+                (f_in[i] - f_in[i + 1]) * (-alpha * (n - i - 1) as f64).exp()
+            } else {
+                T::zero()
+            }
+        });
+        phi[0] *= k0;
+        let mut phi = phi.mapv(Complex::from);
+        self.fft.process(phi.as_slice_mut().unwrap());
+        phi *= j;
+        self.fft.process(phi.as_slice_mut().unwrap());
+        f_out.assign(&(phi.slice(s![..n]).map(|phi| phi.re * factor) / x_out));
+    }
+}
+
+impl<T: DualNum<f64> + DctNum + ScalarOperand> FourierTransform<T> for PolarTransform<T> {
+    fn forward_transform(&self, f_r: ArrayView1<T>, f_k: ArrayViewMut1<T>, scalar: bool) {
+        self.transform(f_r, f_k, scalar, &self.r_grid, &self.k_grid, self.l);
+    }
+
+    fn back_transform(&self, f_k: ArrayViewMut1<T>, f_r: ArrayViewMut1<T>, scalar: bool) {
+        self.transform(
+            f_k.view(),
+            f_r,
+            scalar,
+            &self.k_grid,
+            &self.r_grid,
+            self.gamma / self.l,
+        );
+    }
+}
+
+pub(super) struct NoTransform();
+
+impl NoTransform {
+    pub(super) fn new<T: DualNum<f64>>() -> (Rc<dyn FourierTransform<T>>, Array1<f64>) {
+        (Rc::new(Self()), arr1(&[0.0]))
+    }
+}
+
+impl<T: DualNum<f64>> FourierTransform<T> for NoTransform {
+    fn forward_transform(&self, f: ArrayView1<T>, mut f_k: ArrayViewMut1<T>, _: bool) {
+        f_k.assign(&f);
+    }
+
+    fn back_transform(&self, f_k: ArrayViewMut1<T>, mut f_r: ArrayViewMut1<T>, _: bool) {
+        f_r.assign(&f_k);
+    }
+}

--- a/feos-dft/src/functional.rs
+++ b/feos-dft/src/functional.rs
@@ -1,0 +1,527 @@
+use crate::convolver::Convolver;
+use crate::functional_contribution::*;
+use crate::ideal_chain_contribution::IdealChainContribution;
+use crate::weight_functions::{WeightFunction, WeightFunctionInfo, WeightFunctionShape};
+use feos_core::{
+    Contributions, EosResult, EosUnit, EquationOfState, HelmholtzEnergy, HelmholtzEnergyDual,
+    IdealGasContribution, IdealGasContributionDual, MolarWeight, StateHD,
+};
+use ndarray::*;
+use num_dual::*;
+use petgraph::graph::{Graph, UnGraph};
+use petgraph::visit::EdgeRef;
+use petgraph::Directed;
+use quantity::{QuantityArray, QuantityArray1, QuantityScalar};
+use std::borrow::Cow;
+use std::fmt;
+use std::ops::{AddAssign, Deref, MulAssign};
+use std::rc::Rc;
+
+/// Wrapper struct for the [HelmholtzEnergyFunctional] trait.
+///
+/// Needed (for now) to generically implement the `EquationOfState`
+/// trait for Helmholtz energy functionals.
+#[derive(Clone)]
+pub struct DFT<F>(F);
+
+impl<F> From<F> for DFT<F> {
+    fn from(functional: F) -> Self {
+        Self(functional)
+    }
+}
+
+impl<F> DFT<F> {
+    pub fn into<F2: From<F>>(self) -> DFT<F2> {
+        DFT(self.0.into())
+    }
+}
+
+impl<F> Deref for DFT<F> {
+    type Target = F;
+    fn deref(&self) -> &F {
+        &self.0
+    }
+}
+
+impl<T: MolarWeight<U>, U: EosUnit> MolarWeight<U> for DFT<T> {
+    fn molar_weight(&self) -> QuantityArray1<U> {
+        (self as &T).molar_weight()
+    }
+}
+
+struct DefaultIdealGasContribution();
+impl<D: DualNum<f64>> IdealGasContributionDual<D> for DefaultIdealGasContribution {
+    fn de_broglie_wavelength(&self, _: D, components: usize) -> Array1<D> {
+        Array1::zeros(components)
+    }
+}
+
+impl fmt::Display for DefaultIdealGasContribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ideal gas (default)")
+    }
+}
+
+impl<T: HelmholtzEnergyFunctional> EquationOfState for DFT<T> {
+    fn components(&self) -> usize {
+        self.component_index()[self.component_index().len() - 1] + 1
+    }
+
+    fn subset(&self, component_list: &[usize]) -> Self {
+        (self as &T).subset(component_list)
+    }
+
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
+        (self as &T).compute_max_density(moles)
+    }
+
+    fn residual(&self) -> &[Box<dyn HelmholtzEnergy>] {
+        unreachable!()
+    }
+
+    fn evaluate_residual<D: DualNum<f64>>(&self, state: &StateHD<D>) -> D
+    where
+        dyn HelmholtzEnergy: HelmholtzEnergyDual<D>,
+    {
+        self.contributions()
+            .iter()
+            .map(|c| (c as &dyn HelmholtzEnergy).helmholtz_energy(state))
+            .sum::<D>()
+            + self.ideal_chain_contribution().helmholtz_energy(state)
+    }
+
+    fn evaluate_residual_contributions<D: DualNum<f64>>(
+        &self,
+        state: &StateHD<D>,
+    ) -> Vec<(String, D)>
+    where
+        dyn HelmholtzEnergy: HelmholtzEnergyDual<D>,
+    {
+        let mut res: Vec<(String, D)> = self
+            .contributions()
+            .iter()
+            .map(|c| {
+                (
+                    c.to_string(),
+                    (c as &dyn HelmholtzEnergy).helmholtz_energy(state),
+                )
+            })
+            .collect();
+        res.push((
+            self.ideal_chain_contribution().to_string(),
+            self.ideal_chain_contribution().helmholtz_energy(state),
+        ));
+        res
+    }
+
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        (self as &T).ideal_gas()
+    }
+}
+
+/// Different representations for molecules within DFT.
+pub enum MoleculeShape<'a> {
+    /// For spherical molecules, the number of components.
+    Spherical(usize),
+    /// For non-spherical molecules in a homosegmented approach, the
+    /// chain length parameter $m$.
+    NonSpherical(&'a Array1<f64>),
+    /// For non-spherical molecules in a heterosegmented approach,
+    /// the component index for every segment.
+    Heterosegmented(&'a Array1<usize>),
+}
+
+/// A general Helmholtz energy functional.
+pub trait HelmholtzEnergyFunctional: Sized {
+    /// Return a slice of [FunctionalContribution]s.
+    fn contributions(&self) -> &[Box<dyn FunctionalContribution>];
+
+    /// Return the shape of the molecules and the necessary specifications.
+    fn molecule_shape(&self) -> MoleculeShape;
+
+    /// Return a functional for the specified subset of components.
+    fn subset(&self, component_list: &[usize]) -> DFT<Self>;
+
+    /// Return the maximum density in Angstrom^-3.
+    ///
+    /// This value is used as an estimate for a liquid phase for phase
+    /// equilibria and other iterations. It is not explicitly meant to
+    /// be a mathematical limit for the density (if those exist in the
+    /// equation of state anyways).
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64;
+
+    /// Return the ideal gas contribution.
+    ///
+    /// Per default this function returns an ideal gas contribution
+    /// in which the de Broglie wavelength is 1 for every component.
+    /// Therefore, the correct ideal gas pressure is obtained even
+    /// with no explicit ideal gas term. If a more detailed model is
+    /// required (e.g. for the calculation of internal energies) this
+    /// function has to be overwritten.
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        &DefaultIdealGasContribution()
+    }
+
+    /// Overwrite this, if the functional consists of heterosegmented chains.
+    fn bond_lengths(&self, _temperature: f64) -> UnGraph<(), f64> {
+        Graph::with_capacity(0, 0)
+    }
+
+    fn weight_functions(&self, temperature: f64) -> Vec<WeightFunctionInfo<f64>> {
+        self.contributions()
+            .iter()
+            .map(|c| c.weight_functions(temperature))
+            .collect()
+    }
+
+    fn m(&self) -> Cow<Array1<f64>> {
+        match self.molecule_shape() {
+            MoleculeShape::Spherical(n) => Cow::Owned(Array1::ones(n)),
+            MoleculeShape::NonSpherical(m) => Cow::Borrowed(m),
+            MoleculeShape::Heterosegmented(component_index) => {
+                Cow::Owned(Array1::ones(component_index.len()))
+            }
+        }
+    }
+
+    fn component_index(&self) -> Cow<Array1<usize>> {
+        match self.molecule_shape() {
+            MoleculeShape::Spherical(n) => Cow::Owned(Array1::from_shape_fn(n, |i| i)),
+            MoleculeShape::NonSpherical(m) => Cow::Owned(Array1::from_shape_fn(m.len(), |i| i)),
+            MoleculeShape::Heterosegmented(component_index) => Cow::Borrowed(component_index),
+        }
+    }
+
+    fn ideal_chain_contribution(&self) -> IdealChainContribution {
+        IdealChainContribution::new(&self.component_index(), &self.m())
+    }
+}
+
+impl<T: HelmholtzEnergyFunctional> DFT<T> {
+    /// Calculate the grand potential density $\omega$.
+    pub fn grand_potential_density<U, D>(
+        &self,
+        temperature: QuantityScalar<U>,
+        density: &QuantityArray<U, D::Larger>,
+        convolver: &Rc<dyn Convolver<f64, D>>,
+    ) -> EosResult<QuantityArray<U, D>>
+    where
+        U: EosUnit,
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        // Calculate residual Helmholtz energy density and functional derivative
+        let t = temperature.to_reduced(U::reference_temperature())?;
+        let rho = density.to_reduced(U::reference_density())?;
+        let (mut f, dfdrho) = self.functional_derivative(t, &rho, convolver)?;
+
+        // Calculate the grand potential density
+        for ((rho, dfdrho), &m) in rho
+            .outer_iter()
+            .zip(dfdrho.outer_iter())
+            .zip(self.m().iter())
+        {
+            f -= &((&dfdrho + m) * &rho);
+        }
+
+        let bond_lengths = self.bond_lengths(t);
+        for segment in bond_lengths.node_indices() {
+            let n = bond_lengths.neighbors(segment).count();
+            f += &(&rho.index_axis(Axis(0), segment.index()) * (0.5 * n as f64));
+        }
+
+        Ok(f * t * U::reference_pressure())
+    }
+
+    pub(crate) fn ideal_gas_contribution<D>(
+        &self,
+        temperature: f64,
+        density: &Array<f64, D::Larger>,
+    ) -> Array<f64, D>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let n = self.components();
+        let ig = self.ideal_gas();
+        let lambda = ig.de_broglie_wavelength(temperature, n);
+        let mut phi = Array::zeros(density.raw_dim().remove_axis(Axis(0)));
+        for (i, rhoi) in density.outer_iter().enumerate() {
+            phi += &rhoi.mapv(|rhoi| (rhoi.ln() + lambda[i] - 1.0) * rhoi);
+        }
+        phi * temperature
+    }
+
+    fn ideal_gas_contribution_dual<D>(
+        &self,
+        temperature: Dual64,
+        density: &Array<f64, D::Larger>,
+    ) -> Array<Dual64, D>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let n = self.components();
+        let ig = self.ideal_gas();
+        let lambda = ig.de_broglie_wavelength(temperature, n);
+        let mut phi = Array::zeros(density.raw_dim().remove_axis(Axis(0)));
+        for (i, rhoi) in density.outer_iter().enumerate() {
+            phi += &rhoi.mapv(|rhoi| (lambda[i] + rhoi.ln() - 1.0) * rhoi);
+        }
+        phi * temperature
+    }
+
+    fn intrinsic_helmholtz_energy_density<D, N>(
+        &self,
+        temperature: N,
+        density: &Array<f64, D::Larger>,
+        convolver: &Rc<dyn Convolver<N, D>>,
+    ) -> EosResult<Array<N, D>>
+    where
+        N: DualNum<f64> + ScalarOperand,
+        dyn FunctionalContribution: FunctionalContributionDual<N>,
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let density_dual = density.mapv(N::from);
+        let weighted_densities = convolver.weighted_densities(&density_dual);
+        let functional_contributions = self.contributions();
+        let mut helmholtz_energy_density: Array<N, D> = self
+            .ideal_chain_contribution()
+            .calculate_helmholtz_energy_density(&density.mapv(N::from))?;
+        for (c, wd) in functional_contributions.iter().zip(weighted_densities) {
+            let nwd = wd.shape()[0];
+            let ngrid = wd.len() / nwd;
+            helmholtz_energy_density
+                .view_mut()
+                .into_shape(ngrid)
+                .unwrap()
+                .add_assign(&c.calculate_helmholtz_energy_density(
+                    temperature,
+                    wd.into_shape((nwd, ngrid)).unwrap().view(),
+                )?);
+        }
+        Ok(helmholtz_energy_density * temperature)
+    }
+
+    /// Calculate the entropy density $s$.
+    ///
+    /// Untested with heterosegmented functionals.
+    pub fn entropy_density<D>(
+        &self,
+        temperature: f64,
+        density: &Array<f64, D::Larger>,
+        convolver: &Rc<dyn Convolver<Dual64, D>>,
+        contributions: Contributions,
+    ) -> EosResult<Array<f64, D>>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let temperature_dual = Dual64::from(temperature).derive();
+        let mut helmholtz_energy_density =
+            self.intrinsic_helmholtz_energy_density(temperature_dual, density, convolver)?;
+        match contributions {
+            Contributions::Total => {
+                helmholtz_energy_density += &self.ideal_gas_contribution_dual::<D>(temperature_dual, density);
+            },
+            Contributions::ResidualNpt|Contributions::IdealGas => panic!("Entropy density can only be calculated for Contributions::Residual or Contributions::Total"),
+            Contributions::ResidualNvt => (),
+        }
+        Ok(helmholtz_energy_density.mapv(|f| -f.eps[0]))
+    }
+
+    /// Calculate the individual contributions to the entropy density.
+    ///
+    /// Untested with heterosegmented functionals.
+    pub fn entropy_density_contributions<D>(
+        &self,
+        temperature: f64,
+        density: &Array<f64, D::Larger>,
+        convolver: &Rc<dyn Convolver<Dual64, D>>,
+    ) -> EosResult<Vec<Array<f64, D>>>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+        <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+    {
+        let density_dual = density.mapv(Dual64::from);
+        let temperature_dual = Dual64::from(temperature).derive();
+        let weighted_densities = convolver.weighted_densities(&density_dual);
+        let functional_contributions = self.contributions();
+        let mut helmholtz_energy_density: Vec<Array<Dual64, D>> =
+            Vec::with_capacity(functional_contributions.len() + 1);
+        helmholtz_energy_density.push(
+            self.ideal_chain_contribution()
+                .calculate_helmholtz_energy_density(&density.mapv(Dual64::from))?,
+        );
+
+        for (c, wd) in functional_contributions.iter().zip(weighted_densities) {
+            let nwd = wd.shape()[0];
+            let ngrid = wd.len() / nwd;
+            helmholtz_energy_density.push(
+                c.calculate_helmholtz_energy_density(
+                    temperature_dual,
+                    wd.into_shape((nwd, ngrid)).unwrap().view(),
+                )?
+                .into_shape(density.raw_dim().remove_axis(Axis(0)))
+                .unwrap(),
+            );
+        }
+        Ok(helmholtz_energy_density
+            .iter()
+            .map(|v| v.mapv(|f| -(f * temperature_dual).eps[0]))
+            .collect())
+    }
+
+    /// Calculate the internal energy density $u$.
+    ///
+    /// Untested with heterosegmented functionals.
+    pub fn internal_energy_density<D>(
+        &self,
+        temperature: f64,
+        density: &Array<f64, D::Larger>,
+        external_potential: &Array<f64, D::Larger>,
+        convolver: &Rc<dyn Convolver<Dual64, D>>,
+        contributions: Contributions,
+    ) -> EosResult<Array<f64, D>>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let temperature_dual = Dual64::from(temperature).derive();
+        let mut helmholtz_energy_density_dual =
+            self.intrinsic_helmholtz_energy_density(temperature_dual, density, convolver)?;
+        match contributions {
+                Contributions::Total => {
+                    helmholtz_energy_density_dual += &self.ideal_gas_contribution_dual::<D>(temperature_dual, density);
+                },
+                Contributions::ResidualNpt|Contributions::IdealGas => panic!("Internal energy density can only be calculated for Contributions::Residual or Contributions::Total"),
+                Contributions::ResidualNvt => (),
+            }
+        let helmholtz_energy_density = helmholtz_energy_density_dual
+            .mapv(|f| f.re - f.eps[0] * temperature)
+            + (external_potential * density).sum_axis(Axis(0)) * temperature;
+        Ok(helmholtz_energy_density)
+    }
+
+    /// Calculate the (residual) functional derivative $\frac{\delta\mathcal{F}}{\delta\rho_i(\mathbf{r})}$.
+    #[allow(clippy::type_complexity)]
+    pub fn functional_derivative<D>(
+        &self,
+        temperature: f64,
+        density: &Array<f64, D::Larger>,
+        convolver: &Rc<dyn Convolver<f64, D>>,
+    ) -> EosResult<(Array<f64, D>, Array<f64, D::Larger>)>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let weighted_densities = convolver.weighted_densities(density);
+        let contributions = self.contributions();
+        let mut partial_derivatives = Vec::with_capacity(contributions.len());
+        let mut helmholtz_energy_density = Array::zeros(density.raw_dim().remove_axis(Axis(0)));
+        for (c, wd) in contributions.iter().zip(weighted_densities) {
+            let nwd = wd.shape()[0];
+            let ngrid = wd.len() / nwd;
+            let mut phi = Array::zeros(density.raw_dim().remove_axis(Axis(0)));
+            let mut pd = Array::zeros(wd.raw_dim());
+            c.first_partial_derivatives(
+                temperature,
+                wd.into_shape((nwd, ngrid)).unwrap(),
+                phi.view_mut().into_shape(ngrid).unwrap(),
+                pd.view_mut().into_shape((nwd, ngrid)).unwrap(),
+            )?;
+            partial_derivatives.push(pd);
+            helmholtz_energy_density += &phi;
+        }
+        Ok((
+            helmholtz_energy_density,
+            convolver.functional_derivative(&partial_derivatives),
+        ))
+    }
+
+    /// Calculate the bond integrals $I_{\alpha\alpha'}(\mathbf{r})$
+    pub fn bond_integrals<D>(
+        &self,
+        temperature: f64,
+        functional_derivative: &Array<f64, D::Larger>,
+        convolver: &Rc<dyn Convolver<f64, D>>,
+    ) -> Array<f64, D::Larger>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        // calculate weight functions
+        let bond_lengths = self.bond_lengths(temperature).into_edge_type();
+        let mut bond_weight_functions = bond_lengths.map(
+            |_, _| (),
+            |_, &l| WeightFunction::new_scaled(arr1(&[l]), WeightFunctionShape::Delta),
+        );
+        for n in bond_lengths.node_indices() {
+            for e in bond_lengths.edges(n) {
+                bond_weight_functions.add_edge(
+                    e.target(),
+                    e.source(),
+                    WeightFunction::new_scaled(arr1(&[*e.weight()]), WeightFunctionShape::Delta),
+                );
+            }
+        }
+
+        let expdfdrho = functional_derivative.mapv(|x| (-x).exp());
+        let mut i_graph: Graph<_, Option<Array<f64, D>>, Directed> =
+            bond_weight_functions.map(|_, _| (), |_, _| None);
+
+        let bonds = i_graph.edge_count();
+        let mut calc = 0;
+
+        // go through the whole graph until every bond has been calculated
+        while calc < bonds {
+            let mut edge_id = None;
+            let mut i1 = None;
+
+            // find the first bond that can be calculated
+            'nodes: for node in i_graph.node_indices() {
+                for edge in i_graph.edges(node) {
+                    // skip already calculated bonds
+                    if edge.weight().is_some() {
+                        continue;
+                    }
+
+                    // if all bonds from the neighboring segment are calculated calculate the bond
+                    let edges = i_graph
+                        .edges(edge.target())
+                        .filter(|e| e.target().index() != node.index());
+                    if edges.clone().all(|e| e.weight().is_some()) {
+                        edge_id = Some(edge.id());
+                        let i0 = edges.fold(
+                            expdfdrho
+                                .index_axis(Axis(0), edge.target().index())
+                                .to_owned(),
+                            |acc: Array<f64, D>, e| acc * e.weight().as_ref().unwrap(),
+                        );
+                        i1 =
+                            Some(convolver.convolve(i0.clone(), &bond_weight_functions[edge.id()]));
+                        break 'nodes;
+                    }
+                }
+            }
+            if let Some(edge_id) = edge_id {
+                i_graph[edge_id] = i1;
+                calc += 1;
+            } else {
+                panic!("Cycle in molecular structure detected!")
+            }
+        }
+
+        let mut i = Array::ones(functional_derivative.raw_dim());
+        for node in i_graph.node_indices() {
+            for edge in i_graph.edges(node) {
+                i.index_axis_mut(Axis(0), node.index())
+                    .mul_assign(edge.weight().as_ref().unwrap());
+            }
+        }
+
+        i
+    }
+}

--- a/feos-dft/src/functional_contribution.rs
+++ b/feos-dft/src/functional_contribution.rs
@@ -1,0 +1,171 @@
+use crate::weight_functions::WeightFunctionInfo;
+use feos_core::{EosResult, HelmholtzEnergyDual, StateHD};
+use ndarray::prelude::*;
+use ndarray::RemoveAxis;
+use num_dual::*;
+use num_traits::Zero;
+use std::fmt::Display;
+
+macro_rules! impl_helmholtz_energy {
+    ($number:ty) => {
+        impl HelmholtzEnergyDual<$number> for Box<dyn FunctionalContribution> {
+            fn helmholtz_energy(&self, state: &StateHD<$number>) -> $number {
+                // calculate weight functions
+                let weight_functions = self.weight_functions(state.temperature);
+
+                // calculate segment density
+                let density = weight_functions
+                    .component_index
+                    .mapv(|c| state.partial_density[c]);
+
+                // calculate weighted density and Helmholtz energy
+                let weight_constants = weight_functions.weight_constants(Zero::zero(), 0);
+                let weighted_densities = weight_constants.dot(&density).insert_axis(Axis(1));
+                self.calculate_helmholtz_energy_density(
+                    state.temperature,
+                    weighted_densities.view(),
+                )
+                .unwrap()[0]
+                    * state.volume
+            }
+        }
+    };
+}
+
+impl_helmholtz_energy!(f64);
+impl_helmholtz_energy!(Dual64);
+impl_helmholtz_energy!(Dual<DualVec64<3>, f64>);
+impl_helmholtz_energy!(HyperDual64);
+impl_helmholtz_energy!(Dual3_64);
+impl_helmholtz_energy!(HyperDual<Dual64, f64>);
+impl_helmholtz_energy!(HyperDual<DualVec64<2>, f64>);
+impl_helmholtz_energy!(HyperDual<DualVec64<3>, f64>);
+impl_helmholtz_energy!(Dual3<Dual64, f64>);
+impl_helmholtz_energy!(Dual3<DualVec64<2>, f64>);
+impl_helmholtz_energy!(Dual3<DualVec64<3>, f64>);
+
+/// Individual functional contribution that can
+/// be evaluated using generalized (hyper) dual numbers.
+///
+/// This trait needs to be implemented generically or for
+/// the specific types in the supertraits of [FunctionalContribution]
+/// so that the implementor can be used as a functional
+/// contribution in the Helmholtz energy functional.
+pub trait FunctionalContributionDual<N: DualNum<f64>>: Display {
+    /// Return the weight functions required in this contribution.
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N>;
+    /// Overwrite this if the weight functions in pDGT are different than for DFT.
+    fn weight_functions_pdgt(&self, temperature: N) -> WeightFunctionInfo<N> {
+        self.weight_functions(temperature)
+    }
+
+    /// Return the Helmholtz energy density for the given temperature and weighted densities.
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> EosResult<Array1<N>>;
+}
+
+/// Object safe version of the [FunctionalContributionDual] trait.
+///
+/// The trait is implemented automatically for every struct that implements
+/// the supertraits.
+pub trait FunctionalContribution:
+    FunctionalContributionDual<f64>
+    + FunctionalContributionDual<Dual64>
+    + FunctionalContributionDual<Dual<DualVec64<3>, f64>>
+    + FunctionalContributionDual<HyperDual64>
+    + FunctionalContributionDual<Dual3_64>
+    + FunctionalContributionDual<HyperDual<Dual64, f64>>
+    + FunctionalContributionDual<HyperDual<DualVec64<2>, f64>>
+    + FunctionalContributionDual<HyperDual<DualVec64<3>, f64>>
+    + FunctionalContributionDual<Dual3<Dual64, f64>>
+    + FunctionalContributionDual<Dual3<DualVec64<2>, f64>>
+    + FunctionalContributionDual<Dual3<DualVec64<3>, f64>>
+    + Display
+{
+    fn first_partial_derivatives(
+        &self,
+        temperature: f64,
+        weighted_densities: Array2<f64>,
+        mut helmholtz_energy_density: ArrayViewMut1<f64>,
+        mut first_partial_derivative: ArrayViewMut2<f64>,
+    ) -> EosResult<()> {
+        let mut wd = weighted_densities.mapv(Dual64::from);
+        let t = Dual64::from(temperature);
+        let mut phi = Array::zeros(weighted_densities.raw_dim().remove_axis(Axis(0)));
+
+        for i in 0..wd.shape()[0] {
+            wd.index_axis_mut(Axis(0), i)
+                .map_inplace(|x| x.eps[0] = 1.0);
+            phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
+            first_partial_derivative
+                .index_axis_mut(Axis(0), i)
+                .assign(&phi.mapv(|p| p.eps[0]));
+            wd.index_axis_mut(Axis(0), i)
+                .map_inplace(|x| x.eps[0] = 0.0);
+        }
+        helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
+        Ok(())
+    }
+
+    fn second_partial_derivatives(
+        &self,
+        temperature: f64,
+        weighted_densities: Array2<f64>,
+        mut helmholtz_energy_density: ArrayViewMut1<f64>,
+        mut first_partial_derivative: ArrayViewMut2<f64>,
+        mut second_partial_derivative: ArrayViewMut3<f64>,
+    ) -> EosResult<()> {
+        let mut wd = weighted_densities.mapv(HyperDual64::from);
+        let t = HyperDual64::from(temperature);
+        let mut phi = Array::zeros(weighted_densities.raw_dim().remove_axis(Axis(0)));
+
+        for i in 0..wd.shape()[0] {
+            wd.index_axis_mut(Axis(0), i)
+                .map_inplace(|x| x.eps1[0] = 1.0);
+            for j in 0..=i {
+                wd.index_axis_mut(Axis(0), j)
+                    .map_inplace(|x| x.eps2[0] = 1.0);
+                phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
+                let p = phi.mapv(|p| p.eps1eps2[(0, 0)]);
+                second_partial_derivative
+                    .index_axis_mut(Axis(0), i)
+                    .index_axis_mut(Axis(0), j)
+                    .assign(&p);
+                if i != j {
+                    second_partial_derivative
+                        .index_axis_mut(Axis(0), j)
+                        .index_axis_mut(Axis(0), i)
+                        .assign(&p);
+                }
+                wd.index_axis_mut(Axis(0), j)
+                    .map_inplace(|x| x.eps2[0] = 0.0);
+            }
+            first_partial_derivative
+                .index_axis_mut(Axis(0), i)
+                .assign(&phi.mapv(|p| p.eps1[0]));
+            wd.index_axis_mut(Axis(0), i)
+                .map_inplace(|x| x.eps1[0] = 0.0);
+        }
+        helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
+        Ok(())
+    }
+}
+
+impl<T> FunctionalContribution for T where
+    T: FunctionalContributionDual<f64>
+        + FunctionalContributionDual<Dual64>
+        + FunctionalContributionDual<Dual<DualVec64<3>, f64>>
+        + FunctionalContributionDual<HyperDual64>
+        + FunctionalContributionDual<Dual3_64>
+        + FunctionalContributionDual<HyperDual<Dual64, f64>>
+        + FunctionalContributionDual<HyperDual<DualVec64<2>, f64>>
+        + FunctionalContributionDual<HyperDual<DualVec64<3>, f64>>
+        + FunctionalContributionDual<Dual3<Dual64, f64>>
+        + FunctionalContributionDual<Dual3<DualVec64<2>, f64>>
+        + FunctionalContributionDual<Dual3<DualVec64<3>, f64>>
+        + Display
+{
+}

--- a/feos-dft/src/fundamental_measure_theory.rs
+++ b/feos-dft/src/fundamental_measure_theory.rs
@@ -1,0 +1,373 @@
+//! Helmholtz energy functionals from fundamental measure theory.
+use crate::adsorption::FluidParameters;
+use crate::functional::{HelmholtzEnergyFunctional, MoleculeShape, DFT};
+use crate::functional_contribution::*;
+use crate::solvation::PairPotential;
+use crate::weight_functions::{WeightFunction, WeightFunctionInfo, WeightFunctionShape};
+use feos_core::EosResult;
+use ndarray::*;
+use num_dual::DualNum;
+use std::f64::consts::PI;
+use std::fmt;
+use std::rc::Rc;
+
+const PI36M1: f64 = 1.0 / (36.0 * PI);
+const N3_CUTOFF: f64 = 1e-5;
+
+/// Different monomer shapes for FMT.
+pub enum MonomerShape<N> {
+    /// For spherical monomers, the number of components.
+    Spherical(usize),
+    /// For non-spherical molecules in a homosegmented approach, the
+    /// chain length parameter $m$.
+    NonSpherical(Array1<N>),
+    /// For non-spherical molecules in a heterosegmented approach,
+    /// the geometry factors for every segment.
+    Heterosegmented([Array1<N>; 4]),
+}
+
+/// Properties of (generalized) hard sphere systems.
+pub trait FMTProperties {
+    fn component_index(&self) -> Array1<usize>;
+    fn monomer_shape<N: DualNum<f64>>(&self, temperature: N) -> MonomerShape<N>;
+    fn hs_diameter<N: DualNum<f64>>(&self, temperature: N) -> Array1<N>;
+
+    fn geometry_coefficients<N: DualNum<f64>>(&self, temperature: N) -> [Array1<N>; 4] {
+        match self.monomer_shape(temperature) {
+            MonomerShape::Spherical(n) => {
+                let m = Array1::ones(n);
+                [m.clone(), m.clone(), m.clone(), m]
+            }
+            MonomerShape::NonSpherical(m) => [m.clone(), m.clone(), m.clone(), m],
+            MonomerShape::Heterosegmented(g) => g,
+        }
+    }
+}
+
+/// Different versions of fundamental measure theory
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub enum FMTVersion {
+    /// White Bear ([Roth et al., 2002](https://doi.org/10.1088/0953-8984/14/46/313)) or modified ([Yu and Wu, 2002](https://doi.org/10.1063/1.1520530)) fundamental measure theory
+    WhiteBear,
+    /// Scalar fundamental measure theory by [Kierlik and Rosinberg, 1990](https://doi.org/10.1103/PhysRevA.42.3382)
+    KierlikRosinberg,
+    /// Anti-symmetric White Bear fundamental measure theory ([Rosenfeld et al., 1997](https://doi.org/10.1103/PhysRevE.55.4245)) and SI of ([Kessler et al., 2021](https://doi.org/10.1016/j.micromeso.2021.111263))
+    AntiSymWhiteBear,
+}
+
+/// The [FunctionalContribution] for the hard sphere functional.
+pub struct FMTContribution<P> {
+    pub properties: Rc<P>,
+    version: FMTVersion,
+}
+
+impl<P> Clone for FMTContribution<P> {
+    fn clone(&self) -> Self {
+        Self {
+            properties: self.properties.clone(),
+            version: self.version,
+        }
+    }
+}
+
+impl<P> FMTContribution<P> {
+    pub fn new(properties: &Rc<P>, version: FMTVersion) -> Self {
+        Self {
+            properties: properties.clone(),
+            version,
+        }
+    }
+}
+
+impl<P: FMTProperties, N: DualNum<f64>> FunctionalContributionDual<N> for FMTContribution<P> {
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let r = self.properties.hs_diameter(temperature) * 0.5;
+        let [c0, c1, c2, c3] = self.properties.geometry_coefficients(temperature);
+        match (self.version, r.len()) {
+            (FMTVersion::WhiteBear | FMTVersion::AntiSymWhiteBear, 1) => {
+                WeightFunctionInfo::new(self.properties.component_index(), false).extend(
+                    vec![
+                        WeightFunctionShape::Delta,
+                        WeightFunctionShape::Theta,
+                        WeightFunctionShape::DeltaVec,
+                    ]
+                    .into_iter()
+                    .zip([c2, c3.clone(), c3])
+                    .map(|(s, c)| WeightFunction {
+                        prefactor: c,
+                        kernel_radius: r.clone(),
+                        shape: s,
+                    })
+                    .collect(),
+                    false,
+                )
+            }
+            (FMTVersion::WhiteBear | FMTVersion::AntiSymWhiteBear, _) => {
+                WeightFunctionInfo::new(self.properties.component_index(), false)
+                    .add(
+                        WeightFunction {
+                            prefactor: Zip::from(&c0)
+                                .and(&r)
+                                .map_collect(|&c, &r| r.powi(-2) * c / (4.0 * PI)),
+                            kernel_radius: r.clone(),
+                            shape: WeightFunctionShape::Delta,
+                        },
+                        true,
+                    )
+                    .add(
+                        WeightFunction {
+                            prefactor: Zip::from(&c1)
+                                .and(&r)
+                                .map_collect(|&c, &r| r.recip() * c / (4.0 * PI)),
+                            kernel_radius: r.clone(),
+                            shape: WeightFunctionShape::Delta,
+                        },
+                        true,
+                    )
+                    .add(
+                        WeightFunction {
+                            prefactor: c2,
+                            kernel_radius: r.clone(),
+                            shape: WeightFunctionShape::Delta,
+                        },
+                        true,
+                    )
+                    .add(
+                        WeightFunction {
+                            prefactor: c3.clone(),
+                            kernel_radius: r.clone(),
+                            shape: WeightFunctionShape::Theta,
+                        },
+                        true,
+                    )
+                    .add(
+                        WeightFunction {
+                            prefactor: Zip::from(&c3)
+                                .and(&r)
+                                .map_collect(|&c, &r| r.recip() * c / (4.0 * PI)),
+                            kernel_radius: r.clone(),
+                            shape: WeightFunctionShape::DeltaVec,
+                        },
+                        true,
+                    )
+                    .add(
+                        WeightFunction {
+                            prefactor: c3,
+                            kernel_radius: r,
+                            shape: WeightFunctionShape::DeltaVec,
+                        },
+                        true,
+                    )
+            }
+            (FMTVersion::KierlikRosinberg, _) => {
+                WeightFunctionInfo::new(self.properties.component_index(), false).extend(
+                    vec![
+                        WeightFunctionShape::KR0,
+                        WeightFunctionShape::KR1,
+                        WeightFunctionShape::Delta,
+                        WeightFunctionShape::Theta,
+                    ]
+                    .into_iter()
+                    .zip(self.properties.geometry_coefficients(temperature))
+                    .map(|(s, c)| WeightFunction {
+                        prefactor: c,
+                        kernel_radius: r.clone(),
+                        shape: s,
+                    })
+                    .collect(),
+                    true,
+                )
+            }
+        }
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> EosResult<Array1<N>> {
+        let pure_component_weighted_densities = matches!(
+            self.version,
+            FMTVersion::WhiteBear | FMTVersion::AntiSymWhiteBear
+        ) && self.properties.component_index().len() == 1;
+
+        // scalar weighted densities
+        let (n2, n3) = if pure_component_weighted_densities {
+            (
+                weighted_densities.index_axis(Axis(0), 0),
+                weighted_densities.index_axis(Axis(0), 1),
+            )
+        } else {
+            (
+                weighted_densities.index_axis(Axis(0), 2),
+                weighted_densities.index_axis(Axis(0), 3),
+            )
+        };
+
+        let (n0, n1) = if pure_component_weighted_densities {
+            let r = self.properties.hs_diameter(temperature)[0] * 0.5;
+            (
+                n2.mapv(|n2| n2 / (r * r * 4.0 * PI)),
+                n2.mapv(|n2| n2 / (r * 4.0 * PI)),
+            )
+        } else {
+            (
+                weighted_densities.index_axis(Axis(0), 0).to_owned(),
+                weighted_densities.index_axis(Axis(0), 1).to_owned(),
+            )
+        };
+
+        // vector weighted densities
+        let (n1n2, n2n2) = match self.version {
+            FMTVersion::WhiteBear | FMTVersion::AntiSymWhiteBear => {
+                let (n1v, n2v) = if pure_component_weighted_densities {
+                    let r = self.properties.hs_diameter(temperature)[0] * 0.5;
+                    let n2v = weighted_densities.slice_axis(Axis(0), Slice::new(2, None, 1));
+                    (n2v.mapv(|n2v| n2v / (r * 4.0 * PI)), n2v)
+                } else {
+                    let dim = ((weighted_densities.shape()[0] - 4) / 2) as isize;
+                    (
+                        weighted_densities
+                            .slice_axis(Axis(0), Slice::new(4, Some(4 + dim), 1))
+                            .to_owned(),
+                        weighted_densities
+                            .slice_axis(Axis(0), Slice::new(4 + dim, Some(4 + 2 * dim), 1)),
+                    )
+                };
+                match self.version {
+                    FMTVersion::WhiteBear => (
+                        &n1 * &n2 - (&n1v * &n2v).sum_axis(Axis(0)),
+                        &n2 * &n2 - (&n2v * &n2v).sum_axis(Axis(0)) * 3.0,
+                    ),
+                    FMTVersion::AntiSymWhiteBear => {
+                        let mut xi2 = (&n2v * &n2v).sum_axis(Axis(0)) / n2.map(|n| n.powi(2));
+                        xi2.iter_mut().for_each(|x| {
+                            if x.re() > 1.0 {
+                                *x = N::one()
+                            }
+                        });
+                        (
+                            &n1 * &n2 - (&n1v * &n2v).sum_axis(Axis(0)),
+                            &n2 * &n2 * xi2.mapv(|x| (-x + 1.0).powi(3)),
+                        )
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            FMTVersion::KierlikRosinberg => (&n1 * &n2, &n2 * &n2),
+        };
+
+        // auxiliary variables
+        let ln31 = n3.mapv(|n3| (-n3).ln_1p());
+        let n3rec = n3.mapv(|n3| n3.recip());
+        let n3m1 = n3.mapv(|n3| -n3 + 1.0);
+        let n3m1rec = n3m1.mapv(|n3m1| n3m1.recip());
+
+        // use Taylor expansion for f3 at low densities to avoid numerical issues
+        let mut f3 = (&n3m1 * &n3m1 * &ln31 + n3) * &n3rec * n3rec * &n3m1rec * &n3m1rec;
+        f3.iter_mut().zip(n3).for_each(|(f3, &n3)| {
+            if n3.re() < N3_CUTOFF {
+                *f3 = (((n3 * 35.0 / 6.0 + 4.8) * n3 + 3.75) * n3 + 8.0 / 3.0) * n3 + 1.5;
+            }
+        });
+        Ok(-(&n0 * &ln31) + n1n2 * &n3m1rec + n2n2 * n2 * PI36M1 * f3)
+    }
+}
+
+impl<P: FMTProperties> fmt::Display for FMTContribution<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ver = match self.version {
+            FMTVersion::WhiteBear => "WB",
+            FMTVersion::KierlikRosinberg => "KR",
+            FMTVersion::AntiSymWhiteBear => "AntiSymWB",
+        };
+        write!(f, "FMT functional ({})", ver)
+    }
+}
+
+struct HardSphereProperties {
+    sigma: Array1<f64>,
+}
+
+impl FMTProperties for HardSphereProperties {
+    fn component_index(&self) -> Array1<usize> {
+        Array1::from_shape_fn(self.sigma.len(), |i| i)
+    }
+
+    fn monomer_shape<N>(&self, _: N) -> MonomerShape<N> {
+        MonomerShape::Spherical(self.sigma.len())
+    }
+
+    fn hs_diameter<N: DualNum<f64>>(&self, _: N) -> Array1<N> {
+        self.sigma.mapv(N::from)
+    }
+}
+
+/// [HelmholtzEnergyFunctional] for hard sphere systems.
+pub struct FMTFunctional {
+    properties: Rc<HardSphereProperties>,
+    contributions: Vec<Box<dyn FunctionalContribution>>,
+    version: FMTVersion,
+}
+
+impl FMTFunctional {
+    pub fn new(sigma: &Array1<f64>, version: FMTVersion) -> DFT<Self> {
+        let properties = Rc::new(HardSphereProperties {
+            sigma: sigma.clone(),
+        });
+        let contributions: Vec<Box<dyn FunctionalContribution>> =
+            vec![Box::new(FMTContribution::new(&properties, version))];
+        (Self {
+            properties,
+            contributions,
+            version,
+        })
+        .into()
+    }
+}
+
+impl HelmholtzEnergyFunctional for FMTFunctional {
+    fn contributions(&self) -> &[Box<dyn FunctionalContribution>] {
+        &self.contributions
+    }
+
+    fn subset(&self, component_list: &[usize]) -> DFT<Self> {
+        let sigma = component_list
+            .iter()
+            .map(|&c| self.properties.sigma[c])
+            .collect();
+        Self::new(&sigma, self.version)
+    }
+
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
+        moles.sum() / (moles * &self.properties.sigma).sum() * 1.2
+    }
+
+    fn molecule_shape(&self) -> MoleculeShape {
+        MoleculeShape::Spherical(self.properties.sigma.len())
+    }
+}
+
+impl PairPotential for FMTFunctional {
+    fn pair_potential(&self, i: usize, r: &Array1<f64>, _: f64) -> Array2<f64> {
+        let s = &self.properties.sigma;
+        Array::from_shape_fn((s.len(), r.len()), |(j, k)| {
+            if r[k] > 0.5 * (s[i] + s[j]) {
+                0.0
+            } else {
+                f64::INFINITY
+            }
+        })
+    }
+}
+
+impl FluidParameters for FMTFunctional {
+    fn epsilon_k_ff(&self) -> Array1<f64> {
+        Array::zeros(self.properties.sigma.len())
+    }
+
+    fn sigma_ff(&self) -> &Array1<f64> {
+        &self.properties.sigma
+    }
+}

--- a/feos-dft/src/geometry.rs
+++ b/feos-dft/src/geometry.rs
@@ -1,0 +1,238 @@
+use feos_core::{EosResult, EosUnit};
+use ndarray::Array1;
+use quantity::{QuantityArray1, QuantityArray2, QuantityScalar};
+use std::f64::consts::{FRAC_PI_3, PI};
+
+/// Grids with up to three dimensions.
+#[derive(Clone)]
+pub enum Grid {
+    Cartesian1(Axis),
+    Cartesian2(Axis, Axis),
+    Periodical2(Axis, Axis),
+    Cartesian3(Axis, Axis, Axis),
+    Periodical3(Axis, Axis, Axis),
+    Spherical(Axis),
+    Polar(Axis),
+    Cylindrical { r: Axis, z: Axis },
+}
+
+impl Grid {
+    pub fn new_1d(axis: Axis) -> Self {
+        match axis.geometry {
+            Geometry::Cartesian => Self::Cartesian1(axis),
+            Geometry::Cylindrical => Self::Polar(axis),
+            Geometry::Spherical => Self::Spherical(axis),
+        }
+    }
+
+    pub fn axes(&self) -> Vec<&Axis> {
+        match self {
+            Self::Cartesian1(x) => vec![x],
+            Self::Cartesian2(x, y) | Self::Periodical2(x, y) => vec![x, y],
+            Self::Cartesian3(x, y, z) | Self::Periodical3(x, y, z) => vec![x, y, z],
+            Self::Spherical(r) | Self::Polar(r) => vec![r],
+            Self::Cylindrical { r, z } => vec![r, z],
+        }
+    }
+
+    pub fn axes_mut(&mut self) -> Vec<&mut Axis> {
+        match self {
+            Self::Cartesian1(x) => vec![x],
+            Self::Cartesian2(x, y) | Self::Periodical2(x, y) => vec![x, y],
+            Self::Cartesian3(x, y, z) | Self::Periodical3(x, y, z) => vec![x, y, z],
+            Self::Spherical(r) | Self::Polar(r) => vec![r],
+            Self::Cylindrical { r, z } => vec![r, z],
+        }
+    }
+
+    pub fn grids(&self) -> Vec<&Array1<f64>> {
+        self.axes().iter().map(|ax| &ax.grid).collect()
+    }
+
+    pub(crate) fn integration_weights(&self) -> Vec<&Array1<f64>> {
+        self.axes()
+            .iter()
+            .map(|ax| &ax.integration_weights)
+            .collect()
+    }
+
+    pub(crate) fn integration_weights_unit<U: EosUnit>(&self) -> Vec<QuantityArray1<U>> {
+        self.axes()
+            .iter()
+            .map(|ax| &ax.integration_weights * U::reference_length().powi(ax.geometry.dimension()))
+            .collect()
+    }
+}
+
+/// Geometries of individual axes.
+#[derive(Copy, Clone)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub enum Geometry {
+    Cartesian,
+    Cylindrical,
+    Spherical,
+}
+
+impl Geometry {
+    /// Return the number of spatial dimensions for this geometry.
+    pub fn dimension(&self) -> i32 {
+        match self {
+            Self::Cartesian => 1,
+            Self::Cylindrical => 2,
+            Self::Spherical => 3,
+        }
+    }
+}
+
+/// An individual discretized axis.
+#[derive(Clone)]
+pub struct Axis {
+    pub geometry: Geometry,
+    pub grid: Array1<f64>,
+    pub edges: Array1<f64>,
+    integration_weights: Array1<f64>,
+    potential_offset: f64,
+}
+
+impl Axis {
+    /// Create a new (equidistant) cartesian axis.
+    ///
+    /// The potential_offset is required to make sure that particles
+    /// can not interact through walls.
+    pub fn new_cartesian<U: EosUnit>(
+        points: usize,
+        length: QuantityScalar<U>,
+        potential_offset: Option<f64>,
+    ) -> EosResult<Self> {
+        let potential_offset = potential_offset.unwrap_or(0.0);
+        let l = length.to_reduced(U::reference_length())? + potential_offset;
+        let cell_size = l / points as f64;
+        let grid = Array1::linspace(0.5 * cell_size, l - 0.5 * cell_size, points);
+        let edges = Array1::linspace(0.0, l, points + 1);
+        let integration_weights = Array1::from_elem(points, cell_size);
+        Ok(Self {
+            geometry: Geometry::Cartesian,
+            grid,
+            edges,
+            integration_weights,
+            potential_offset,
+        })
+    }
+
+    /// Create a new (equidistant) spherical axis.
+    pub fn new_spherical<U: EosUnit>(points: usize, length: QuantityScalar<U>) -> EosResult<Self> {
+        let l = length.to_reduced(U::reference_length())?;
+        let cell_size = l / points as f64;
+        let grid = Array1::linspace(0.5 * cell_size, l - 0.5 * cell_size, points);
+        let edges = Array1::linspace(0.0, l, points + 1);
+        let integration_weights = Array1::from_shape_fn(points, |k| {
+            4.0 * FRAC_PI_3 * cell_size.powi(3) * (3 * k * k + 3 * k + 1) as f64
+        });
+        Ok(Self {
+            geometry: Geometry::Spherical,
+            grid,
+            edges,
+            integration_weights,
+            potential_offset: 0.0,
+        })
+    }
+
+    /// Create a new logarithmically scaled cylindrical axis.
+    pub fn new_polar<U: EosUnit>(points: usize, length: QuantityScalar<U>) -> EosResult<Self> {
+        let l = length.to_reduced(U::reference_length())?;
+
+        let mut alpha = 0.002_f64;
+        for _ in 0..20 {
+            alpha = -(1.0 - (-alpha).exp()).ln() / (points - 1) as f64;
+        }
+        let x0 = 0.5 * ((-alpha * points as f64).exp() + (-alpha * (points - 1) as f64).exp());
+        let grid = (0..points)
+            .into_iter()
+            .map(|i| l * x0 * (alpha * i as f64).exp())
+            .collect();
+        let edges = (0..=points)
+            .into_iter()
+            .map(|i| {
+                if i == 0 {
+                    0.0
+                } else {
+                    l * (-alpha * (points - i) as f64).exp()
+                }
+            })
+            .collect();
+
+        let k0 = (2.0 * alpha).exp() * (2.0 * alpha.exp() + (2.0 * alpha).exp() - 1.0)
+            / ((1.0 + alpha.exp()).powi(2) * ((2.0 * alpha).exp() - 1.0));
+        let integration_weights = (0..points)
+            .into_iter()
+            .map(|i| {
+                (match i {
+                    0 => k0 * (2.0 * alpha).exp(),
+                    1 => ((2.0 * alpha).exp() - k0) * (2.0 * alpha).exp(),
+                    _ => (2.0 * alpha * i as f64).exp() * ((2.0 * alpha).exp() - 1.0),
+                }) * ((-2.0 * alpha * points as f64).exp() * PI * l * l)
+            })
+            .collect();
+
+        Ok(Self {
+            geometry: Geometry::Cylindrical,
+            grid,
+            edges,
+            integration_weights,
+            potential_offset: 0.0,
+        })
+    }
+
+    /// Returns the total length of the axis.
+    ///
+    /// This includes the `potential_offset` and used e.g.
+    /// to determine the correct frequency vector in FFT.
+    pub fn length(&self) -> f64 {
+        self.edges[self.grid.len()] - self.edges[0]
+    }
+
+    /// Returns the volume of the axis.
+    ///
+    /// Depending on the geometry, the result is in m, m² or m³.
+    /// The `potential_offset` is not included in the volume, as
+    /// it is mainly used to calculate excess properties.
+    pub fn volume<U: EosUnit>(&self) -> QuantityScalar<U> {
+        let length = (self.edges[self.grid.len()] - self.potential_offset - self.edges[0])
+            * U::reference_length();
+        (match self.geometry {
+            Geometry::Cartesian => 1.0,
+            Geometry::Cylindrical => 4.0 * PI,
+            Geometry::Spherical => 4.0 * FRAC_PI_3,
+        }) * length.powi(self.geometry.dimension())
+    }
+
+    /// Interpolate a function on the given axis.
+    pub fn interpolate<U: EosUnit>(
+        &self,
+        x: f64,
+        y: &QuantityArray2<U>,
+        i: usize,
+    ) -> QuantityScalar<U> {
+        let n = self.grid.len();
+        y.get((
+            i,
+            if x >= self.edges[n] {
+                n - 1
+            } else {
+                match self.geometry {
+                    Geometry::Cartesian | Geometry::Spherical => (x / self.edges[1]) as usize,
+                    Geometry::Cylindrical => {
+                        if x < self.edges[1] {
+                            0
+                        } else {
+                            (n as f64
+                                - (n - 1) as f64 * (x / self.edges[n]).ln()
+                                    / (self.edges[1] / self.edges[n]).ln())
+                                as usize
+                        }
+                    }
+                }
+            },
+        ))
+    }
+}

--- a/feos-dft/src/ideal_chain_contribution.rs
+++ b/feos-dft/src/ideal_chain_contribution.rs
@@ -1,0 +1,77 @@
+use feos_core::{EosResult, EosUnit, HelmholtzEnergyDual, StateHD};
+use ndarray::*;
+use num_dual::DualNum;
+use quantity::{QuantityArray, QuantityScalar};
+use std::fmt;
+
+#[derive(Clone)]
+pub struct IdealChainContribution {
+    component_index: Array1<usize>,
+    m: Array1<f64>,
+}
+
+impl IdealChainContribution {
+    pub fn new(component_index: &Array1<usize>, m: &Array1<f64>) -> Self {
+        Self {
+            component_index: component_index.clone(),
+            m: m.clone(),
+        }
+    }
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for IdealChainContribution {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let segments = self.component_index.len();
+        if self.component_index[segments - 1] + 1 != segments {
+            return D::zero();
+        }
+
+        // calculate segment density
+        let density = self.component_index.mapv(|c| state.partial_density[c]);
+
+        // calculate Helmholtz energy
+        (&density
+            * &(&self.m - 1.0)
+            * density.mapv(|r| (r.abs() + D::from(f64::EPSILON)).ln() - 1.0))
+        .sum()
+            * state.volume
+    }
+}
+
+impl fmt::Display for IdealChainContribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ideal chain")
+    }
+}
+
+impl IdealChainContribution {
+    pub fn calculate_helmholtz_energy_density<D, N>(
+        &self,
+        density: &Array<N, D::Larger>,
+    ) -> EosResult<Array<N, D>>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+        N: DualNum<f64>,
+    {
+        let mut phi = Array::zeros(density.raw_dim().remove_axis(Axis(0)));
+        for (i, rhoi) in density.outer_iter().enumerate() {
+            phi += &rhoi.mapv(|rhoi| (rhoi.ln() - 1.0) * (self.m[i] - 1.0) * rhoi);
+        }
+        Ok(phi)
+    }
+
+    pub fn helmholtz_energy_density<U: EosUnit, D>(
+        &self,
+        temperature: QuantityScalar<U>,
+        density: &QuantityArray<U, D::Larger>,
+    ) -> EosResult<QuantityArray<U, D>>
+    where
+        D: Dimension,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        let rho = density.to_reduced(U::reference_density())?;
+        let t = temperature.to_reduced(U::reference_temperature())?;
+        Ok(self.calculate_helmholtz_energy_density(&rho)? * t * U::reference_pressure())
+    }
+}

--- a/feos-dft/src/interface/mod.rs
+++ b/feos-dft/src/interface/mod.rs
@@ -1,0 +1,320 @@
+//! Density profiles at planar interfaces and interfacial tensions.
+use crate::convolver::ConvolverFFT;
+use crate::functional::{HelmholtzEnergyFunctional, DFT};
+use crate::geometry::{Axis, Grid};
+use crate::profile::{DFTProfile, DFTSpecifications};
+use crate::solver::DFTSolver;
+use feos_core::{Contributions, EosError, EosResult, EosUnit, PhaseEquilibrium};
+use ndarray::{s, Array, Array1, Array2, Axis as Axis_nd, Ix1};
+use quantity::{QuantityArray1, QuantityArray2, QuantityScalar};
+
+mod surface_tension_diagram;
+pub use surface_tension_diagram::SurfaceTensionDiagram;
+
+const RELATIVE_WIDTH: f64 = 6.0;
+const MIN_WIDTH: f64 = 100.0;
+
+/// Density profile and properties of a planar interface.
+pub struct PlanarInterface<U: EosUnit, F: HelmholtzEnergyFunctional> {
+    pub profile: DFTProfile<U, Ix1, F>,
+    pub vle: PhaseEquilibrium<U, DFT<F>, 2>,
+    pub surface_tension: Option<QuantityScalar<U>>,
+    pub equimolar_radius: Option<QuantityScalar<U>>,
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> Clone for PlanarInterface<U, F> {
+    fn clone(&self) -> Self {
+        Self {
+            profile: self.profile.clone(),
+            vle: self.vle.clone(),
+            surface_tension: self.surface_tension,
+            equimolar_radius: self.equimolar_radius,
+        }
+    }
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> PlanarInterface<U, F> {
+    pub fn solve_inplace(&mut self, solver: Option<&DFTSolver>, debug: bool) -> EosResult<()> {
+        // Solve the profile
+        self.profile.solve(solver, debug)?;
+
+        // postprocess
+        self.surface_tension = Some(self.profile.integrate(
+            &(self.profile.grand_potential_density()?
+                + self.vle.vapor().pressure(Contributions::Total)),
+        ));
+        let delta_rho = self.vle.liquid().density - self.vle.vapor().density;
+        self.equimolar_radius = Some(
+            self.profile
+                .integrate(&(self.profile.density.sum_axis(Axis_nd(0)) - self.vle.vapor().density))
+                / delta_rho,
+        );
+
+        Ok(())
+    }
+
+    pub fn solve(mut self, solver: Option<&DFTSolver>) -> EosResult<Self> {
+        self.solve_inplace(solver, false)?;
+        Ok(self)
+    }
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> PlanarInterface<U, F> {
+    pub fn new(
+        vle: &PhaseEquilibrium<U, DFT<F>, 2>,
+        n_grid: usize,
+        l_grid: QuantityScalar<U>,
+    ) -> EosResult<Self> {
+        let dft = &vle.vapor().eos;
+
+        // generate grid
+        let grid = Grid::Cartesian1(Axis::new_cartesian(n_grid, l_grid, None)?);
+
+        // initialize convolver
+        let t = vle
+            .vapor()
+            .temperature
+            .to_reduced(U::reference_temperature())?;
+        let weight_functions = dft.weight_functions(t);
+        let convolver = ConvolverFFT::plan(&grid, &weight_functions, None);
+
+        Ok(Self {
+            profile: DFTProfile::new(grid, convolver, vle.vapor(), None, None)?,
+            vle: vle.clone(),
+            surface_tension: None,
+            equimolar_radius: None,
+        })
+    }
+
+    pub fn from_tanh(
+        vle: &PhaseEquilibrium<U, DFT<F>, 2>,
+        n_grid: usize,
+        l_grid: QuantityScalar<U>,
+        critical_temperature: QuantityScalar<U>,
+    ) -> EosResult<Self> {
+        let mut profile = Self::new(vle, n_grid, l_grid)?;
+
+        // calculate segment indices
+        let indices = &profile.profile.dft.component_index();
+
+        // calculate density profile
+        let z0 = 0.5 * l_grid.to_reduced(U::reference_length())?;
+        let (z0, sign) = (z0.abs(), -z0.signum());
+        let reduced_temperature = vle.vapor().temperature.to_reduced(critical_temperature)?;
+        profile.profile.density =
+            QuantityArray2::from_shape_fn(profile.profile.density.raw_dim(), |(i, z)| {
+                let rho_v = profile.vle.vapor().partial_density.get(indices[i]);
+                let rho_l = profile.vle.liquid().partial_density.get(indices[i]);
+                0.5 * (rho_l - rho_v)
+                    * (sign * (profile.profile.grid.grids()[0][z] - z0) / 3.0
+                        * (2.4728 - 2.3625 * reduced_temperature))
+                        .tanh()
+                    + 0.5 * (rho_l + rho_v)
+            });
+
+        // specify specification
+        profile.profile.specification =
+            DFTSpecifications::total_moles_from_profile(&profile.profile)?;
+
+        Ok(profile)
+    }
+
+    pub fn from_pdgt(vle: &PhaseEquilibrium<U, DFT<F>, 2>, n_grid: usize) -> EosResult<Self> {
+        let dft = &vle.vapor().eos;
+
+        if dft.component_index().len() != 1 {
+            panic!("Initialization from pDGT not possible for segment DFT or mixtures");
+        }
+
+        // calculate density profile from pDGT
+        let n_grid_pdgt = 20;
+        let mut z_pdgt = Array1::zeros(n_grid_pdgt) * U::reference_length();
+        let mut w_pdgt = U::reference_length();
+        let (rho_pdgt, gamma_pdgt) =
+            dft.solve_pdgt(vle, 20, 0, Some((&mut z_pdgt, &mut w_pdgt)))?;
+        if !gamma_pdgt
+            .to_reduced(U::reference_surface_tension())?
+            .is_normal()
+        {
+            return Err(EosError::InvalidState(
+                String::from("DFTProfile::from_pdgt"),
+                String::from("gamma_pdgt"),
+                gamma_pdgt.to_reduced(U::reference_surface_tension())?,
+            ));
+        }
+
+        // create PlanarInterface
+        let l_grid = (MIN_WIDTH * U::reference_length())
+            .max(w_pdgt * RELATIVE_WIDTH)
+            .unwrap();
+        let mut profile = Self::new(vle, n_grid, l_grid)?;
+
+        // interpolate density profile from pDGT to DFT
+        let r = l_grid * 0.5;
+        profile.profile.density = interp_symmetric(
+            vle,
+            z_pdgt,
+            rho_pdgt,
+            &profile.vle,
+            profile.profile.grid.grids()[0],
+            r,
+        )?;
+
+        // specify specification
+        profile.profile.specification =
+            DFTSpecifications::total_moles_from_profile(&profile.profile)?;
+
+        Ok(profile)
+    }
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> PlanarInterface<U, F> {
+    pub fn shift_equimolar_inplace(&mut self) {
+        let s = self.profile.density.shape();
+        let m = &self.profile.dft.m();
+        let mut rho_l = 0.0 * U::reference_density();
+        let mut rho_v = 0.0 * U::reference_density();
+        let mut rho = Array::zeros(s[1]) * U::reference_density();
+        for i in 0..s[0] {
+            rho_l += self.profile.density.get((i, 0)) * m[i];
+            rho_v += self.profile.density.get((i, s[1] - 1)) * m[i];
+            rho += &(&self.profile.density.index_axis(Axis_nd(0), i) * m[i]);
+        }
+
+        let x = (rho - rho_v) / (rho_l - rho_v);
+        let ze = self.profile.grid.axes()[0].edges[0]
+            + self
+                .profile
+                .integrate(&x)
+                .to_reduced(U::reference_length())
+                .unwrap();
+        self.profile.grid.axes_mut()[0].grid -= ze;
+    }
+
+    pub fn shift_equimolar(mut self) -> Self {
+        self.shift_equimolar_inplace();
+        self
+    }
+
+    fn set_density_scale(&mut self, init: &QuantityArray2<U>) {
+        assert_eq!(self.profile.density.shape(), init.shape());
+        let n_grid = self.profile.density.shape()[1];
+        let drho_init = &init.index_axis(Axis_nd(1), 0) - &init.index_axis(Axis_nd(1), n_grid - 1);
+        let rho_init_0 = init.index_axis(Axis_nd(1), n_grid - 1);
+        let drho = &self.profile.density.index_axis(Axis_nd(1), 0)
+            - &self.profile.density.index_axis(Axis_nd(1), n_grid - 1);
+        let rho_0 = self.profile.density.index_axis(Axis_nd(1), n_grid - 1);
+
+        self.profile.density =
+            QuantityArray2::from_shape_fn(self.profile.density.raw_dim(), |(i, j)| {
+                (init.get((i, j)) - rho_init_0.get(i))
+                    .to_reduced(drho_init.get(i))
+                    .unwrap()
+                    * drho.get(i)
+                    + rho_0.get(i)
+            });
+    }
+
+    pub fn set_density_inplace(&mut self, init: &QuantityArray2<U>, scale: bool) {
+        if scale {
+            self.set_density_scale(init)
+        } else {
+            assert_eq!(self.profile.density.shape(), init.shape());
+            self.profile.density = init.clone();
+        }
+    }
+
+    pub fn set_density(mut self, init: &QuantityArray2<U>, scale: bool) -> Self {
+        self.set_density_inplace(init, scale);
+        self
+    }
+}
+
+fn interp_symmetric<U: EosUnit, F: HelmholtzEnergyFunctional>(
+    vle_pdgt: &PhaseEquilibrium<U, DFT<F>, 2>,
+    z_pdgt: QuantityArray1<U>,
+    rho_pdgt: QuantityArray2<U>,
+    vle: &PhaseEquilibrium<U, DFT<F>, 2>,
+    z: &Array1<f64>,
+    radius: QuantityScalar<U>,
+) -> EosResult<QuantityArray2<U>> {
+    let reduced_density = Array2::from_shape_fn(rho_pdgt.raw_dim(), |(i, j)| {
+        (rho_pdgt.get((i, j)) - vle_pdgt.vapor().partial_density.get(i))
+            .to_reduced(
+                vle_pdgt.liquid().partial_density.get(i) - vle_pdgt.vapor().partial_density.get(i),
+            )
+            .unwrap()
+            - 0.5
+    });
+    let segments = vle_pdgt.vapor().eos.component_index().len();
+    let mut reduced_density = interp(
+        &z_pdgt.to_reduced(U::reference_length())?,
+        &reduced_density,
+        &(z - radius.to_reduced(U::reference_length())?),
+        &Array1::from_elem(segments, 0.5),
+        &Array1::from_elem(segments, -0.5),
+        false,
+    ) + interp(
+        &z_pdgt.to_reduced(U::reference_length())?,
+        &reduced_density,
+        &(z + radius.to_reduced(U::reference_length())?),
+        &Array1::from_elem(segments, -0.5),
+        &Array1::from_elem(segments, 0.5),
+        true,
+    );
+    if radius < 0.0 * U::reference_length() {
+        reduced_density += 1.0;
+    }
+    Ok(QuantityArray2::from_shape_fn(
+        reduced_density.raw_dim(),
+        |(i, j)| {
+            reduced_density[(i, j)]
+                * (vle.liquid().partial_density.get(i) - vle.vapor().partial_density.get(i))
+                + vle.vapor().partial_density.get(i)
+        },
+    ))
+}
+
+fn interp(
+    x_old: &Array1<f64>,
+    y_old: &Array2<f64>,
+    x_new: &Array1<f64>,
+    y_left: &Array1<f64>,
+    y_right: &Array1<f64>,
+    reverse: bool,
+) -> Array2<f64> {
+    let n = x_old.len();
+
+    let (x_rev, y_rev) = if reverse {
+        (-&x_old.slice(s![..;-1]), y_old.slice(s![.., ..;-1]))
+    } else {
+        (x_old.to_owned(), y_old.view())
+    };
+
+    let mut y_new = Array2::zeros((y_rev.shape()[0], x_new.len()));
+    let mut k = 0;
+    for i in 0..x_new.len() {
+        while k < n && x_new[i] > x_rev[k] {
+            k += 1;
+        }
+        y_new.slice_mut(s![.., i]).assign(&if k == 0 {
+            y_left
+                + &((&y_rev.slice(s![.., 0]) - y_left)
+                    * ((&y_rev.slice(s![.., 1]) - y_left) / (&y_rev.slice(s![.., 0]) - y_left))
+                        .mapv(|x| x.powf((x_new[i] - x_rev[0]) / (x_rev[1] - x_rev[0]))))
+        } else if k == n {
+            y_right
+                + &((&y_rev.slice(s![.., n - 2]) - y_right)
+                    * ((&y_rev.slice(s![.., n - 1]) - y_right)
+                        / (&y_rev.slice(s![.., n - 2]) - y_right))
+                        .mapv(|x| {
+                            x.powf((x_new[i] - x_rev[n - 2]) / (x_rev[n - 1] - x_rev[n - 2]))
+                        }))
+        } else {
+            &y_rev.slice(s![.., k - 1])
+                + &((x_new[i] - x_rev[k - 1]) / (x_rev[k] - x_rev[k - 1])
+                    * (&y_rev.slice(s![.., k]) - &y_rev.slice(s![.., k - 1])))
+        });
+    }
+    y_new
+}

--- a/feos-dft/src/interface/surface_tension_diagram.rs
+++ b/feos-dft/src/interface/surface_tension_diagram.rs
@@ -1,0 +1,79 @@
+use super::PlanarInterface;
+use crate::functional::{HelmholtzEnergyFunctional, DFT};
+use crate::solver::DFTSolver;
+use feos_core::{EosUnit, PhaseEquilibrium, StateVec};
+use quantity::{QuantityArray1, QuantityScalar};
+
+const DEFAULT_GRID_POINTS: usize = 2048;
+
+/// Container structure for the efficient calculation of surface tension diagrams.
+pub struct SurfaceTensionDiagram<U: EosUnit, F: HelmholtzEnergyFunctional> {
+    pub profiles: Vec<PlanarInterface<U, F>>,
+}
+
+#[allow(clippy::ptr_arg)]
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> SurfaceTensionDiagram<U, F> {
+    pub fn new(
+        dia: &Vec<PhaseEquilibrium<U, DFT<F>, 2>>,
+        init_densities: Option<bool>,
+        n_grid: Option<usize>,
+        l_grid: Option<QuantityScalar<U>>,
+        critical_temperature: Option<QuantityScalar<U>>,
+        solver: Option<&DFTSolver>,
+    ) -> Self {
+        let n_grid = n_grid.unwrap_or(DEFAULT_GRID_POINTS);
+        let mut profiles: Vec<PlanarInterface<U, F>> = Vec::with_capacity(dia.len());
+        for vle in dia.iter() {
+            // check for a critical point
+            let profile = if PhaseEquilibrium::is_trivial_solution(vle.vapor(), vle.liquid()) {
+                PlanarInterface::from_tanh(
+                    vle,
+                    10,
+                    100.0 * U::reference_length(),
+                    500.0 * U::reference_temperature(),
+                )
+            } else {
+                // initialize with pDGT for single segments and tanh for mixtures and segment DFT
+                if vle.vapor().eos.component_index().len() == 1 {
+                    PlanarInterface::from_pdgt(vle, n_grid)
+                } else {
+                    PlanarInterface::from_tanh(
+                        vle,
+                        n_grid,
+                        l_grid.unwrap_or(100.0 * U::reference_length()),
+                        critical_temperature.unwrap_or(500.0 * U::reference_temperature()),
+                    )
+                }
+                .map(|mut profile| {
+                    if let Some(init) = profiles.last() {
+                        if init.profile.density.shape() == profile.profile.density.shape() {
+                            if let Some(scale) = init_densities {
+                                profile.set_density_inplace(&init.profile.density, scale)
+                            }
+                        }
+                    }
+                    profile
+                })
+            }
+            .and_then(|profile| profile.solve(solver));
+            if let Ok(profile) = profile {
+                profiles.push(profile);
+            }
+        }
+        Self { profiles }
+    }
+
+    pub fn vapor(&self) -> StateVec<'_, U, DFT<F>> {
+        self.profiles.iter().map(|p| p.vle.vapor()).collect()
+    }
+
+    pub fn liquid(&self) -> StateVec<'_, U, DFT<F>> {
+        self.profiles.iter().map(|p| p.vle.liquid()).collect()
+    }
+
+    pub fn surface_tension(&mut self) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(self.profiles.len(), |i| {
+            self.profiles[i].surface_tension.unwrap()
+        })
+    }
+}

--- a/feos-dft/src/lib.rs
+++ b/feos-dft/src/lib.rs
@@ -1,0 +1,29 @@
+#![warn(clippy::all)]
+#![allow(clippy::suspicious_operation_groupings)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::new_ret_no_self)]
+
+pub mod adsorption;
+mod convolver;
+mod functional;
+mod functional_contribution;
+pub mod fundamental_measure_theory;
+mod geometry;
+mod ideal_chain_contribution;
+pub mod interface;
+mod pdgt;
+mod profile;
+pub mod solvation;
+mod solver;
+mod weight_functions;
+
+pub use convolver::{Convolver, ConvolverFFT};
+pub use functional::{HelmholtzEnergyFunctional, MoleculeShape, DFT};
+pub use functional_contribution::{FunctionalContribution, FunctionalContributionDual};
+pub use geometry::{Axis, Geometry, Grid};
+pub use profile::{DFTProfile, DFTSpecification, DFTSpecifications};
+pub use solver::DFTSolver;
+pub use weight_functions::{WeightFunction, WeightFunctionInfo, WeightFunctionShape};
+
+#[cfg(feature = "python")]
+pub mod python;

--- a/feos-dft/src/pdgt.rs
+++ b/feos-dft/src/pdgt.rs
@@ -1,0 +1,241 @@
+use super::functional::{HelmholtzEnergyFunctional, DFT};
+use super::functional_contribution::FunctionalContribution;
+use super::weight_functions::WeightFunctionInfo;
+use feos_core::{Contributions, EosResult, EosUnit, EquationOfState, PhaseEquilibrium};
+use ndarray::*;
+use num_dual::HyperDual64;
+use quantity::{QuantityArray1, QuantityArray2, QuantityScalar};
+use std::ops::AddAssign;
+
+impl WeightFunctionInfo<HyperDual64> {
+    fn pdgt_weight_constants(&self) -> (Array2<f64>, Array2<f64>, Array2<f64>) {
+        let k = HyperDual64::from(0.0).derive1().derive2();
+        let w = self.weight_constants(k, 1);
+        (
+            w.mapv(|w| w.re),
+            w.mapv(|w| -w.eps1[0]),
+            w.mapv(|w| -0.5 * w.eps1eps2[(0, 0)]),
+        )
+    }
+}
+
+impl dyn FunctionalContribution {
+    pub fn pdgt_properties(
+        &self,
+        temperature: f64,
+        density: &Array2<f64>,
+        helmholtz_energy_density: &mut Array1<f64>,
+        first_partial_derivatives: Option<&mut Array2<f64>>,
+        second_partial_derivatives: Option<&mut Array3<f64>>,
+        influence_diagonal: Option<&mut Array2<f64>>,
+        influence_matrix: Option<&mut Array3<f64>>,
+    ) -> EosResult<()> {
+        // calculate weighted densities
+        let weight_functions = self.weight_functions_pdgt(HyperDual64::from(temperature));
+        let (w0, w1, w2) = weight_functions.pdgt_weight_constants();
+        let weighted_densities = w0.dot(density);
+
+        // calculate Helmholtz energy and derivatives
+        let w = weighted_densities.shape()[0]; // # of weighted densities
+        let s = density.shape()[0]; // # of segments
+        let n = density.shape()[1]; // # of grid points
+        let mut df = Array::zeros((w, n));
+        let mut d2f = Array::zeros((w, w, n));
+        self.second_partial_derivatives(
+            temperature,
+            weighted_densities,
+            helmholtz_energy_density.view_mut(),
+            df.view_mut(),
+            d2f.view_mut(),
+        )?;
+
+        // calculate partial derivatives w.r.t. density
+        if let Some(df_drho) = first_partial_derivatives {
+            df_drho.assign(&df.t().dot(&w0));
+        }
+
+        // calculate second partial derivatives w.r.t. density
+        if let Some(d2f_drho2) = second_partial_derivatives {
+            for i in 0..s {
+                for j in 0..s {
+                    for alpha in 0..w {
+                        for beta in 0..w {
+                            d2f_drho2
+                                .index_axis_mut(Axis(0), i)
+                                .index_axis_mut(Axis(0), j)
+                                .add_assign(
+                                    &(&d2f.index_axis(Axis(0), alpha).index_axis(Axis(0), beta)
+                                        * w0[(alpha, i)]
+                                        * w0[(beta, j)]),
+                                );
+                        }
+                    }
+                }
+            }
+        }
+
+        // calculate influence diagonal
+        if let Some(c) = influence_diagonal {
+            for i in 0..s {
+                for alpha in 0..w {
+                    for beta in 0..w {
+                        c.index_axis_mut(Axis(0), i).add_assign(
+                            &(&d2f.index_axis(Axis(0), alpha).index_axis(Axis(0), beta)
+                                * (w1[(alpha, i)] * w1[(beta, i)]
+                                    - w0[(alpha, i)] * w2[(beta, i)]
+                                    - w2[(alpha, i)] * w0[(beta, i)])),
+                        );
+                    }
+                }
+            }
+        }
+
+        // calculate influence matrix
+        if let Some(c) = influence_matrix {
+            for i in 0..s {
+                for j in 0..s {
+                    for alpha in 0..w {
+                        for beta in 0..w {
+                            c.index_axis_mut(Axis(0), i)
+                                .index_axis_mut(Axis(0), j)
+                                .add_assign(
+                                    &(&d2f.index_axis(Axis(0), alpha).index_axis(Axis(0), beta)
+                                        * (w1[(alpha, i)] * w1[(beta, j)]
+                                            - w0[(alpha, i)] * w2[(beta, j)]
+                                            - w2[(alpha, i)] * w0[(beta, j)])),
+                                );
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn influence_diagonal<U: EosUnit>(
+        &self,
+        temperature: QuantityScalar<U>,
+        density: &QuantityArray2<U>,
+    ) -> EosResult<(QuantityArray1<U>, QuantityArray2<U>)> {
+        let t = temperature.to_reduced(U::reference_temperature())?;
+        let n = density.shape()[1];
+        let mut f = Array::zeros(n);
+        let mut c = Array::zeros(density.raw_dim());
+        self.pdgt_properties(
+            t,
+            &density.to_reduced(U::reference_density())?,
+            &mut f,
+            None,
+            None,
+            Some(&mut c),
+            None,
+        )?;
+        Ok((
+            f * t * U::reference_pressure(),
+            c * t * U::reference_influence_parameter(),
+        ))
+    }
+}
+
+impl<T: HelmholtzEnergyFunctional> DFT<T> {
+    pub fn solve_pdgt<U: EosUnit>(
+        &self,
+        vle: &PhaseEquilibrium<U, Self, 2>,
+        n_grid: usize,
+        reference_component: usize,
+        z: Option<(&mut QuantityArray1<U>, &mut QuantityScalar<U>)>,
+    ) -> EosResult<(QuantityArray2<U>, QuantityScalar<U>)> {
+        // calculate density profile
+        let density = if self.components() == 1 {
+            let delta_rho = (vle.vapor().density - vle.liquid().density) / (n_grid + 1) as f64;
+            QuantityArray1::linspace(
+                vle.liquid().density + delta_rho,
+                vle.vapor().density - delta_rho,
+                n_grid,
+            )?
+            .insert_axis(Axis(0))
+        } else {
+            self.pdgt_density_profile_mix(vle, n_grid, reference_component)?
+        };
+
+        // calculate Helmholtz energy density and influence parameter
+        let mut delta_omega = Array::zeros(n_grid) * U::reference_pressure();
+        let mut influence_diagonal =
+            Array::zeros(density.raw_dim()) * U::reference_influence_parameter();
+        for contribution in self.contributions() {
+            let (f, c) = contribution.influence_diagonal(vle.vapor().temperature, &density)?;
+            delta_omega += &f;
+            influence_diagonal += &c;
+        }
+        delta_omega += &self
+            .ideal_chain_contribution()
+            .helmholtz_energy_density::<_, Ix1>(vle.vapor().temperature, &density)?;
+
+        let t = vle
+            .vapor()
+            .temperature
+            .to_reduced(U::reference_temperature())?;
+        let rho = density.to_reduced(U::reference_density())?;
+        delta_omega += &(self.ideal_gas_contribution::<Ix1>(t, &rho) * U::reference_pressure());
+
+        // calculate excess grand potential density
+        let mu = vle.vapor().chemical_potential(Contributions::Total);
+        for i in 0..self.components() {
+            let rhoi = density.index_axis(Axis(0), i);
+            let mui = mu.get(i);
+            delta_omega -= &(&rhoi * mui);
+        }
+        delta_omega += vle.vapor().pressure(Contributions::Total);
+
+        // calculate density gradients w.r.t. reference density
+        let dx = density.get((reference_component, 0)) - density.get((reference_component, 1));
+        let drho = density.gradient(
+            -dx,
+            &vle.liquid().partial_density,
+            &vle.vapor().partial_density,
+        );
+
+        // calculate integrand
+        let gamma_int =
+            ((influence_diagonal * delta_omega.clone() * 2.0).sqrt()? * drho).sum_axis(Axis(0));
+
+        // calculate z-axis
+        if let Some((z, w)) = z {
+            let z_int = gamma_int.clone() / (delta_omega * 2.0);
+            *z = z_int.integrate_trapezoidal_cumulative(dx);
+
+            // calculate equimolar surface
+            let rho_v = density.index_axis(Axis(1), 0).sum();
+            let rho_l = density.index_axis(Axis(1), n_grid - 1).sum();
+            let rho_r = (density.sum_axis(Axis(0)) - rho_v) / (rho_l - rho_v);
+            let ze = (rho_r.clone() * z_int.clone()).integrate_trapezoidal(dx);
+
+            // calculate interfacial width
+            *w = (rho_r * z.clone() * z_int).integrate_trapezoidal(dx);
+            *w = (24.0 * (*w - 0.5 * ze.powi(2))).sqrt()?;
+
+            // shift density profile
+            *z -= ze;
+        }
+
+        // integration weights (First and last points are 0)
+        let mut weights = Array::ones(n_grid);
+        weights[0] = 7.0 / 6.0;
+        weights[1] = 23.0 / 24.0;
+        weights[n_grid - 2] = 23.0 / 24.0;
+        weights[n_grid - 1] = 7.0 / 6.0;
+        let weights = weights * dx;
+
+        // calculate surface tension
+        Ok((density, gamma_int.integrate(&[weights])))
+    }
+
+    fn pdgt_density_profile_mix<U: EosUnit>(
+        &self,
+        _vle: &PhaseEquilibrium<U, Self, 2>,
+        _n_grid: usize,
+        _reference_component: usize,
+    ) -> EosResult<QuantityArray2<U>> {
+        unimplemented!()
+    }
+}

--- a/feos-dft/src/profile.rs
+++ b/feos-dft/src/profile.rs
@@ -1,0 +1,595 @@
+use crate::convolver::{Convolver, ConvolverFFT};
+use crate::functional::{HelmholtzEnergyFunctional, DFT};
+use crate::geometry::Grid;
+use crate::solver::DFTSolver;
+use crate::weight_functions::WeightFunctionInfo;
+use feos_core::{
+    log_result, Contributions, EosError, EosResult, EosUnit, EquationOfState, State, Verbosity,
+};
+use ndarray::{
+    s, Array, Array1, ArrayBase, ArrayViewMut, ArrayViewMut1, Axis as Axis_nd, Data, Dimension,
+    Ix1, Ix2, Ix3, RemoveAxis,
+};
+use num_dual::Dual64;
+use quantity::{Quantity, QuantityArray, QuantityArray1, QuantityScalar};
+use std::ops::MulAssign;
+use std::rc::Rc;
+
+pub(crate) const MAX_POTENTIAL: f64 = 50.0;
+pub(crate) const CUTOFF_RADIUS: f64 = 14.0;
+
+/// General specifications for the chemical potential in a DFT calculation.
+///
+/// In the most basic case, the chemical potential is specified in a DFT calculation,
+/// for more general systems, this trait provides the possibility to declare additional
+/// equations for the calculation of the chemical potential during the iteration.
+pub trait DFTSpecification<U, D: Dimension, F> {
+    fn calculate_chemical_potential(
+        &self,
+        profile: &DFTProfile<U, D, F>,
+        chemical_potential: &Array1<f64>,
+        z: &Array1<f64>,
+        bulk: &State<U, DFT<F>>,
+    ) -> EosResult<Array1<f64>>;
+}
+
+/// Common specifications for the grand potentials in a DFT calculation.
+pub enum DFTSpecifications {
+    /// DFT with specified chemical potential.
+    ChemicalPotential,
+    /// DFT with specified number of particles.
+    ///
+    /// The solution is still a grand canonical density profile, but the chemical
+    /// potentials are iterated together with the density profile to obtain a result
+    /// with the specified number of particles.
+    Moles { moles: Array1<f64> },
+    /// DFT with specified total number of moles and chemical potential differences.
+    TotalMoles {
+        total_moles: f64,
+        chemical_potential: Array1<f64>,
+    },
+}
+
+impl DFTSpecifications {
+    /// Calculate the number of particles from the profile.
+    ///
+    /// Call this after initializing the density profile to keep the number of
+    /// particles constant in systems, where the number itself is difficult to obtain.
+    pub fn moles_from_profile<U: EosUnit, D: Dimension, F: HelmholtzEnergyFunctional>(
+        profile: &DFTProfile<U, D, F>,
+    ) -> EosResult<Rc<Self>>
+    where
+        <D as Dimension>::Larger: Dimension<Smaller = D>,
+    {
+        let rho = profile.density.to_reduced(U::reference_density())?;
+        Ok(Rc::new(Self::Moles {
+            moles: profile.integrate_reduced_comp(&rho),
+        }))
+    }
+
+    /// Calculate the number of particles from the profile.
+    ///
+    /// Call this after initializing the density profile to keep the total number of
+    /// particles constant in systems, e.g. to fix the equimolar dividing surface.
+    pub fn total_moles_from_profile<U: EosUnit, D: Dimension, F: HelmholtzEnergyFunctional>(
+        profile: &DFTProfile<U, D, F>,
+    ) -> EosResult<Rc<Self>>
+    where
+        <D as Dimension>::Larger: Dimension<Smaller = D>,
+    {
+        let rho = profile
+            .density
+            .to_reduced(U::reference_density())?
+            .sum_axis(Axis_nd(0));
+        Ok(Rc::new(Self::TotalMoles {
+            total_moles: profile.integrate_reduced(rho),
+            chemical_potential: profile.reduced_chemical_potential()?,
+        }))
+    }
+}
+
+impl<U: EosUnit, D: Dimension, F: HelmholtzEnergyFunctional> DFTSpecification<U, D, F>
+    for DFTSpecifications
+{
+    fn calculate_chemical_potential(
+        &self,
+        profile: &DFTProfile<U, D, F>,
+        chemical_potential: &Array1<f64>,
+        z: &Array1<f64>,
+        _: &State<U, DFT<F>>,
+    ) -> EosResult<Array1<f64>> {
+        let m: &Array1<f64> = &profile.dft.m();
+        Ok(match self {
+            Self::ChemicalPotential => chemical_potential.clone(),
+            Self::Moles { moles } => (moles / z).mapv(f64::ln) * m,
+            Self::TotalMoles {
+                total_moles,
+                chemical_potential,
+            } => {
+                let exp_mu = (chemical_potential / m).mapv(f64::exp);
+                ((&exp_mu * *total_moles) / (z * &exp_mu).sum()).mapv(f64::ln) * m
+            }
+        })
+    }
+}
+
+/// A one-, two-, or three-dimensional density profile.
+pub struct DFTProfile<U, D: Dimension, F> {
+    pub grid: Grid,
+    pub convolver: Rc<dyn Convolver<f64, D>>,
+    pub dft: Rc<DFT<F>>,
+    pub temperature: QuantityScalar<U>,
+    pub density: QuantityArray<U, D::Larger>,
+    pub specification: Rc<dyn DFTSpecification<U, D, F>>,
+    pub external_potential: Array<f64, D::Larger>,
+    pub bulk: State<U, DFT<F>>,
+}
+
+impl<U: EosUnit, F> DFTProfile<U, Ix1, F> {
+    pub fn r(&self) -> QuantityArray1<U> {
+        self.grid.grids()[0] * U::reference_length()
+    }
+
+    pub fn z(&self) -> QuantityArray1<U> {
+        self.grid.grids()[0] * U::reference_length()
+    }
+}
+
+impl<U: EosUnit, F> DFTProfile<U, Ix2, F> {
+    pub fn edges(&self) -> (QuantityArray1<U>, QuantityArray1<U>) {
+        (
+            &self.grid.axes()[0].edges * U::reference_length(),
+            &self.grid.axes()[1].edges * U::reference_length(),
+        )
+    }
+
+    pub fn r(&self) -> QuantityArray1<U> {
+        self.grid.grids()[0] * U::reference_length()
+    }
+
+    pub fn z(&self) -> QuantityArray1<U> {
+        self.grid.grids()[1] * U::reference_length()
+    }
+}
+
+impl<U: EosUnit, F> DFTProfile<U, Ix3, F> {
+    pub fn edges(&self) -> (QuantityArray1<U>, QuantityArray1<U>, QuantityArray1<U>) {
+        (
+            &self.grid.axes()[0].edges * U::reference_length(),
+            &self.grid.axes()[1].edges * U::reference_length(),
+            &self.grid.axes()[2].edges * U::reference_length(),
+        )
+    }
+
+    pub fn x(&self) -> QuantityArray1<U> {
+        self.grid.grids()[0] * U::reference_length()
+    }
+
+    pub fn y(&self) -> QuantityArray1<U> {
+        self.grid.grids()[1] * U::reference_length()
+    }
+
+    pub fn z(&self) -> QuantityArray1<U> {
+        self.grid.grids()[2] * U::reference_length()
+    }
+}
+
+impl<U: EosUnit, D: Dimension, F: HelmholtzEnergyFunctional> DFTProfile<U, D, F>
+where
+    <D as Dimension>::Larger: Dimension<Smaller = D>,
+{
+    /// Create a new density profile.
+    ///
+    /// If no external potential is specified, it is set to 0. The density is
+    /// initialized based on the bulk state and the external potential. The
+    /// specification is set to `ChemicalPotential` and needs to be overriden
+    /// after this call if something else is required.
+    pub fn new(
+        grid: Grid,
+        convolver: Rc<dyn Convolver<f64, D>>,
+        bulk: &State<U, DFT<F>>,
+        external_potential: Option<Array<f64, D::Larger>>,
+        density: Option<&QuantityArray<U, D::Larger>>,
+    ) -> EosResult<Self> {
+        let dft = bulk.eos.clone();
+
+        // initialize external potential
+        let external_potential = external_potential.unwrap_or_else(|| {
+            let mut n_grid = vec![dft.component_index().len()];
+            grid.axes()
+                .iter()
+                .for_each(|&ax| n_grid.push(ax.grid.len()));
+            Array::zeros(n_grid).into_dimensionality().unwrap()
+        });
+
+        // initialize density
+        let density = if let Some(density) = density {
+            density.clone()
+        } else {
+            let t = bulk.temperature.to_reduced(U::reference_temperature())?;
+            let bonds = dft
+                .bond_integrals(t, &external_potential, &convolver)
+                .mapv(f64::abs)
+                * (-&external_potential).mapv(f64::exp);
+            let mut density = Array::zeros(external_potential.raw_dim());
+            let bulk_density = bulk.partial_density.to_reduced(U::reference_density())?;
+            for (s, &c) in dft.component_index().iter().enumerate() {
+                density.index_axis_mut(Axis_nd(0), s).assign(
+                    &(bonds.index_axis(Axis_nd(0), s).map(|is| is.min(1.0)) * bulk_density[c]),
+                );
+            }
+            density * U::reference_density()
+        };
+
+        Ok(Self {
+            grid,
+            convolver,
+            dft: bulk.eos.clone(),
+            temperature: bulk.temperature,
+            density,
+            specification: Rc::new(DFTSpecifications::ChemicalPotential),
+            external_potential,
+            bulk: bulk.clone(),
+        })
+    }
+
+    fn integrate_reduced(&self, mut profile: Array<f64, D>) -> f64 {
+        let integration_weights = self.grid.integration_weights();
+
+        for (i, w) in integration_weights.into_iter().enumerate() {
+            for mut l in profile.lanes_mut(Axis_nd(i)) {
+                l.mul_assign(w);
+            }
+        }
+        profile.sum()
+    }
+
+    fn integrate_reduced_comp(&self, profile: &Array<f64, D::Larger>) -> Array1<f64> {
+        Array1::from_shape_fn(profile.shape()[0], |i| {
+            self.integrate_reduced(profile.index_axis(Axis_nd(0), i).to_owned())
+        })
+    }
+
+    /// Return the volume of the profile.
+    ///
+    /// Depending on the geometry, the result is in m, m² or m³.
+    pub fn volume(&self) -> QuantityScalar<U> {
+        self.grid
+            .axes()
+            .iter()
+            .fold(None, |acc, &ax| {
+                Some(acc.map_or(ax.volume(), |acc| acc * ax.volume()))
+            })
+            .unwrap()
+    }
+
+    /// Integrate a given profile over the iteration domain.
+    pub fn integrate<S: Data<Elem = f64>>(
+        &self,
+        profile: &Quantity<ArrayBase<S, D>, U>,
+    ) -> QuantityScalar<U> {
+        profile.integrate(&self.grid.integration_weights_unit())
+    }
+
+    /// Integrate each component individually.
+    pub fn integrate_comp<S: Data<Elem = f64>>(
+        &self,
+        profile: &Quantity<ArrayBase<S, D::Larger>, U>,
+    ) -> QuantityArray1<U> {
+        QuantityArray1::from_shape_fn(profile.shape()[0], |i| {
+            self.integrate(&profile.index_axis(Axis_nd(0), i))
+        })
+    }
+
+    /// Return the number of moles of each component in the system.
+    pub fn moles(&self) -> QuantityArray1<U> {
+        let rho = self.density.to_reduced(U::reference_density()).unwrap();
+        let mut d = rho.raw_dim();
+        d[0] = self.dft.components();
+        let mut density_comps = Array::zeros(d);
+        for (i, &j) in self.dft.component_index().iter().enumerate() {
+            density_comps
+                .index_axis_mut(Axis_nd(0), j)
+                .assign(&rho.index_axis(Axis_nd(0), i));
+        }
+        self.integrate_comp(&(density_comps * U::reference_density()))
+    }
+
+    /// Return the total number of moles in the system.
+    pub fn total_moles(&self) -> QuantityScalar<U> {
+        self.moles().sum()
+    }
+
+    /// Return the chemical potential of the system
+    pub fn chemical_potential(&self) -> QuantityArray1<U> {
+        self.bulk.chemical_potential(Contributions::Total)
+    }
+
+    fn reduced_chemical_potential(&self) -> EosResult<Array1<f64>> {
+        let temperature = self
+            .bulk
+            .temperature
+            .to_reduced(U::reference_temperature())?;
+        let lambda_de_broglie = self
+            .dft
+            .ideal_gas()
+            .de_broglie_wavelength(temperature, self.bulk.eos.components());
+        let mu_comp = self
+            .chemical_potential()
+            .to_reduced(U::reference_molar_energy())?
+            / temperature
+            - lambda_de_broglie;
+        Ok(self.dft.component_index().mapv(|c| mu_comp[c]))
+    }
+}
+
+impl<U: Clone, D: Dimension, F> Clone for DFTProfile<U, D, F> {
+    fn clone(&self) -> Self {
+        Self {
+            grid: self.grid.clone(),
+            convolver: self.convolver.clone(),
+            dft: self.dft.clone(),
+            temperature: self.temperature.clone(),
+            density: self.density.clone(),
+            specification: self.specification.clone(),
+            external_potential: self.external_potential.clone(),
+            bulk: self.bulk.clone(),
+        }
+    }
+}
+
+impl<U, D, F> DFTProfile<U, D, F>
+where
+    U: EosUnit,
+    D: Dimension,
+    D::Larger: Dimension<Smaller = D>,
+    F: HelmholtzEnergyFunctional,
+{
+    pub fn weighted_densities(&self) -> EosResult<Vec<Array<f64, D::Larger>>> {
+        Ok(self
+            .convolver
+            .weighted_densities(&self.density.to_reduced(U::reference_density())?))
+    }
+
+    pub fn functional_derivative(&self) -> EosResult<Array<f64, D::Larger>> {
+        let (_, dfdrho) = self.dft.functional_derivative(
+            self.temperature.to_reduced(U::reference_temperature())?,
+            &self.density.to_reduced(U::reference_density())?,
+            &self.convolver,
+        )?;
+        Ok(dfdrho)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn residual(&self, log: bool) -> EosResult<(Array<f64, D::Larger>, Array1<f64>)> {
+        // Read from profile
+        let temperature = self.temperature.to_reduced(U::reference_temperature())?;
+        let density = self.density.to_reduced(U::reference_density())?;
+        let chemical_potential = self.reduced_chemical_potential()?;
+        let mut bulk = self.bulk.clone();
+
+        // Allocate residual vectors
+        let mut res_rho = Array::zeros(density.raw_dim());
+        let mut res_mu = Array1::zeros(chemical_potential.len());
+
+        self.calculate_residual(
+            temperature,
+            &density,
+            &chemical_potential,
+            &mut bulk,
+            res_rho.view_mut(),
+            res_mu.view_mut(),
+            log,
+        )?;
+
+        Ok((res_rho, res_mu))
+    }
+
+    fn calculate_residual(
+        &self,
+        temperature: f64,
+        density: &Array<f64, D::Larger>,
+        chemical_potential: &Array1<f64>,
+        bulk: &mut State<U, DFT<F>>,
+        mut res_rho: ArrayViewMut<f64, D::Larger>,
+        mut res_mu: ArrayViewMut1<f64>,
+        log: bool,
+    ) -> EosResult<()> {
+        // Update bulk state
+        let lambda_de_broglie = self
+            .dft
+            .ideal_gas()
+            .de_broglie_wavelength(temperature, bulk.eos.components());
+        let mut mu_comp = Array::zeros(bulk.eos.components());
+        for (s, &c) in self.dft.component_index().iter().enumerate() {
+            mu_comp[c] = chemical_potential[s];
+        }
+        bulk.update_chemical_potential(
+            &((mu_comp + lambda_de_broglie) * temperature * U::reference_molar_energy()),
+        )?;
+
+        // calculate intrinsic functional derivative
+        let (_, mut dfdrho) =
+            self.dft
+                .functional_derivative(temperature, density, &self.convolver)?;
+
+        // calculate total functional derivative
+        dfdrho += &self.external_potential;
+
+        // calculate bond integrals
+        let bonds = self
+            .dft
+            .bond_integrals(temperature, &dfdrho, &self.convolver);
+
+        // Euler-Lagrange equation
+        let m = &self.dft.m();
+        res_rho
+            .outer_iter_mut()
+            .zip(dfdrho.outer_iter())
+            .zip(chemical_potential.iter())
+            .zip(m.iter())
+            .zip(density.outer_iter())
+            .zip(bonds.outer_iter())
+            .for_each(|(((((mut res, df), &mu), &m), rho), is)| {
+                res.assign(
+                    &(if log {
+                        rho.mapv(f64::ln) - (mu - &df) / m - is.mapv(f64::ln)
+                    } else {
+                        &rho - &(((mu - &df) / m).mapv(f64::exp) * is)
+                    }),
+                );
+            });
+
+        // set residual to 0 where external potentials are overwhelming
+        res_rho
+            .iter_mut()
+            .zip(self.external_potential.iter())
+            .for_each(|(r, &p)| {
+                if p + f64::EPSILON >= MAX_POTENTIAL {
+                    *r = 0.0;
+                }
+            });
+
+        // Additional residuals for the calculation of the chemical potential
+        let z: Array1<_> = dfdrho
+            .outer_iter()
+            .zip(m.iter())
+            .zip(bonds.outer_iter())
+            .map(|((df, &m), is)| self.integrate_reduced((-&df / m).mapv(f64::exp) * is))
+            .collect();
+        let mu_spec =
+            self.specification
+                .calculate_chemical_potential(self, chemical_potential, &z, bulk)?;
+
+        res_mu.assign(
+            &(if log {
+                chemical_potential - &mu_spec
+            } else {
+                chemical_potential.mapv(f64::exp) - mu_spec.mapv(f64::exp)
+            }),
+        );
+
+        Ok(())
+    }
+
+    pub fn solve(&mut self, solver: Option<&DFTSolver>, debug: bool) -> EosResult<()> {
+        // unwrap solver
+        let solver = solver.cloned().unwrap_or_default();
+
+        // Read from profile
+        let temperature = self.temperature.to_reduced(U::reference_temperature())?;
+        let mut density = self.density.to_reduced(U::reference_density())?;
+        let mut chemical_potential = self.reduced_chemical_potential()?;
+        let mut bulk = self.bulk.clone();
+
+        // initialize x-vector
+        let n_rho = density.len();
+        let mut x = Array1::zeros(n_rho + density.shape()[0]);
+        x.slice_mut(s![..n_rho])
+            .assign(&density.view().into_shape(n_rho).unwrap());
+        x.slice_mut(s![n_rho..])
+            .assign(&chemical_potential.mapv(f64::exp));
+
+        // Residual function
+        let mut residual =
+            |x: &Array1<f64>, mut res: ArrayViewMut1<f64>, log: bool| -> EosResult<()> {
+                // Read density and chemical potential from solution vector
+                density.assign(&x.slice(s![..n_rho]).into_shape(density.shape()).unwrap());
+                chemical_potential.assign(&x.slice(s![n_rho..]).mapv(f64::ln));
+
+                // Create views for different residuals
+                let (res_rho, res_mu) = res.multi_slice_mut((s![..n_rho], s![n_rho..]));
+                let res_rho = res_rho.into_shape(density.raw_dim()).unwrap();
+
+                // Calculate residual
+                self.calculate_residual(
+                    temperature,
+                    &density,
+                    &chemical_potential,
+                    &mut bulk,
+                    res_rho,
+                    res_mu,
+                    log,
+                )
+            };
+
+        // Call solver(s)
+        let (converged, iterations) = solver.solve(&mut x, &mut residual)?;
+        if converged {
+            log_result!(solver.verbosity, "DFT solved in {} iterations", iterations);
+        } else if debug {
+            log_result!(
+                solver.verbosity,
+                "DFT not converged in {} iterations",
+                iterations
+            );
+        } else {
+            return Err(EosError::NotConverged(String::from("DFT")));
+        }
+
+        // Update profile
+        self.density = density * U::reference_density();
+        self.bulk = bulk;
+
+        Ok(())
+    }
+}
+
+impl<U: EosUnit, D: Dimension + RemoveAxis + 'static, F: HelmholtzEnergyFunctional>
+    DFTProfile<U, D, F>
+where
+    D::Larger: Dimension<Smaller = D>,
+    D::Smaller: Dimension<Larger = D>,
+    <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+{
+    pub fn entropy_density(&self, contributions: Contributions) -> EosResult<QuantityArray<U, D>> {
+        // initialize convolver
+        let t = self.temperature.to_reduced(U::reference_temperature())?;
+        let functional_contributions = self.dft.contributions();
+        let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
+            .iter()
+            .map(|c| c.weight_functions(Dual64::from(t).derive()))
+            .collect();
+        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
+
+        Ok(self.dft.entropy_density(
+            t,
+            &self.density.to_reduced(U::reference_density())?,
+            &convolver,
+            contributions,
+        )? * (U::reference_entropy() / U::reference_volume()))
+    }
+
+    pub fn entropy(&self, contributions: Contributions) -> EosResult<QuantityScalar<U>> {
+        Ok(self.integrate(&self.entropy_density(contributions)?))
+    }
+
+    pub fn grand_potential_density(&self) -> EosResult<QuantityArray<U, D>> {
+        self.dft
+            .grand_potential_density(self.temperature, &self.density, &self.convolver)
+    }
+
+    pub fn grand_potential(&self) -> EosResult<QuantityScalar<U>> {
+        Ok(self.integrate(&self.grand_potential_density()?))
+    }
+
+    pub fn internal_energy(&self, contributions: Contributions) -> EosResult<QuantityScalar<U>> {
+        // initialize convolver
+        let t = self.temperature.to_reduced(U::reference_temperature())?;
+        let functional_contributions = self.dft.contributions();
+        let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
+            .iter()
+            .map(|c| c.weight_functions(Dual64::from(t).derive()))
+            .collect();
+        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
+
+        let internal_energy_density = self.dft.internal_energy_density(
+            t,
+            &self.density.to_reduced(U::reference_density())?,
+            &self.external_potential,
+            &convolver,
+            contributions,
+        )? * U::reference_pressure();
+        Ok(self.integrate(&internal_energy_density))
+    }
+}

--- a/feos-dft/src/python/adsorption/external_potential.rs
+++ b/feos-dft/src/python/adsorption/external_potential.rs
@@ -1,0 +1,221 @@
+use crate::adsorption::ExternalPotential;
+use numpy::PyArray1;
+use pyo3::prelude::*;
+use quantity::python::{PySIArray2, PySINumber};
+use quantity::si::*;
+
+/// A collection of external potentials.
+#[pyclass(name = "ExternalPotential")]
+#[derive(Clone)]
+pub struct PyExternalPotential(pub ExternalPotential<SIUnit>);
+
+#[pymethods]
+#[allow(non_snake_case)]
+impl PyExternalPotential {
+    /// Hard wall potential
+    ///
+    /// .. math:: V_i^\mathrm{ext}(z)=\begin{cases}\infty&z\leq\sigma_{si}\\\\0&z>\sigma_{si}\end{cases},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)
+    ///
+    /// Parameters
+    /// ----------
+    /// sigma_ss : float
+    ///     Segment diameter of the solid.
+    ///
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[allow(non_snake_case)]
+    #[pyo3(text_signature = "(sigma_ss)")]
+    pub fn HardWall(sigma_ss: f64) -> Self {
+        Self(ExternalPotential::HardWall { sigma_ss })
+    }
+
+    /// 9-3 Lennard-Jones potential
+    ///
+    /// .. math:: V_i^\mathrm{ext}(z)=\frac{2\pi}{45} m_i\varepsilon_{si}\sigma_{si}^3\rho_s\left(2\left(\frac{\sigma_{si}}{z}\right)^9-15\left(\frac{\sigma_{si}}{z}\right)^3\right),~~~~\varepsilon_{si}=\sqrt{\varepsilon_{ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)
+    ///
+    /// Parameters
+    /// ----------
+    /// sigma_ss : float
+    ///     Segment diameter of the solid.
+    /// epsilon_k_ss : float
+    ///     Energy parameter of the solid.
+    /// rho_s : float
+    ///     Density of the solid.
+    ///
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[pyo3(text_signature = "(sigma_ss, epsilon_k_ss, rho_s)")]
+    pub fn LJ93(sigma_ss: f64, epsilon_k_ss: f64, rho_s: f64) -> Self {
+        Self(ExternalPotential::LJ93 {
+            sigma_ss,
+            epsilon_k_ss,
+            rho_s,
+        })
+    }
+
+    /// Simple 9-3 Lennard-Jones potential
+    ///
+    /// .. math:: V_i^\mathrm{ext}(z)=\varepsilon_{si}\left(\left(\frac{\sigma_{si}}{z}\right)^9-\left(\frac{\sigma_{si}}{z}\right)^3\right),~~~~\varepsilon_{si}=\sqrt{\varepsilon_{ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)
+    ///
+    /// Parameters
+    /// ----------
+    /// sigma_ss : float
+    ///     Segment diameter of the solid.
+    /// epsilon_k_ss : float
+    ///     Energy parameter of the solid.
+    ///
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[pyo3(text_signature = "(sigma_ss, epsilon_k_ss)")]
+    pub fn SimpleLJ93(sigma_ss: f64, epsilon_k_ss: f64) -> Self {
+        Self(ExternalPotential::SimpleLJ93 {
+            sigma_ss,
+            epsilon_k_ss,
+        })
+    }
+
+    /// Custom 9-3 Lennard-Jones potential
+    ///
+    /// .. math:: V_i^\mathrm{ext}(z)=\varepsilon_{si}\left(\left(\frac{\sigma_{si}}{z}\right)^9-\left(\frac{\sigma_{si}}{z}\right)^3\right)
+    ///
+    /// Parameters
+    /// ----------
+    /// sigma_sf : numpy.ndarray[float]
+    ///     Solid-fluid interaction diameters.
+    /// epsilon_k_sf : numpy.ndarray[float]
+    ///     Solid-fluid interaction energies.
+    ///
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[pyo3(text_signature = "(sigma_sf, epsilon_k_sf)")]
+    pub fn CustomLJ93(sigma_sf: &PyArray1<f64>, epsilon_k_sf: &PyArray1<f64>) -> Self {
+        Self(ExternalPotential::CustomLJ93 {
+            sigma_sf: sigma_sf.to_owned_array(),
+            epsilon_k_sf: epsilon_k_sf.to_owned_array(),
+        })
+    }
+
+    /// Steele potential
+    ///
+    /// .. math:: V_i^\mathrm{ext}(z)=2\pi m_i\xi\varepsilon_{si}\sigma_{si}^2\Delta\rho_s\left(0.4\left(\frac{\sigma_{si}}{z}\right)^{10}-\left(\frac{\sigma_{si}}{z}\right)^4-\frac{\sigma_{si}^4}{3\Delta\left(z+0.61\Delta\right)^3}\right),~~~~\varepsilon_{si}=\sqrt{\varepsilon_{ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right),~~~~\Delta=3.35
+    ///
+    /// Parameters
+    /// ----------
+    /// sigma_ss : float
+    ///     Segment diameter of the solid.
+    /// epsilon_k_ss : float
+    ///     Energy parameter of the solid.
+    /// rho_s : float
+    ///     Density of the solid.
+    /// xi : float, optional
+    ///     Binary wall-fluid interaction parameter.
+    ///
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[pyo3(text_signature = "(sigma_ss, epsilon_k_ss, rho_s, xi=None)")]
+    pub fn Steele(sigma_ss: f64, epsilon_k_ss: f64, rho_s: f64, xi: Option<f64>) -> Self {
+        Self(ExternalPotential::Steele {
+            sigma_ss,
+            epsilon_k_ss,
+            rho_s,
+            xi,
+        })
+    }
+
+    /// Double well potential
+    ///
+    /// .. math:: V_i^\mathrm{ext}(z)=\mathrm{min}\left(\frac{2\pi}{45} m_i\varepsilon_{2si}\sigma_{si}^3\rho_s\left(2\left(\frac{2\sigma_{si}}{z}\right)^9-15\left(\frac{2\sigma_{si}}{z}\right)^3\right),0\right)+\frac{2\pi}{45} m_i\varepsilon_{1si}\sigma_{si}^3\rho_s\left(2\left(\frac{\sigma_{si}}{z}\right)^9-15\left(\frac{\sigma_{si}}{z}\right)^3\right),~~~~\varepsilon_{1si}=\sqrt{\varepsilon_{1ss}\varepsilon_{ii}},~~~~\varepsilon_{2si}=\sqrt{\varepsilon_{2ss}\varepsilon_{ii}},~~~~\sigma_{si}=\frac{1}{2}\left(\sigma_{ss}+\sigma_{ii}\right)
+    ///
+    /// Parameters
+    /// ----------
+    /// sigma_ss : float
+    ///     Segment diameter of the solid.
+    /// epsilon1_k_ss : float
+    ///     Energy parameter of the first well.
+    /// epsilon2_k_ss : float
+    ///     Energy parameter of the second well.
+    /// rho_s : float
+    ///     Density of the solid.
+    ///
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[pyo3(text_signature = "(sigma_ss, epsilon1_k_ss, epsilon2_k_ss, rho_s)")]
+    pub fn DoubleWell(sigma_ss: f64, epsilon1_k_ss: f64, epsilon2_k_ss: f64, rho_s: f64) -> Self {
+        Self(ExternalPotential::DoubleWell {
+            sigma_ss,
+            epsilon1_k_ss,
+            epsilon2_k_ss,
+            rho_s,
+        })
+    }
+
+    /// Free-energy averaged potential
+    ///
+    /// for details see: `J. Eller, J. Gross (2021) <https://pubs.acs.org/doi/abs/10.1021/acs.langmuir.0c03287>`_
+    ///
+    /// Parameters
+    /// ----------
+    /// coordinates: SIArray2
+    ///     The positions of all interaction sites in the solid.
+    /// sigma_ss : numpy.ndarray[float]
+    ///     The size parameters of all interaction sites.
+    /// epsilon_k_ss : numpy.ndarray[float]
+    ///     The energy parameter of all interaction sites.
+    /// pore_center : [SINumber; 3]
+    ///     The cartesian coordinates of the center of the pore
+    /// system_size : [SINumber; 3]
+    ///     The size of the unit cell.
+    /// n_grid : [int; 2]
+    ///     The number of grid points in each direction.
+    /// cutoff_radius : float, optional
+    ///     The cutoff used in the calculation of fluid/wall interactions.
+    /// Returns
+    /// -------
+    /// ExternalPotential
+    ///
+    #[staticmethod]
+    #[pyo3(
+        text_signature = "(coordinates, sigma_ss, epsilon_k_ss, pore_center, system_size, n_grid, cutoff_radius=None)"
+    )]
+    pub fn FreeEnergyAveraged(
+        coordinates: &PySIArray2,
+        sigma_ss: &PyArray1<f64>,
+        epsilon_k_ss: &PyArray1<f64>,
+        pore_center: [f64; 3],
+        system_size: [PySINumber; 3],
+        n_grid: [usize; 2],
+        cutoff_radius: Option<f64>,
+    ) -> Self {
+        Self(ExternalPotential::FreeEnergyAveraged {
+            coordinates: coordinates.clone().into(),
+            sigma_ss: sigma_ss.to_owned_array(),
+            epsilon_k_ss: epsilon_k_ss.to_owned_array(),
+            pore_center,
+            system_size: [
+                system_size[0].into(),
+                system_size[1].into(),
+                system_size[2].into(),
+            ],
+            n_grid,
+            cutoff_radius,
+        })
+    }
+}

--- a/feos-dft/src/python/adsorption/mod.rs
+++ b/feos-dft/src/python/adsorption/mod.rs
@@ -1,0 +1,275 @@
+mod external_potential;
+mod pore;
+
+pub use external_potential::PyExternalPotential;
+
+#[macro_export]
+macro_rules! impl_adsorption {
+    ($func:ty, $py_func:ty) => {
+        /// Container structure for adsorption isotherms in 1D pores.
+        #[pyclass(name = "Adsorption1D", unsendable)]
+        pub struct PyAdsorption1D(Adsorption1D<SIUnit, $func>);
+
+        /// Container structure for adsorption isotherms in 3D pores.
+        #[pyclass(name = "Adsorption3D", unsendable)]
+        pub struct PyAdsorption3D(Adsorption3D<SIUnit, $func>);
+
+        impl_adsorption_isotherm!($func, $py_func, PyAdsorption1D, PyPore1D, PyPoreProfile1D);
+        impl_adsorption_isotherm!($func, $py_func, PyAdsorption3D, PyPore3D, PyPoreProfile3D);
+
+        fn parse_pressure_specification(pressure: &PyAny) -> PyResult<PressureSpecification<SIUnit>> {
+            if let Ok((p_min, p_max, points)) = pressure.extract::<(PySINumber, PySINumber, usize)>() {
+                Ok(PressureSpecification::Plim {
+                    p_min: p_min.into(),
+                    p_max: p_max.into(),
+                    points,
+                })
+            } else if let Ok(pressure) = pressure.extract::<PySIArray1>() {
+                Ok(PressureSpecification::Pvec(pressure.into()))
+            } else {
+                Err(PyErr::new::<PyValueError, _>(format!(
+                    "`pressure` must be (p_min, p_max, points) or an SIArray1 containing specific values."
+                )))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_adsorption_isotherm {
+    ($func:ty, $py_func:ty, $py_adsorption:ty, $py_pore:ty, $py_pore_profile:ident) => {
+        #[pymethods]
+        impl $py_adsorption {
+            /// Calculate an adsorption isotherm for the given pressure range.
+            /// The profiles are evaluated starting from the lowest pressure.
+            /// The resulting density profiles can be metastable.
+            ///
+            /// Parameters
+            /// ----------
+            /// functional : HelmholtzEnergyFunctional
+            ///     The Helmholtz energy functional.
+            /// temperature : SINumber
+            ///     The temperature.
+            /// pressure : {(SINumber, SINumber, int), SIArray1}
+            ///     The pressures for which the profiles are calculated. Either
+            ///     a tuple containing the minimum pressure, the maximum pressure,
+            ///     and the number of points, or an array containing specific values.
+            /// pore : Pore
+            ///     The pore parameters.
+            /// molefracs: numpy.ndarray[float], optional
+            ///     For a mixture, the molefracs of the bulk system.
+            /// solver: DFTSolver, optional
+            ///     Custom solver options.
+            ///
+            /// Returns
+            /// -------
+            /// Adsorption
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(functional, temperature, pressure, pore, molefracs=None, solver=None)")]
+            pub fn adsorption_isotherm(
+                functional: &$py_func,
+                temperature: PySINumber,
+                pressure: &PyAny,
+                pore: &$py_pore,
+                molefracs: Option<&PyArray1<f64>>,
+                solver: Option<PyDFTSolver>,
+            ) -> PyResult<Self> {
+                Ok(Self(Adsorption::adsorption_isotherm(
+                    &functional.0,
+                    temperature.into(),
+                    &parse_pressure_specification(pressure)?,
+                    &pore.0,
+                    molefracs.map(|x| x.to_owned_array()).as_ref(),
+                    solver.map(|s| s.0).as_ref(),
+                )?))
+            }
+
+            /// Calculate a desorption isotherm for the given pressure range.
+            /// The profiles are evaluated starting from the highest pressure.
+            /// The resulting density profiles can be metastable.
+            ///
+            /// Parameters
+            /// ----------
+            /// functional : HelmholtzEnergyFunctional
+            ///     The Helmholtz energy functional.
+            /// temperature : SINumber
+            ///     The temperature.
+            /// pressure : {(SINumber, SINumber, int), SIArray1}
+            ///     The pressures for which the profiles are calculated. Either
+            ///     a tuple containing the minimum pressure, the maximum pressure,
+            ///     and the number of points, or an array containing specific values.
+            /// pore : Pore
+            ///     The pore parameters.
+            /// molefracs: numpy.ndarray[float], optional
+            ///     For a mixture, the molefracs of the bulk system.
+            /// solver: DFTSolver, optional
+            ///     Custom solver options.
+            ///
+            /// Returns
+            /// -------
+            /// Adsorption
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(functional, temperature, pressure, pore, molefracs=None, solver=None)")]
+            pub fn desorption_isotherm(
+                functional: &$py_func,
+                temperature: PySINumber,
+                pressure: &PyAny,
+                pore: &$py_pore,
+                molefracs: Option<&PyArray1<f64>>,
+                solver: Option<PyDFTSolver>,
+            ) -> PyResult<Self> {
+                Ok(Self(Adsorption::desorption_isotherm(
+                    &functional.0,
+                    temperature.into(),
+                    &parse_pressure_specification(pressure)?,
+                    &pore.0,
+                    molefracs.map(|x| x.to_owned_array()).as_ref(),
+                    solver.map(|s| s.0).as_ref(),
+                )?))
+            }
+
+            /// Calculate an equilibrium isotherm for the given pressure range.
+            /// A phase equilibrium in the pore is calculated to determine the
+            /// stable phases for every pressure. If no phase equilibrium can be
+            /// calculated, the isotherm is calculated twice, one in the adsorption
+            /// direction and once in the desorption direction to determine the
+            /// stability of the profiles.
+            ///
+            /// Parameters
+            /// ----------
+            /// functional : HelmholtzEnergyFunctional
+            ///     The Helmholtz energy functional.
+            /// temperature : SINumber
+            ///     The temperature.
+            /// pressure : {(SINumber, SINumber, int), SIArray1}
+            ///     The pressures for which the profiles are calculated. Either
+            ///     a tuple containing the minimum pressure, the maximum pressure,
+            ///     and the number of points, or an array containing specific values.
+            /// pore : Pore
+            ///     The pore parameters.
+            /// molefracs: numpy.ndarray[float], optional
+            ///     For a mixture, the molefracs of the bulk system.
+            /// solver: DFTSolver, optional
+            ///     Custom solver options.
+            ///
+            /// Returns
+            /// -------
+            /// Adsorption
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(functional, temperature, pressure, pore, molefracs=None, solver=None)")]
+            pub fn equilibrium_isotherm(
+                functional: &$py_func,
+                temperature: PySINumber,
+                pressure: &PyAny,
+                pore: &$py_pore,
+                molefracs: Option<&PyArray1<f64>>,
+                solver: Option<PyDFTSolver>,
+            ) -> PyResult<Self> {
+                Ok(Self(Adsorption::equilibrium_isotherm(
+                    &functional.0,
+                    temperature.into(),
+                    &parse_pressure_specification(pressure)?,
+                    &pore.0,
+                    molefracs.map(|x| x.to_owned_array()).as_ref(),
+                    solver.map(|s| s.0).as_ref(),
+                )?))
+            }
+
+            /// Calculate a phase equilibrium in a pore.
+            ///
+            /// Parameters
+            /// ----------
+            /// functional : HelmholtzEnergyFunctional
+            ///     The Helmholtz energy functional.
+            /// temperature : SINumber
+            ///     The temperature.
+            /// p_min : SINumber
+            ///     A suitable lower limit for the pressure.
+            /// p_max : SINumber
+            ///     A suitable upper limit for the pressure.
+            /// pore : Pore
+            ///     The pore parameters.
+            /// molefracs: numpy.ndarray[float], optional
+            ///     For a mixture, the molefracs of the bulk system.
+            /// solver: DFTSolver, optional
+            ///     Custom solver options.
+            /// max_iter : int, optional
+            ///     The maximum number of iterations of the phase equilibrium calculation.
+            /// tol: float, optional
+            ///     The tolerance of the phase equilibrium calculation.
+            /// verbosity: Verbosity, optional
+            ///     The verbosity of the phase equilibrium calculation.
+            ///
+            /// Returns
+            /// -------
+            /// Adsorption
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(functional, temperature, p_min, p_max, pore, molefracs=None, solver=None, max_iter=None, tol=None, verbosity=None)")]
+            pub fn phase_equilibrium(
+                functional: &$py_func,
+                temperature: PySINumber,
+                p_min: PySINumber,
+                p_max: PySINumber,
+                pore: &$py_pore,
+                molefracs: Option<&PyArray1<f64>>,
+                solver: Option<PyDFTSolver>,
+                max_iter: Option<usize>,
+                tol: Option<f64>,
+                verbosity: Option<Verbosity>,
+            ) -> PyResult<Self> {
+                Ok(Self(Adsorption::phase_equilibrium(
+                    &functional.0,
+                    temperature.into(),
+                    p_min.into(),
+                    p_max.into(),
+                    &pore.0,
+                    molefracs.map(|x| x.to_owned_array()).as_ref(),
+                    solver.map(|s| s.0).as_ref(),
+                    (max_iter, tol, verbosity).into(),
+                )?))
+            }
+
+            #[getter]
+            fn get_profiles(&self) -> Vec<$py_pore_profile> {
+                self.0
+                    .profiles
+                    .iter()
+                    .filter_map(|p| {
+                        p.as_ref()
+                            .ok()
+                            .map(|p| $py_pore_profile(p.clone()))
+                    })
+                    .collect()
+            }
+
+            #[getter]
+            fn get_pressure(&self) -> PySIArray1 {
+                self.0.pressure().into()
+            }
+
+            #[getter]
+            fn get_molar_gibbs_energy(&self) -> PySIArray1 {
+                self.0.molar_gibbs_energy().into()
+            }
+
+            #[getter]
+            fn get_adsorption(&self) -> PySIArray2 {
+                self.0.adsorption().into()
+            }
+
+            #[getter]
+            fn get_total_adsorption(&self) -> PySIArray1 {
+                self.0.total_adsorption().into()
+            }
+
+            #[getter]
+            fn get_grand_potential(&mut self) -> PySIArray1 {
+                self.0.grand_potential().into()
+            }
+        }
+    };
+}

--- a/feos-dft/src/python/adsorption/pore.rs
+++ b/feos-dft/src/python/adsorption/pore.rs
@@ -1,0 +1,232 @@
+#[macro_export]
+macro_rules! impl_pore {
+    ($func:ty, $py_func:ty) => {
+        /// Parameters required to specify a 1D pore.
+        ///
+        /// Parameters
+        /// ----------
+        /// geometry : Geometry
+        ///     The pore geometry.
+        /// pore_size : SINumber
+        ///     The width of the slit pore in cartesian coordinates,
+        ///     or the pore radius in spherical and cylindrical coordinates.
+        /// potential : ExternalPotential
+        ///     The potential used to model wall-fluid interactions.
+        /// n_grid : int, optional
+        ///     The number of grid points.
+        /// potential_cutoff : float, optional
+        ///     Maximum value for the external potential.
+        ///
+        /// Returns
+        /// -------
+        /// Pore1D
+        ///
+        #[pyclass(name = "Pore1D")]
+        #[pyo3(text_signature = "(geometry, pore_size, potential, n_grid=None, potential_cutoff=None)")]
+        pub struct PyPore1D(Pore1D<SIUnit>);
+
+        #[pyclass(name = "PoreProfile1D", unsendable)]
+        pub struct PyPoreProfile1D(PoreProfile1D<SIUnit, $func>);
+
+        impl_1d_profile!(PyPoreProfile1D, [get_r, get_z]);
+
+        #[pymethods]
+        impl PyPore1D {
+            #[new]
+            fn new(
+                geometry: Geometry,
+                pore_size: PySINumber,
+                potential: PyExternalPotential,
+                n_grid: Option<usize>,
+                potential_cutoff: Option<f64>,
+            ) -> Self {
+                Self(Pore1D::new(
+                    geometry,
+                    pore_size.into(),
+                    potential.0,
+                    n_grid,
+                    potential_cutoff,
+                ))
+            }
+
+            /// Initialize the pore for the given bulk state.
+            ///
+            /// Parameters
+            /// ----------
+            /// bulk : State
+            ///     The bulk state in equilibrium with the pore.
+            /// density : SIArray2, optional
+            ///     Initial values for the density profile.
+            /// external_potential : numpy.ndarray[float], optional
+            ///     The external potential in the pore. Used to
+            ///     save computation time in the case of costly
+            ///     evaluations of external potentials.
+            ///
+            /// Returns
+            /// -------
+            /// PoreProfile1D
+            #[pyo3(text_signature = "($self, bulk, density=None, external_potential=None)")]
+            fn initialize(
+                &self,
+                bulk: &PyState,
+                density: Option<PySIArray2>,
+                external_potential: Option<&PyArray2<f64>>,
+            ) -> PyResult<PyPoreProfile1D> {
+                Ok(PyPoreProfile1D(self.0.initialize(
+                    &bulk.0,
+                    density.as_deref(),
+                    external_potential.map(|e| e.to_owned_array()).as_ref(),
+                )?))
+            }
+
+            #[getter]
+            fn get_geometry(&self)-> Geometry {
+                self.0.geometry
+            }
+
+            #[getter]
+            fn get_pore_size(&self)-> PySINumber {
+                self.0.pore_size.into()
+            }
+
+            #[getter]
+            fn get_potential(&self)-> PyExternalPotential {
+                PyExternalPotential(self.0.potential.clone())
+            }
+
+            #[getter]
+            fn get_n_grid(&self)-> Option<usize> {
+                self.0.n_grid
+            }
+
+            #[getter]
+            fn get_potential_cutoff(&self)-> Option<f64> {
+                self.0.potential_cutoff
+            }
+
+            /// The pore volume using Helium at 298 K as reference.
+            #[getter]
+            fn get_pore_volume(&self) -> PyResult<PySINumber> {
+                Ok(self.0.pore_volume()?.into())
+            }
+        }
+
+        #[pymethods]
+        impl PyPoreProfile1D {
+            #[getter]
+            fn get_grand_potential(&self) -> Option<PySINumber> {
+                self.0.grand_potential.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_interfacial_tension(&self) -> Option<PySINumber> {
+                self.0.interfacial_tension.map(PySINumber::from)
+            }
+        }
+
+        /// Parameters required to specify a 3D pore.
+        ///
+        /// Parameters
+        /// ----------
+        /// system_size : [SINumber; 3]
+        ///     The size of the unit cell.
+        /// n_grid : [int; 3]
+        ///     The number of grid points in each direction.
+        /// coordinates : numpy.ndarray[float]
+        ///     The positions of all interaction sites in the solid.
+        /// sigma_ss : numpy.ndarray[float]
+        ///     The size parameters of all interaction sites.
+        /// epsilon_k_ss : numpy.ndarray[float]
+        ///     The energy parameter of all interaction sites.
+        /// potential_cutoff: float, optional
+        ///     Maximum value for the external potential.
+        /// cutoff_radius: SINumber, optional
+        ///     The cutoff radius for the calculation of solid-fluid interactions.
+        ///
+        /// Returns
+        /// -------
+        /// Pore3D
+        ///
+        #[pyclass(name = "Pore3D")]
+        #[pyo3(text_signature = "(system_size, n_grid, coordinates, sigma_ss, epsilon_k_ss, potential_cutoff=None, cutoff_radius=None)")]
+        pub struct PyPore3D(Pore3D<SIUnit>);
+
+        #[pyclass(name = "PoreProfile3D", unsendable)]
+        pub struct PyPoreProfile3D(PoreProfile3D<SIUnit, $func>);
+
+        impl_3d_profile!(PyPoreProfile3D, get_x, get_y, get_z);
+
+        #[pymethods]
+        impl PyPore3D {
+            #[new]
+            fn new(
+                system_size: [PySINumber; 3],
+                n_grid: [usize; 3],
+                coordinates: &PySIArray2,
+                sigma_ss: &PyArray1<f64>,
+                epsilon_k_ss: &PyArray1<f64>,
+                potential_cutoff: Option<f64>,
+                cutoff_radius: Option<PySINumber>,
+            ) -> Self {
+                Self(Pore3D::new(
+                    [system_size[0].into(), system_size[1].into(), system_size[2].into()],
+                    n_grid,
+                    coordinates.clone().into(),
+                    sigma_ss.to_owned_array(),
+                    epsilon_k_ss.to_owned_array(),
+                    potential_cutoff,
+                    cutoff_radius.map(|c| c.into()),
+                ))
+            }
+
+            /// Initialize the pore for the given bulk state.
+            ///
+            /// Parameters
+            /// ----------
+            /// bulk : State
+            ///     The bulk state in equilibrium with the pore.
+            /// density : SIArray4, optional
+            ///     Initial values for the density profile.
+            /// external_potential : numpy.ndarray[float], optional
+            ///     The external potential in the pore. Used to
+            ///     save computation time in the case of costly
+            ///     evaluations of external potentials.
+            ///
+            /// Returns
+            /// -------
+            /// PoreProfile3D
+            #[pyo3(text_signature = "($self, bulk, density=None, external_potential=None)")]
+            fn initialize(
+                &self,
+                bulk: &PyState,
+                density: Option<PySIArray4>,
+                external_potential: Option<&PyArray4<f64>>,
+            ) -> PyResult<PyPoreProfile3D> {
+                Ok(PyPoreProfile3D(self.0.initialize(
+                    &bulk.0,
+                    density.as_deref(),
+                    external_potential.map(|e| e.to_owned_array()).as_ref(),
+                )?))
+            }
+
+            /// The pore volume using Helium at 298 K as reference.
+            #[getter]
+            fn get_pore_volume(&self) -> PyResult<PySINumber> {
+                Ok(self.0.pore_volume()?.into())
+            }
+        }
+
+        #[pymethods]
+        impl PyPoreProfile3D {
+            #[getter]
+            fn get_grand_potential(&self) -> Option<PySINumber> {
+                self.0.grand_potential.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_interfacial_tension(&self) -> Option<PySINumber> {
+                self.0.interfacial_tension.map(PySINumber::from)
+            }
+        }
+    };
+}

--- a/feos-dft/src/python/interface/mod.rs
+++ b/feos-dft/src/python/interface/mod.rs
@@ -1,0 +1,118 @@
+mod surface_tension_diagram;
+
+#[macro_export]
+macro_rules! impl_planar_interface {
+    ($func:ty) => {
+        /// A one-dimensional density profile of a vapor-liquid or liquid-liquid interface.
+        #[pyclass(name = "PlanarInterface", unsendable)]
+        pub struct PyPlanarInterface(PlanarInterface<SIUnit, $func>);
+
+        impl_1d_profile!(PyPlanarInterface, [get_z]);
+
+        #[pymethods]
+        impl PyPlanarInterface {
+            /// Initialize a planar interface with a hyperbolic tangent.
+            ///
+            /// Parameters
+            /// ----------
+            /// vle : PhaseEquilibrium
+            ///     The bulk phase equilibrium.
+            /// n_grid : int
+            ///     The number of grid points.
+            /// l_grid: SINumber
+            ///     The width of the calculation domain.
+            /// critical_temperature: SINumber
+            ///     An estimate for the critical temperature of the system.
+            ///     Used to guess the width of the interface.
+            ///
+            /// Returns
+            /// -------
+            /// PlanarInterface
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(vle, n_grid, l_grid, critical_temperature)")]
+            fn from_tanh(
+                vle: &PyPhaseEquilibrium,
+                n_grid: usize,
+                l_grid: PySINumber,
+                critical_temperature: PySINumber,
+            ) -> PyResult<Self> {
+                let profile = PlanarInterface::from_tanh(
+                    &vle.0,
+                    n_grid,
+                    l_grid.into(),
+                    critical_temperature.into(),
+                )?;
+                Ok(PyPlanarInterface(profile))
+            }
+
+            /// Initialize a planar interface with a pDGT calculation.
+            ///
+            /// Parameters
+            /// ----------
+            /// vle : PhaseEquilibrium
+            ///     The bulk phase equilibrium.
+            /// n_grid : int
+            ///     The number of grid points.
+            ///
+            /// Returns
+            /// -------
+            /// PlanarInterface
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(vle, n_grid)")]
+            fn from_pdgt(vle: &PyPhaseEquilibrium, n_grid: usize) -> PyResult<Self> {
+                let profile = PlanarInterface::from_pdgt(&vle.0, n_grid)?;
+                Ok(PyPlanarInterface(profile))
+            }
+
+            /// Initialize a planar interface with a provided density profile.
+            ///
+            /// Parameters
+            /// ----------
+            /// vle : PhaseEquilibrium
+            ///     The bulk phase equilibrium.
+            /// n_grid : int
+            ///     The number of grid points.
+            /// l_grid: SINumber
+            ///     The width of the calculation domain.
+            /// density_profile: SIArray2
+            ///     Initial condition for the density profile iterations
+            ///
+            /// Returns
+            /// -------
+            /// PlanarInterface
+            ///
+            #[staticmethod]
+            #[pyo3(text_signature = "(vle, n_grid, l_grid, density_profile)")]
+            fn from_density_profile(
+                vle: &PyPhaseEquilibrium,
+                n_grid: usize,
+                l_grid: PySINumber,
+                density_profile: PySIArray2,
+            ) -> PyResult<Self> {
+                let mut profile = PlanarInterface::new(&vle.0, n_grid, l_grid.into())?;
+                profile.profile.density = density_profile.into();
+                Ok(PyPlanarInterface(profile))
+            }
+        }
+
+        #[pymethods]
+        impl PyPlanarInterface {
+            #[getter]
+            fn get_surface_tension(&mut self) -> Option<PySINumber> {
+                self.0.surface_tension.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_equimolar_radius(&mut self) -> Option<PySINumber> {
+                self.0.equimolar_radius.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_vle(&self) -> PyPhaseEquilibrium {
+                PyPhaseEquilibrium(self.0.vle.clone())
+            }
+        }
+    };
+}

--- a/feos-dft/src/python/interface/surface_tension_diagram.rs
+++ b/feos-dft/src/python/interface/surface_tension_diagram.rs
@@ -1,0 +1,80 @@
+#[macro_export]
+macro_rules! impl_surface_tension_diagram {
+    ($func:ty) => {
+        /// Container structure for the efficient calculation of surface tension diagrams.
+        ///
+        /// Parameters
+        /// ----------
+        /// dia : [PhaseEquilibrium]
+        ///     The underlying phase diagram given as a list of states
+        ///     for which surface tensions shall be calculated.
+        /// init_densities : bool, optional
+        ///     None: Do not initialize densities with old results
+        ///     True: Initialize and scale densities
+        ///     False: Initialize without scaling
+        /// n_grid : int, optional
+        ///     The number of grid points (default: 2048).
+        /// l_grid : SINumber, optional
+        ///     The size of the calculation domain (default: 100 A)
+        /// critical_temperature: SINumber, optional
+        ///     An estimate for the critical temperature, used to initialize
+        ///     density profile (default: 500 K)
+        /// solver: DFTSolver, optional
+        ///     Custom solver options
+        ///
+        /// Returns
+        /// -------
+        /// SurfaceTensionDiagram
+        ///
+        #[pyclass(name = "SurfaceTensionDiagram", unsendable)]
+        #[pyo3(text_signature = "(dia, init_densities=None, n_grid=None, l_grid=None, critical_temperature=None, solver=None)")]
+        pub struct PySurfaceTensionDiagram(SurfaceTensionDiagram<SIUnit, $func>);
+
+        #[pymethods]
+        impl PySurfaceTensionDiagram {
+            #[new]
+            pub fn isotherm(
+                dia: Vec<PyPhaseEquilibrium>,
+                init_densities: Option<bool>,
+                n_grid: Option<usize>,
+                l_grid: Option<PySINumber>,
+                critical_temperature: Option<PySINumber>,
+                solver: Option<PyDFTSolver>,
+            ) -> Self {
+                let x = dia.into_iter().map(|vle| vle.0).collect();
+                Self(SurfaceTensionDiagram::new(
+                    &x,
+                    init_densities,
+                    n_grid,
+                    l_grid.map(|l| l.into()),
+                    critical_temperature.map(|c| c.into()),
+                    solver.map(|s| s.0).as_ref(),
+                ))
+            }
+
+            #[getter]
+            fn get_profiles(&self) -> Vec<PyPlanarInterface> {
+                self.0
+                    .profiles
+                    .iter()
+                    .map(|p| PyPlanarInterface(p.clone()))
+                    .collect()
+            }
+
+            #[getter]
+            pub fn get_vapor(&self) -> PyStateVec {
+                self.0.vapor().into()
+            }
+
+            #[getter]
+            pub fn get_liquid(&self) -> PyStateVec {
+                self.0.liquid().into()
+            }
+
+            #[getter]
+            pub fn get_surface_tension(&mut self) -> PySIArray1 {
+                self.0.surface_tension().into()
+            }
+        }
+    };
+}

--- a/feos-dft/src/python/mod.rs
+++ b/feos-dft/src/python/mod.rs
@@ -1,0 +1,8 @@
+mod adsorption;
+mod interface;
+mod profile;
+mod solvation;
+mod solver;
+
+pub use adsorption::PyExternalPotential;
+pub use solver::PyDFTSolver;

--- a/feos-dft/src/python/profile.rs
+++ b/feos-dft/src/python/profile.rs
@@ -1,0 +1,246 @@
+#[macro_export]
+macro_rules! impl_profile {
+    ($struct:ident, $arr:ident, $arr2:ident, $si_arr:ident, $si_arr2:ident, $py_arr2:ident, [$([$ind:expr, $ax:ident]),+]) => {
+        #[pymethods]
+        impl $struct {
+            /// Calculate the residual for the given profile.
+            ///
+            /// Parameters
+            /// ----------
+            /// log: bool, optional
+            ///     calculate the logarithmic residual (default: False).
+            ///
+            /// Returns
+            /// -------
+            /// (numpy.ndarray[float], numpy.ndarray[float])
+            ///
+            #[args(log = "false")]
+            #[pyo3(text_signature = "($self, log)")]
+            fn residual<'py>(
+                &self,
+                log: bool,
+                py: Python<'py>,
+            ) -> PyResult<(&'py $arr2<f64>, &'py PyArray1<f64>)> {
+                let (res_rho, res_mu) = self.0.profile.residual(log)?;
+                Ok((res_rho.view().to_pyarray(py), res_mu.view().to_pyarray(py)))
+            }
+
+            /// Solve the profile in-place. A non-default solver can be provided
+            /// optionally.
+            ///
+            /// Parameters
+            /// ----------
+            /// solver : DFTSolver, optional
+            ///     The solver used to solve the profile.
+            /// debug: bool, optional
+            ///     If True, do not check for convergence.
+            ///
+            /// Returns
+            /// -------
+            /// $struct
+            ///
+            #[args(debug = "false")]
+            #[pyo3(text_signature = "($self, solver=None, debug=False)")]
+            fn solve(slf: &PyCell<Self>, solver: Option<PyDFTSolver>, debug: bool) -> PyResult<&PyCell<Self>> {
+                slf.borrow_mut()
+                    .0
+                    .solve_inplace(solver.map(|s| s.0).as_ref(), debug)?;
+                Ok(slf)
+            }
+
+            $(
+            #[getter]
+            fn $ax(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.profile.grid.grids()[$ind].clone() * SIUnit::reference_length())
+            })+
+
+            #[getter]
+            fn get_temperature(&self) -> PySINumber {
+                PySINumber::from(self.0.profile.temperature)
+            }
+
+            #[getter]
+            fn get_density(&self) -> $si_arr2 {
+                $si_arr2::from(self.0.profile.density.clone())
+            }
+
+            #[getter]
+            fn get_moles(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.profile.moles())
+            }
+
+            #[getter]
+            fn get_total_moles(&self) -> PySINumber {
+                PySINumber::from(self.0.profile.total_moles())
+            }
+
+            #[getter]
+            fn get_external_potential<'py>(&self, py: Python<'py>) -> &'py $py_arr2<f64> {
+                self.0.profile.external_potential.view().to_pyarray(py)
+            }
+
+            #[getter]
+            fn get_chemical_potential(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.profile.chemical_potential())
+            }
+
+            #[getter]
+            fn get_bulk(&self) -> PyState {
+                PyState(self.0.profile.bulk.clone())
+            }
+
+            #[getter]
+            fn get_weighted_densities<'py>(
+                &self,
+                py: Python<'py>,
+            ) -> PyResult<Vec<&'py $arr2<f64>>> {
+                let n = self.0.profile.weighted_densities()?;
+                Ok(n.into_iter().map(|n| n.view().to_pyarray(py)).collect())
+            }
+
+            #[getter]
+            fn get_functional_derivative<'py>(
+                &self,
+                py: Python<'py>,
+            ) -> PyResult<&'py $arr2<f64>> {
+                Ok(self.0.profile.functional_derivative()?.view().to_pyarray(py))
+            }
+
+            /// Calculate the entropy density of the inhomogeneous system.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn entropy_density(
+                &mut self,
+                contributions: Contributions,
+            ) -> PyResult<$si_arr> {
+                Ok($si_arr::from(
+                    self.0.profile.entropy_density(contributions)?,
+                ))
+            }
+
+            /// Calculate the entropy of the inhomogeneous system.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn entropy(
+                &mut self,
+                contributions: Contributions,
+            ) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(
+                    self.0.profile.entropy(contributions)?,
+                ))
+            }
+
+            /// Calculate the internal energy of the inhomogeneous system.
+            ///
+            /// Parameters
+            /// ----------
+            /// contributions: Contributions, optional
+            ///     the contributions of the helmholtz energy.
+            ///     Defaults to Contributions.Total.
+            ///
+            /// Returns
+            /// -------
+            /// SINumber
+            #[args(contributions = "Contributions::Total")]
+            #[pyo3(text_signature = "($self, contributions)")]
+            fn internal_energy(
+                &mut self,
+                contributions: Contributions,
+            ) -> PyResult<PySINumber> {
+                Ok(PySINumber::from(
+                    self.0.profile.internal_energy(contributions)?,
+                ))
+            }
+
+            #[getter]
+            fn get_grand_potential_density(&self) -> PyResult<$si_arr> {
+                Ok($si_arr::from(
+                    self.0.profile.grand_potential_density()?,
+                ))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_1d_profile {
+    ($struct:ident, [$($ax:ident),+]) => {
+        impl_profile!(
+            $struct,
+            PyArray1,
+            PyArray2,
+            PySIArray1,
+            PySIArray2,
+            PyArray2,
+            [$([0, $ax]),+]
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! impl_2d_profile {
+    ($struct:ident, $ax1:ident, $ax2:ident) => {
+        impl_profile!(
+            $struct,
+            PyArray2,
+            PyArray3,
+            PySIArray2,
+            PySIArray3,
+            PyArray3,
+            [[0, $ax1], [1, $ax2]]
+        );
+
+        #[pymethods]
+        impl $struct {
+            #[getter]
+            fn get_edges(&self) -> (PySIArray1, PySIArray1) {
+                let (edge1, edge2) = self.0.profile.edges();
+                (edge1.into(), edge2.into())
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_3d_profile {
+    ($struct:ident, $ax1:ident, $ax2:ident, $ax3:ident) => {
+        impl_profile!(
+            $struct,
+            PyArray3,
+            PyArray4,
+            PySIArray3,
+            PySIArray4,
+            PyArray4,
+            [[0, $ax1], [1, $ax2], [2, $ax3]]
+        );
+
+        #[pymethods]
+        impl $struct {
+            #[getter]
+            fn get_edges(&self) -> (PySIArray1, PySIArray1, PySIArray1) {
+                let (edge1, edge2, edge3) = self.0.profile.edges();
+                (edge1.into(), edge2.into(), edge3.into())
+            }
+        }
+    };
+}

--- a/feos-dft/src/python/solvation.rs
+++ b/feos-dft/src/python/solvation.rs
@@ -1,0 +1,136 @@
+#[macro_export]
+macro_rules! impl_solvation_profile {
+    ($func:ty) => {
+        /// Density profile and properties of a solute in an inhomogeneous fluid.
+        ///
+        /// Parameters
+        /// ----------
+        /// bulk : State
+        ///     The bulk state of the surrounding solvent.
+        /// n_grid : [int, int, int]
+        ///     The number of grid points in x-, y- and z-direction.
+        /// coordinates : SIArray2
+        ///     The cartesian coordinates of all N interaction sites.
+        /// sigma : numpy.ndarray[float]
+        ///     The size parameters of all N interaction sites in units of Angstrom.
+        /// epsilon_k : numpy.ndarray[float]
+        ///     The reduced energy parameters epsilon / kB of all N interaction sites in units of Kelvin.
+        /// system_size : [SINumber, SINumber, SINumber], optional
+        ///     The box length in x-, y- and z-direction (default: [40.0 * ANGSTROM, 40.0 * ANGSTROM, 40.0 * ANGSTROM]).
+        /// cutoff_radius : SINumber, optional
+        ///      The cut-off radius up to which the dispersive solute-solvent interactions are evaluated (default: 14.0 * ANGSTROM).
+        /// potential_cutoff: float, optional
+        ///     Maximum value for the external potential.
+        ///
+        /// Returns
+        /// -------
+        /// SolvationProfile
+        ///
+        #[pyclass(name = "SolvationProfile", unsendable)]
+        #[pyo3(text_signature = "(bulk, n_grid, coordinates, sigma, epsilon_k, system_size=None, cutoff_radius=None, potential_cutoff=None)")]
+        pub struct PySolvationProfile(SolvationProfile<SIUnit, $func>);
+
+        impl_3d_profile!(PySolvationProfile, get_x, get_y, get_z);
+
+        #[pymethods]
+        impl PySolvationProfile {
+            #[new]
+            fn new(
+                bulk: &PyState,
+                n_grid: [usize; 3],
+                coordinates: &PySIArray2,
+                sigma: &PyArray1<f64>,
+                epsilon_k: &PyArray1<f64>,
+                system_size: Option<[PySINumber; 3]>,
+                cutoff_radius: Option<PySINumber>,
+                potential_cutoff: Option<f64>,
+            ) -> PyResult<Self> {
+                let s = system_size.map(|s| [s[0].into(), s[1].into(), s[2].into()]);
+
+                Ok(Self(SolvationProfile::new(
+                    &bulk.0,
+                    n_grid,
+                    coordinates.clone().into(),
+                    sigma.to_owned_array(),
+                    epsilon_k.to_owned_array(),
+                    s,
+                    cutoff_radius.map(|r| r.into()),
+                    potential_cutoff,
+                )?))
+            }
+
+            #[getter]
+            fn get_grand_potential(&self) -> Option<PySINumber> {
+                self.0.grand_potential.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_solvation_free_energy(&self) -> Option<PySINumber> {
+                self.0.solvation_free_energy.map(PySINumber::from)
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_pair_correlation {
+    ($func:ty) => {
+        /// Density profile and properties of a test particle system.
+        ///
+        /// Parameters
+        /// ----------
+        /// bulk : State
+        ///     The bulk state in equilibrium with the profile.
+        /// test_particle : int
+        ///     The index of the test particle.
+        /// n_grid : int
+        ///     The number of grid points.
+        /// width: SINumber
+        ///     The width of the system.
+        ///
+        /// Returns
+        /// -------
+        /// PairCorrelation
+        ///
+        #[pyclass(name = "PairCorrelation", unsendable)]
+        #[pyo3(text_signature = "(bulk, test_particle, n_grid, width)")]
+        pub struct PyPairCorrelation(PairCorrelation<SIUnit, $func>);
+
+        impl_1d_profile!(PyPairCorrelation, [get_r]);
+
+        #[pymethods]
+        impl PyPairCorrelation {
+            #[new]
+            fn new(
+                bulk: PyState,
+                test_particle: usize,
+                n_grid: usize,
+                width: PySINumber,
+            ) -> PyResult<Self> {
+                let profile = PairCorrelation::new(&bulk.0, test_particle, n_grid, width.into())?;
+                Ok(PyPairCorrelation(profile))
+            }
+
+            #[getter]
+            fn get_pair_correlation_function<'py>(
+                &self,
+                py: Python<'py>,
+            ) -> Option<&'py PyArray2<f64>> {
+                self.0
+                    .pair_correlation_function
+                    .as_ref()
+                    .map(|g| g.view().to_pyarray(py))
+            }
+
+            #[getter]
+            fn get_self_solvation_free_energy(&self) -> Option<PySINumber> {
+                self.0.self_solvation_free_energy.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_structure_factor(&self) -> Option<f64> {
+                self.0.structure_factor
+            }
+        }
+    };
+}

--- a/feos-dft/src/python/solver.rs
+++ b/feos-dft/src/python/solver.rs
@@ -1,0 +1,144 @@
+use crate::DFTSolver;
+use feos_core::Verbosity;
+use pyo3::prelude::*;
+
+/// Settings for the DFT solver.
+///
+/// Parameters
+/// ----------
+/// verbosity: Verbosity, optional
+///     The verbosity level of the solver.
+///
+/// Returns
+/// -------
+/// DFTSolver
+#[pyclass(name = "DFTSolver")]
+#[derive(Clone)]
+#[pyo3(text_signature = "(verbosity=None)")]
+pub struct PyDFTSolver(pub DFTSolver);
+
+#[pymethods]
+impl PyDFTSolver {
+    #[new]
+    fn new(verbosity: Option<Verbosity>) -> Self {
+        Self(DFTSolver::new(verbosity.unwrap_or_default()))
+    }
+
+    /// The default solver.
+    ///
+    /// Returns
+    /// -------
+    /// DFTSolver
+    #[classattr]
+    fn default() -> Self {
+        Self(DFTSolver::default())
+    }
+
+    /// Add a picard iteration to the solver object.
+    ///
+    /// Parameters
+    /// ----------
+    /// log: bool, optional
+    ///     Iterate the logarithm of the density profile
+    /// max_iter: int, optional
+    ///     The maximum number of iterations.
+    /// tol: float, optional
+    ///     The tolerance.
+    /// beta: float, optional
+    ///     The damping factor.
+    ///
+    /// Returns
+    /// -------
+    /// DFTSolver
+    #[pyo3(text_signature = "($self, log=None, max_iter=None, tol=None, beta=None)")]
+    fn picard_iteration(
+        &self,
+        max_rel: Option<f64>,
+        log: Option<bool>,
+        max_iter: Option<usize>,
+        tol: Option<f64>,
+        beta: Option<f64>,
+    ) -> Self {
+        let mut solver = self.0.clone().picard_iteration(max_rel);
+        if let Some(log) = log {
+            if log {
+                solver = solver.log();
+            }
+        }
+        if let Some(max_iter) = max_iter {
+            solver = solver.max_iter(max_iter);
+        }
+        if let Some(tol) = tol {
+            solver = solver.tol(tol);
+        }
+        if let Some(beta) = beta {
+            solver = solver.beta(beta);
+        }
+        Self(solver)
+    }
+
+    fn log_iter(&self) -> Self {
+        let mut solver = self.0.clone();
+        solver.verbosity = Verbosity::Iter;
+        Self(solver)
+    }
+
+    fn log_result(&self) -> Self {
+        let mut solver = self.0.clone();
+        solver.verbosity = Verbosity::Result;
+        Self(solver)
+    }
+
+    /// Add Anderson mixing to the solver object.
+    ///
+    /// Parameters
+    /// ----------
+    /// mmax: int, optional
+    ///     The maximum number of old solutions that are used.
+    /// log: bool, optional
+    ///     Iterate the logarithm of the density profile
+    /// max_iter: int, optional
+    ///     The maximum number of iterations.
+    /// tol: float, optional
+    ///     The tolerance.
+    /// beta: float, optional
+    ///     The damping factor.
+    ///
+    /// Returns
+    /// -------
+    /// DFTSolver
+    #[pyo3(text_signature = "($self, mmax=None, log=None, max_iter=None, tol=None, beta=None)")]
+    fn anderson_mixing(
+        &self,
+        mmax: Option<usize>,
+        log: Option<bool>,
+        max_iter: Option<usize>,
+        tol: Option<f64>,
+        beta: Option<f64>,
+    ) -> Self {
+        let mut solver = self.0.clone().anderson_mixing(mmax);
+        if let Some(log) = log {
+            if log {
+                solver = solver.log();
+            }
+        }
+        if let Some(max_iter) = max_iter {
+            solver = solver.max_iter(max_iter);
+        }
+        if let Some(tol) = tol {
+            solver = solver.tol(tol);
+        }
+        if let Some(beta) = beta {
+            solver = solver.beta(beta);
+        }
+        Self(solver)
+    }
+
+    fn _repr_markdown_(&self) -> String {
+        self.0._repr_markdown_()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}

--- a/feos-dft/src/solvation/mod.rs
+++ b/feos-dft/src/solvation/mod.rs
@@ -1,0 +1,208 @@
+//! Solvation free energies and pair correlaion functions.
+use crate::adsorption::FluidParameters;
+use crate::convolver::ConvolverFFT;
+use crate::functional::{HelmholtzEnergyFunctional, DFT};
+use crate::geometry::{Axis, Grid};
+use crate::profile::{DFTProfile, CUTOFF_RADIUS, MAX_POTENTIAL};
+use crate::solver::DFTSolver;
+use feos_core::{Contributions, EosResult, EosUnit, State};
+use ndarray::prelude::*;
+use ndarray::Zip;
+use quantity::{QuantityArray2, QuantityScalar};
+
+mod pair_correlation;
+pub use pair_correlation::{PairCorrelation, PairPotential};
+
+/// Density profile and properties of a solute in a inhomogeneous bulk fluid.
+pub struct SolvationProfile<U: EosUnit, F: HelmholtzEnergyFunctional> {
+    pub profile: DFTProfile<U, Ix3, F>,
+    pub grand_potential: Option<QuantityScalar<U>>,
+    pub solvation_free_energy: Option<QuantityScalar<U>>,
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> Clone for SolvationProfile<U, F> {
+    fn clone(&self) -> Self {
+        Self {
+            profile: self.profile.clone(),
+            grand_potential: self.grand_potential,
+            solvation_free_energy: self.solvation_free_energy,
+        }
+    }
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional> SolvationProfile<U, F> {
+    pub fn solve_inplace(&mut self, solver: Option<&DFTSolver>, debug: bool) -> EosResult<()> {
+        // Solve the profile
+        self.profile.solve(solver, debug)?;
+
+        // calculate grand potential density
+        let omega = self.profile.grand_potential()?;
+        self.grand_potential = Some(omega);
+
+        // calculate solvation free energy
+        self.solvation_free_energy = Some(
+            (omega + self.profile.bulk.pressure(Contributions::Total) * self.profile.volume())
+                / U::reference_moles(),
+        );
+
+        Ok(())
+    }
+
+    pub fn solve(mut self, solver: Option<&DFTSolver>) -> EosResult<Self> {
+        self.solve_inplace(solver, false)?;
+        Ok(self)
+    }
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional + FluidParameters> SolvationProfile<U, F> {
+    pub fn new(
+        bulk: &State<U, DFT<F>>,
+        n_grid: [usize; 3],
+        coordinates: QuantityArray2<U>,
+        sigma_ss: Array1<f64>,
+        epsilon_ss: Array1<f64>,
+        system_size: Option<[QuantityScalar<U>; 3]>,
+        cutoff_radius: Option<QuantityScalar<U>>,
+        potential_cutoff: Option<f64>,
+    ) -> EosResult<Self> {
+        let dft: &F = &bulk.eos;
+
+        let system_size = system_size.unwrap_or([40.0 * U::reference_length(); 3]);
+
+        // generate grid
+        let x = Axis::new_cartesian(n_grid[0], system_size[0], None)?;
+        let y = Axis::new_cartesian(n_grid[1], system_size[1], None)?;
+        let z = Axis::new_cartesian(n_grid[2], system_size[2], None)?;
+
+        // move center of geometry of solute to box center
+        let mut coordinates = Array2::from_shape_fn(coordinates.raw_dim(), |(i, j)| {
+            (coordinates.get((i, j)))
+                .to_reduced(U::reference_length())
+                .unwrap()
+        });
+
+        let center = [
+            system_size[0].to_reduced(U::reference_length())? / 2.0,
+            system_size[1].to_reduced(U::reference_length())? / 2.0,
+            system_size[2].to_reduced(U::reference_length())? / 2.0,
+        ];
+
+        let shift: Array2<f64> = Array2::from_shape_fn((3, 1), |(i, _)| {
+            center[i] - coordinates.row(i).sum() / coordinates.ncols() as f64
+        });
+
+        coordinates = coordinates + shift;
+
+        // temperature
+        let t = bulk.temperature.to_reduced(U::reference_temperature())?;
+
+        // calculate external potential
+        let external_potential = external_potential_3d(
+            dft,
+            [&x, &y, &z],
+            coordinates,
+            sigma_ss,
+            epsilon_ss,
+            cutoff_radius,
+            potential_cutoff,
+            t,
+        )?;
+
+        // initialize convolver
+        let grid = Grid::Cartesian3(x, y, z);
+        let weight_functions = dft.weight_functions(t);
+        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
+
+        Ok(Self {
+            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), None)?,
+            grand_potential: None,
+            solvation_free_energy: None,
+        })
+    }
+}
+
+fn external_potential_3d<U: EosUnit, F: FluidParameters>(
+    functional: &F,
+    axis: [&Axis; 3],
+    coordinates: Array2<f64>,
+    sigma_ss: Array1<f64>,
+    epsilon_ss: Array1<f64>,
+    cutoff_radius: Option<QuantityScalar<U>>,
+    potential_cutoff: Option<f64>,
+    reduced_temperature: f64,
+) -> EosResult<Array4<f64>> {
+    // allocate external potential
+    let m = functional.m();
+    let mut external_potential = Array4::zeros((
+        m.len(),
+        axis[0].grid.len(),
+        axis[1].grid.len(),
+        axis[2].grid.len(),
+    ));
+
+    let cutoff_radius = cutoff_radius
+        .unwrap_or(CUTOFF_RADIUS * U::reference_length())
+        .to_reduced(U::reference_length())?;
+
+    // square cut-off radius
+    let cutoff_radius2 = cutoff_radius.powi(2);
+
+    // calculate external potential
+    let sigma_ff = functional.sigma_ff();
+    let epsilon_k_ff = functional.epsilon_k_ff();
+
+    Zip::indexed(&mut external_potential).par_for_each(|(i, ix, iy, iz), u| {
+        let distance2 = calculate_distance2(
+            [&axis[0].grid[ix], &axis[1].grid[iy], &axis[2].grid[iz]],
+            &coordinates,
+        );
+        let sigma_sf = sigma_ss.mapv(|s| (s + sigma_ff[i]) / 2.0);
+        let epsilon_sf = epsilon_ss.mapv(|e| (e * epsilon_k_ff[i]).sqrt());
+        *u = (0..sigma_ss.len())
+            .map(|alpha| {
+                m[i] * evaluate(
+                    distance2[alpha],
+                    sigma_sf[alpha],
+                    epsilon_sf[alpha],
+                    cutoff_radius2,
+                )
+            })
+            .sum::<f64>()
+            / reduced_temperature
+    });
+
+    let potential_cutoff = potential_cutoff.unwrap_or(MAX_POTENTIAL);
+    external_potential.map_inplace(|x| {
+        if *x > potential_cutoff {
+            *x = potential_cutoff
+        }
+    });
+
+    Ok(external_potential)
+}
+
+/// Evaluate LJ12-6 potential between solid site "alpha" and fluid segment
+fn evaluate(distance2: f64, sigma: f64, epsilon: f64, cutoff_radius2: f64) -> f64 {
+    let sigma_r = sigma.powi(2) / distance2;
+
+    let potential: f64 = if distance2 > cutoff_radius2 {
+        0.0
+    } else if distance2 == 0.0 {
+        f64::INFINITY
+    } else {
+        4.0 * epsilon * (sigma_r.powi(6) - sigma_r.powi(3))
+    };
+
+    potential
+}
+
+/// Evaluate the squared euclidian distance between a point and the coordinates of all solid atoms.
+fn calculate_distance2(point: [&f64; 3], coordinates: &Array2<f64>) -> Array1<f64> {
+    Array1::from_shape_fn(coordinates.ncols(), |i| {
+        let rx = coordinates[[0, i]] - point[0];
+        let ry = coordinates[[1, i]] - point[1];
+        let rz = coordinates[[2, i]] - point[2];
+
+        rx.powi(2) + ry.powi(2) + rz.powi(2)
+    })
+}

--- a/feos-dft/src/solvation/pair_correlation.rs
+++ b/feos-dft/src/solvation/pair_correlation.rs
@@ -1,0 +1,107 @@
+//! Functionalities for the calculation of pair correlation functions.
+use super::{Axis, DFTProfile, Grid};
+use crate::convolver::ConvolverFFT;
+use crate::functional::{HelmholtzEnergyFunctional, DFT};
+use crate::profile::MAX_POTENTIAL;
+use crate::solver::DFTSolver;
+use feos_core::{Contributions, EosResult, EosUnit, State};
+use ndarray::prelude::*;
+use quantity::QuantityScalar;
+
+/// The underlying pair potential, that the Helmholtz energy functional
+/// models.
+pub trait PairPotential {
+    /// Return the pair potential of particle i with all other particles.
+    fn pair_potential(&self, i: usize, r: &Array1<f64>, temperature: f64) -> Array2<f64>;
+}
+
+/// Density profile and properties of a test particle system.
+pub struct PairCorrelation<U, F> {
+    pub profile: DFTProfile<U, Ix1, F>,
+    pub pair_correlation_function: Option<Array2<f64>>,
+    pub self_solvation_free_energy: Option<QuantityScalar<U>>,
+    pub structure_factor: Option<f64>,
+}
+
+impl<U: Clone, F> Clone for PairCorrelation<U, F> {
+    fn clone(&self) -> Self {
+        Self {
+            profile: self.profile.clone(),
+            pair_correlation_function: self.pair_correlation_function.clone(),
+            self_solvation_free_energy: self.self_solvation_free_energy.clone(),
+            structure_factor: self.structure_factor,
+        }
+    }
+}
+
+impl<U: EosUnit, F: HelmholtzEnergyFunctional + PairPotential> PairCorrelation<U, F> {
+    pub fn new(
+        bulk: &State<U, DFT<F>>,
+        test_particle: usize,
+        n_grid: usize,
+        width: QuantityScalar<U>,
+    ) -> EosResult<Self> {
+        let dft = &bulk.eos;
+
+        // generate grid
+        let axis = Axis::new_spherical(n_grid, width)?;
+
+        // calculate external potential
+        let t = bulk.temperature.to_reduced(U::reference_temperature())?;
+        let mut external_potential = dft.pair_potential(test_particle, &axis.grid, t) / t;
+        external_potential.map_inplace(|x| {
+            if *x > MAX_POTENTIAL {
+                *x = MAX_POTENTIAL
+            }
+        });
+
+        // initialize convolver
+        let grid = Grid::Spherical(axis);
+        let weight_functions = dft.weight_functions(t);
+        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
+
+        Ok(Self {
+            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), None)?,
+            pair_correlation_function: None,
+            self_solvation_free_energy: None,
+            structure_factor: None,
+        })
+    }
+
+    pub fn solve_inplace(&mut self, solver: Option<&DFTSolver>, debug: bool) -> EosResult<()> {
+        // Solve the profile
+        self.profile.solve(solver, debug)?;
+
+        // calculate pair correlation function
+        self.pair_correlation_function = Some(Array::from_shape_fn(
+            self.profile.density.raw_dim(),
+            |(i, j)| {
+                self.profile
+                    .density
+                    .get((i, j))
+                    .to_reduced(self.profile.bulk.partial_density.get(i))
+                    .unwrap()
+            },
+        ));
+
+        // calculate self solvation free energy
+        self.self_solvation_free_energy = Some(self.profile.integrate(
+            &(self.profile.grand_potential_density()?
+                + self.profile.bulk.pressure(Contributions::Total)),
+        ));
+
+        // calculate structure factor
+        self.structure_factor = Some(
+            (self.profile.total_moles() - self.profile.bulk.density * self.profile.volume())
+                .to_reduced(U::reference_moles())?
+                + 1.0,
+        );
+
+        Ok(())
+    }
+
+    pub fn solve(mut self, solver: Option<&DFTSolver>) -> EosResult<Self> {
+        self.solve_inplace(solver, false)?;
+        Ok(self)
+    }
+}

--- a/feos-dft/src/solver.rs
+++ b/feos-dft/src/solver.rs
@@ -1,0 +1,342 @@
+use feos_core::{log_iter, EosError, EosResult, Verbosity};
+use ndarray::prelude::*;
+use num_dual::linalg::{norm, LU};
+use std::collections::VecDeque;
+use std::fmt;
+
+const DEFAULT_PARAMS_PICARD: SolverParameter = SolverParameter {
+    solver: DFTAlgorithm::PicardIteration(1.0),
+    log: false,
+    max_iter: 500,
+    tol: 1e-11,
+    beta: 0.15,
+};
+const DEFAULT_PARAMS_ANDERSON_LOG: SolverParameter = SolverParameter {
+    solver: DFTAlgorithm::AndersonMixing(100),
+    log: true,
+    max_iter: 50,
+    tol: 1e-5,
+    beta: 0.15,
+};
+const DEFAULT_PARAMS_ANDERSON: SolverParameter = SolverParameter {
+    solver: DFTAlgorithm::AndersonMixing(100),
+    log: false,
+    max_iter: 150,
+    tol: 1e-11,
+    beta: 0.15,
+};
+
+#[derive(Clone, Copy)]
+struct SolverParameter {
+    solver: DFTAlgorithm,
+    log: bool,
+    max_iter: usize,
+    tol: f64,
+    beta: f64,
+}
+
+#[derive(Clone, Copy)]
+enum DFTAlgorithm {
+    PicardIteration(f64),
+    AndersonMixing(usize),
+}
+
+/// Settings for the DFT solver.
+#[derive(Clone)]
+pub struct DFTSolver {
+    parameters: Vec<SolverParameter>,
+    pub verbosity: Verbosity,
+}
+
+impl Default for DFTSolver {
+    fn default() -> Self {
+        Self {
+            parameters: vec![DEFAULT_PARAMS_ANDERSON_LOG, DEFAULT_PARAMS_ANDERSON],
+            verbosity: Verbosity::None,
+        }
+    }
+}
+
+impl DFTSolver {
+    /// Create a new empty `DFTSolver` object.
+    pub fn new(verbosity: Verbosity) -> Self {
+        Self {
+            parameters: Vec::new(),
+            verbosity,
+        }
+    }
+
+    /// Add a Picard iteration to the solver.
+    pub fn picard_iteration(mut self, max_rel: Option<f64>) -> Self {
+        let mut algorithm = DEFAULT_PARAMS_PICARD;
+        if let Some(max_rel) = max_rel {
+            algorithm.solver = DFTAlgorithm::PicardIteration(max_rel);
+        }
+        self.parameters.push(algorithm);
+        self
+    }
+
+    /// Add Anderson mixing to the solver.
+    pub fn anderson_mixing(mut self, mmax: Option<usize>) -> Self {
+        let mut algorithm = DEFAULT_PARAMS_ANDERSON;
+        if let Some(mmax) = mmax {
+            algorithm.solver = DFTAlgorithm::AndersonMixing(mmax);
+        }
+        self.parameters.push(algorithm);
+        self
+    }
+
+    /// Iterate the logarithm of the density profile in the last solver.
+    pub fn log(mut self) -> Self {
+        self.parameters.last_mut().unwrap().log = true;
+        self
+    }
+
+    /// Set the maximum number of iterations for the last solver.
+    pub fn max_iter(mut self, max_iter: usize) -> Self {
+        self.parameters.last_mut().unwrap().max_iter = max_iter;
+        self
+    }
+
+    /// Set the tolerance for the last solver.
+    pub fn tol(mut self, tol: f64) -> Self {
+        self.parameters.last_mut().unwrap().tol = tol;
+        self
+    }
+
+    /// Set the damping factor for the last solver
+    pub fn beta(mut self, beta: f64) -> Self {
+        self.parameters.last_mut().unwrap().beta = beta;
+        self
+    }
+
+    pub(crate) fn solve<F>(&self, x: &mut Array1<f64>, residual: &mut F) -> EosResult<(bool, usize)>
+    where
+        F: FnMut(&Array1<f64>, ArrayViewMut1<f64>, bool) -> EosResult<()>,
+    {
+        log_iter!(self.verbosity, "solver               | iter | residual ");
+        let mut converged = false;
+        let mut iterations = 0;
+        for algorithm in &self.parameters {
+            let (c, i) = algorithm.solve(x, residual, self.verbosity)?;
+            converged = c;
+            iterations += i;
+        }
+        Ok((converged, iterations))
+    }
+}
+
+impl SolverParameter {
+    fn solve<F>(
+        &self,
+        x: &mut Array1<f64>,
+        residual: &mut F,
+        verbosity: Verbosity,
+    ) -> EosResult<(bool, usize)>
+    where
+        F: FnMut(&Array1<f64>, ArrayViewMut1<f64>, bool) -> EosResult<()>,
+    {
+        match self.solver {
+            DFTAlgorithm::PicardIteration(max_rel) => {
+                self.solve_picard(max_rel, x, residual, verbosity)
+            }
+            DFTAlgorithm::AndersonMixing(mmax) => self.solve_anderson(mmax, x, residual, verbosity),
+        }
+    }
+
+    fn solve_picard<F>(
+        &self,
+        max_rel: f64,
+        x: &mut Array1<f64>,
+        residual: &mut F,
+        verbosity: Verbosity,
+    ) -> EosResult<(bool, usize)>
+    where
+        F: FnMut(&Array1<f64>, ArrayViewMut1<f64>, bool) -> EosResult<()>,
+    {
+        log_iter!(verbosity, "{:-<43}", "");
+        let mut resm = Array::zeros(x.raw_dim());
+
+        for k in 1..=self.max_iter {
+            // calculate residual
+            residual(x, resm.view_mut(), self.log)?;
+
+            // calculate beta
+            let mut beta_min: Option<f64> = None;
+            let beta = (max_rel * (&*x / &resm).mapv(f64::abs)).mapv(|beta| {
+                if beta < self.beta {
+                    beta_min = Some(beta_min.map_or(beta, |b| b.min(beta)));
+                    beta
+                } else {
+                    self.beta
+                }
+            });
+
+            // update solution
+            if self.log {
+                *x *= &(&resm * (-beta)).mapv(f64::exp);
+            } else {
+                *x -= &(&resm * beta);
+            }
+
+            // check for convergence
+            let res = norm(&resm) / (resm.len() as f64).sqrt();
+            log_iter!(
+                verbosity,
+                "Picard iteration {:3} | {:>4} | {:.6e} | {}",
+                if self.log { "log" } else { "" },
+                k,
+                res,
+                beta_min.unwrap_or(self.beta)
+            );
+
+            if res.is_nan() {
+                return Err(EosError::IterationFailed(String::from("Picard Iteration")));
+            }
+            if res < self.tol && beta_min.is_none() {
+                return Ok((true, k));
+            }
+        }
+        Ok((false, self.max_iter))
+    }
+
+    fn solve_anderson<F>(
+        &self,
+        mmax: usize,
+        x: &mut Array1<f64>,
+        residual: &mut F,
+        verbosity: Verbosity,
+    ) -> EosResult<(bool, usize)>
+    where
+        F: FnMut(&Array1<f64>, ArrayViewMut1<f64>, bool) -> EosResult<()>,
+    {
+        log_iter!(verbosity, "{:-<43}", "");
+        let mut resm = VecDeque::with_capacity(mmax);
+        let mut xm = VecDeque::with_capacity(mmax);
+        let mut r;
+        let mut alpha;
+
+        for k in 1..=self.max_iter {
+            // drop old values
+            if resm.len() == mmax {
+                resm.pop_front();
+                xm.pop_front();
+            }
+            let m = resm.len() + 1;
+
+            // calculate residual
+            let mut res = Array::zeros(x.raw_dim());
+            residual(x, res.view_mut(), self.log)?;
+            resm.push_back(res);
+
+            // save x value
+            if self.log {
+                xm.push_back(x.mapv(f64::ln));
+            } else {
+                xm.push_back(x.clone());
+            }
+
+            // calculate alpha
+            r = Array::from_shape_fn((m + 1, m + 1), |(i, j)| match (i == m, j == m) {
+                (false, false) => (&resm[i] * &resm[j]).sum(),
+                (true, true) => 0.0,
+                _ => 1.0,
+            });
+            alpha = Array::zeros(m + 1);
+            alpha[m] = 1.0;
+            alpha = LU::new(r)?.solve(&alpha);
+            // r.solveh_inplace(&mut alpha)?;
+
+            // update solution
+            x.fill(0.0);
+            for i in 0..m {
+                *x += &(alpha[i] * (&xm[i] - &(self.beta * &resm[i])));
+            }
+            if self.log {
+                x.mapv_inplace(f64::exp);
+            } else {
+                x.mapv_inplace(f64::abs);
+            }
+
+            // check for convergence
+            let resv = &resm[m - 1];
+            let res = norm(resv) / (resv.len() as f64).sqrt();
+            log_iter!(
+                verbosity,
+                "Anderson mixing {:3}  | {:>4} | {:.6e} ",
+                if self.log { "log" } else { "" },
+                k,
+                res
+            );
+
+            if res.is_nan() {
+                return Err(EosError::IterationFailed(String::from("Anderson Mixing")));
+            }
+            if res < self.tol {
+                return Ok((true, k));
+            }
+        }
+        Ok((false, self.max_iter))
+    }
+}
+
+impl fmt::Display for DFTAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::PicardIteration(max_rel) => write!(f, "Picard Iteration (max_rel={})", max_rel),
+            Self::AndersonMixing(mmax) => write!(f, "Anderson Mixing (mmax={})", mmax),
+        }
+    }
+}
+
+impl fmt::Debug for DFTAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::PicardIteration(_) => write!(f, "Picard Iteration"),
+            Self::AndersonMixing(_) => write!(f, "Anderson Mixing"),
+        }
+    }
+}
+
+impl fmt::Display for SolverParameter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} max_iter: {}, tol: {}, beta: {}",
+            self.solver, self.max_iter, self.tol, self.beta
+        )
+    }
+}
+
+impl fmt::Display for DFTSolver {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for algorithm in &self.parameters {
+            writeln!(f, "{algorithm}")?;
+        }
+        Ok(())
+    }
+}
+
+impl DFTSolver {
+    pub fn _repr_markdown_(&self) -> String {
+        let mut res =
+            String::from("|solver|log|max_iter|tol|beta|mmax|max_rel|\n|-|:-:|-:|-:|-:|-:|-:|");
+        for algorithm in &self.parameters {
+            let (mmax, max_rel) = match algorithm.solver {
+                DFTAlgorithm::PicardIteration(max_rel) => (String::new(), max_rel.to_string()),
+                DFTAlgorithm::AndersonMixing(mmax) => (mmax.to_string(), String::new()),
+            };
+            res += &fmt::format(format_args!(
+                "\n|{:?}|{}|{}|{:e}|{}|{}|{}|",
+                algorithm.solver,
+                if algorithm.log { "x" } else { "" },
+                algorithm.max_iter,
+                algorithm.tol,
+                algorithm.beta,
+                mmax,
+                max_rel
+            ));
+        }
+        res
+    }
+}

--- a/feos-dft/src/weight_functions.rs
+++ b/feos-dft/src/weight_functions.rs
@@ -1,0 +1,325 @@
+use ndarray::*;
+use num_dual::DualNum;
+// use rustfft::num_complex::Complex;
+use std::f64::consts::{FRAC_PI_3, PI};
+use std::ops::Mul;
+
+/// A weight function corresponding to a single weighted density.
+#[derive(Clone)]
+pub struct WeightFunction<T> {
+    /// Factor in front of normalized weight function
+    pub prefactor: Array1<T>,
+    /// Kernel radius of the convolution
+    pub kernel_radius: Array1<T>,
+    /// Shape of the weight function (Dirac delta, Heaviside, etc.)
+    pub shape: WeightFunctionShape,
+}
+
+impl<T: DualNum<f64>> WeightFunction<T> {
+    /// Create a new weight function without prefactor
+    pub fn new_unscaled(kernel_radius: Array1<T>, shape: WeightFunctionShape) -> Self {
+        Self {
+            prefactor: Array::ones(kernel_radius.raw_dim()),
+            kernel_radius,
+            shape,
+        }
+    }
+
+    /// Create a new weight function with weight constant = 1
+    pub fn new_scaled(kernel_radius: Array1<T>, shape: WeightFunctionShape) -> Self {
+        let unscaled = Self::new_unscaled(kernel_radius, shape);
+        let weight_constants = unscaled.scalar_weight_constants(T::zero());
+        Self {
+            prefactor: weight_constants.mapv(|w| w.recip()),
+            kernel_radius: unscaled.kernel_radius,
+            shape,
+        }
+    }
+
+    /// Calculates the value of the scalar weight function depending on its shape
+    /// `k_abs` describes the absolute value of the Fourier variable
+    pub(crate) fn fft_scalar_weight_functions<D: Dimension, T2: DualNum<f64>>(
+        &self,
+        k_abs: &Array<T2, D>,
+        lanczos: &Option<Array<T2, D>>,
+    ) -> Array<T, D::Larger>
+    where
+        T: Mul<T2, Output = T>,
+        D::Larger: Dimension<Smaller = D>,
+    {
+        // Allocate vector for weight functions
+        let mut d = vec![self.prefactor.len()];
+        k_abs.shape().iter().for_each(|&x| d.push(x));
+        let mut w = Array::zeros(d.into_dimension())
+            .into_dimensionality()
+            .unwrap();
+
+        // Calculate weight function for each component
+        for i in 0..self.prefactor.len() {
+            let radius = self.kernel_radius[i];
+            let p = self.prefactor[i];
+            let rik = k_abs.mapv(|k| radius * k);
+            let mut w_i = w.index_axis_mut(Axis(0), i);
+            w_i.assign(&match self.shape {
+                WeightFunctionShape::Theta => rik.mapv(|rik| {
+                    (rik.sph_j0() + rik.sph_j2()) * 4.0 * FRAC_PI_3 * radius.powi(3) * p
+                }),
+                WeightFunctionShape::Delta => {
+                    rik.mapv(|rik| rik.sph_j0() * 4.0 * PI * radius.powi(2) * p)
+                }
+                WeightFunctionShape::KR1 => {
+                    rik.mapv(|rik| (rik.sph_j0() + rik.cos()) * 0.5 * radius * p)
+                }
+                WeightFunctionShape::KR0 => rik.mapv(|rik| (rik * rik.sin() * 0.5 + rik.cos()) * p),
+                WeightFunctionShape::DeltaVec => unreachable!(),
+            });
+
+            // Apply Lanczos sigma factor
+            if let Some(l) = lanczos {
+                w_i.assign(&(&w_i * l));
+            }
+        }
+
+        // Return real part of weight function
+        w
+    }
+
+    /// Calculates the value of the vector weight function depending on its shape
+    /// `k_abs` describes the absolute value of the Fourier variable
+    /// `k` describes the (potentially multi-dimensional) Fourier variable
+    pub(crate) fn fft_vector_weight_functions<D: Dimension, T2: DualNum<f64>>(
+        &self,
+        k_abs: &Array<T2, D>,
+        k: &Array<T2, D::Larger>,
+        lanczos: &Option<Array<T2, D>>,
+    ) -> Array<T, <D::Larger as Dimension>::Larger>
+    where
+        D::Larger: Dimension<Smaller = D>,
+        <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
+        T: Mul<T2, Output = T>,
+    {
+        // Allocate vector for weight functions
+        let mut d = vec![k.shape()[0], self.prefactor.len()];
+        k.shape().iter().skip(1).for_each(|&x| d.push(x));
+        let mut w = Array::zeros(d.into_dimension())
+            .into_dimensionality()
+            .unwrap();
+
+        // Iterate all dimensions
+        for (k_x, mut w_x) in k.outer_iter().zip(w.outer_iter_mut()) {
+            // Calculate weight function for each component
+            for i in 0..self.prefactor.len() {
+                let radius = self.kernel_radius[i];
+                let p = self.prefactor[i];
+                let rik = k_abs.mapv(|k| radius * k);
+                let mut w_i = w_x.index_axis_mut(Axis(0), i);
+                w_i.assign(&match self.shape {
+                    WeightFunctionShape::DeltaVec => {
+                        &rik.mapv(|rik| {
+                            (rik.sph_j0() + rik.sph_j2()) * (-radius.powi(3) * 4.0 * FRAC_PI_3 * p)
+                        }) * &k_x
+                    }
+                    _ => unreachable!(),
+                });
+
+                // Apply Lanczos sigma factor
+                if let Some(l) = lanczos {
+                    w_i.assign(&(&w_i * l));
+                }
+            }
+        }
+        // Return imaginary part of weight function
+        w
+    }
+
+    /// Scalar weights for the bulk convolver (for the bulk convolver only the prefactor
+    /// of the normalized weight functions are required)
+    pub fn scalar_weight_constants(&self, k: T) -> Array1<T> {
+        let k = arr0(k);
+        self.fft_scalar_weight_functions(&k, &None)
+    }
+
+    /// Vector weights for the bulk convolver (for the bulk convolver only the prefactor
+    /// of the normalized weight functions are required)
+    pub fn vector_weight_constants(&self, k: T) -> Array1<T> {
+        let k_abs = arr0(k);
+        let k = arr1(&[k]);
+        self.fft_vector_weight_functions(&k_abs, &k, &None)
+            .index_axis_move(Axis(0), 0)
+    }
+}
+
+/// Possible weight function shapes.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum WeightFunctionShape {
+    /// Heaviside step function
+    Theta,
+    /// Dirac delta function
+    Delta,
+    /// Combination of first & second derivative of Dirac delta function (with different prefactor; only in Kierlik-Rosinberg functional)
+    KR0,
+    /// First derivative of Dirac delta function (with different prefactor; only in Kierlik-Rosinberg functional)
+    KR1,
+    /// Vector-shape as combination of Dirac delta and outward normal
+    DeltaVec,
+}
+
+/// Defining `type` for information about weight functions based on
+/// `WeightFunctionBase<TScal, TVec>`.
+// pub type WeightFunctionInfo<T> = WeightFunctionBase<WeightFunction<T>, WeightFunction<T>>;
+
+pub struct WeightFunctionInfo<T> {
+    /// Index of the component that each individual segment belongs to.
+    pub(crate) component_index: Array1<usize>,
+    /// Flag if local density is required in the functional
+    pub(crate) local_density: bool,
+    /// Container for scalar component-wise weighted densities
+    pub(crate) scalar_component_weighted_densities: Vec<WeightFunction<T>>,
+    /// Container for vector component-wise weighted densities
+    pub(crate) vector_component_weighted_densities: Vec<WeightFunction<T>>,
+    /// Container for scalar FMT weighted densities
+    pub(crate) scalar_fmt_weighted_densities: Vec<WeightFunction<T>>,
+    /// Container for vector FMT weighted densities
+    pub(crate) vector_fmt_weighted_densities: Vec<WeightFunction<T>>,
+}
+
+impl<T> WeightFunctionInfo<T> {
+    /// Calculates the total number of weighted densities for each functional
+    /// from multiple weight functions depending on dimension.
+    pub fn n_weighted_densities(&self, dimensions: usize) -> usize {
+        let segments = self.component_index.len();
+        (if self.local_density { segments } else { 0 })
+            + self.scalar_component_weighted_densities.len() * segments
+            + self.vector_component_weighted_densities.len() * segments * dimensions
+            + self.scalar_fmt_weighted_densities.len()
+            + self.vector_fmt_weighted_densities.len() * dimensions
+    }
+}
+
+impl<T> WeightFunctionInfo<T> {
+    /// Initializing empty `WeightFunctionInfo`.
+    pub fn new(component_index: Array1<usize>, local_density: bool) -> Self {
+        Self {
+            component_index,
+            local_density,
+            scalar_component_weighted_densities: Vec::new(),
+            vector_component_weighted_densities: Vec::new(),
+            scalar_fmt_weighted_densities: Vec::new(),
+            vector_fmt_weighted_densities: Vec::new(),
+        }
+    }
+
+    /// Adds and sorts [WeightFunction] depending on information
+    /// about {FMT, component} & {scalar-valued, vector-valued}.
+    pub fn add(mut self, weight_function: WeightFunction<T>, fmt: bool) -> Self {
+        let segments = self.component_index.len();
+
+        // Check size of `kernel_radius`
+        if segments != weight_function.kernel_radius.len() {
+            panic!(
+                "Number of segments is fixed to {}; `kernel_radius` has {} entries.",
+                segments,
+                weight_function.kernel_radius.len()
+            );
+        }
+
+        // Check size of `prefactor`
+        if segments != weight_function.prefactor.len() {
+            panic!(
+                "Number of segments is fixed to {}; `prefactor` has {} entries.",
+                segments,
+                weight_function.prefactor.len()
+            );
+        }
+
+        // Add new `WeightFunction`
+        match (fmt, weight_function.shape) {
+            // {Component, vector}
+            (false, WeightFunctionShape::DeltaVec) => self
+                .vector_component_weighted_densities
+                .push(weight_function),
+            // {Component, scalar}
+            (false, _) => self
+                .scalar_component_weighted_densities
+                .push(weight_function),
+            // {FMT, vector}
+            (true, WeightFunctionShape::DeltaVec) => {
+                self.vector_fmt_weighted_densities.push(weight_function)
+            }
+            // {FMT, scalar}
+            (true, _) => self.scalar_fmt_weighted_densities.push(weight_function),
+        };
+
+        // Return
+        self
+    }
+
+    /// Adds and sorts multiple [WeightFunction]s.
+    pub fn extend(mut self, weight_functions: Vec<WeightFunction<T>>, fmt: bool) -> Self {
+        // Add each element of vector
+        for wf in weight_functions {
+            self = self.add(wf, fmt);
+        }
+
+        // Return
+        self
+    }
+
+    /// Expose weight functions outside of this crate
+    pub fn as_slice(&self) -> [&Vec<WeightFunction<T>>; 4] {
+        [
+            &self.scalar_component_weighted_densities,
+            &self.vector_component_weighted_densities,
+            &self.scalar_fmt_weighted_densities,
+            &self.vector_fmt_weighted_densities,
+        ]
+    }
+}
+
+impl<T: DualNum<f64>> WeightFunctionInfo<T> {
+    /// calculates the matrix of weight constants for this set of weighted densities
+    pub fn weight_constants(&self, k: T, dimensions: usize) -> Array2<T> {
+        let segments = self.component_index.len();
+        let n_wd = self.n_weighted_densities(dimensions);
+        let mut weight_constants = Array::zeros([n_wd, segments]);
+        let mut j = 0;
+        if self.local_density {
+            weight_constants
+                .slice_mut(s![j..j + segments, ..])
+                .into_diag()
+                .assign(&Array::ones(segments));
+            j += segments;
+        }
+        for w in &self.scalar_component_weighted_densities {
+            weight_constants
+                .slice_mut(s![j..j + segments, ..])
+                .into_diag()
+                .assign(&w.scalar_weight_constants(k));
+            j += segments;
+        }
+        if dimensions == 1 {
+            for w in &self.vector_component_weighted_densities {
+                weight_constants
+                    .slice_mut(s![j..j + segments, ..])
+                    .into_diag()
+                    .assign(&w.vector_weight_constants(k));
+                j += segments;
+            }
+        }
+        for w in &self.scalar_fmt_weighted_densities {
+            weight_constants
+                .slice_mut(s![j, ..])
+                .assign(&w.scalar_weight_constants(k));
+            j += 1;
+        }
+        if dimensions == 1 {
+            for w in &self.vector_fmt_weighted_densities {
+                weight_constants
+                    .slice_mut(s![j, ..])
+                    .assign(&w.vector_weight_constants(k));
+                j += 1;
+            }
+        }
+        weight_constants
+    }
+}

--- a/src/eos.rs
+++ b/src/eos.rs
@@ -3,6 +3,8 @@ use feos_core::python::cubic::PyPengRobinsonParameters;
 use feos_core::python::user_defined::PyEoSObj;
 use feos_core::*;
 use feos_estimator::*;
+use feos_fcsaft::python::PyFcSaftParameters;
+use feos_fcsaft::{FcSaft, FcSaftOptions};
 use feos_gc_pcsaft::python::PyGcPcSaftEosParameters;
 use feos_gc_pcsaft::{GcPcSaft, GcPcSaftOptions};
 use feos_pcsaft::python::PyPcSaftParameters;
@@ -25,6 +27,7 @@ use std::rc::Rc;
 pub enum EosVariant {
     PcSaft(PcSaft),
     GcPcSaft(GcPcSaft),
+    FcSaft(FcSaft),
     PengRobinson(PengRobinson),
     Python(PyEoSObj),
     Pets(Pets),
@@ -36,6 +39,7 @@ impl EquationOfState for EosVariant {
         match self {
             EosVariant::PcSaft(eos) => eos.components(),
             EosVariant::GcPcSaft(eos) => eos.components(),
+            EosVariant::FcSaft(eos) => eos.components(),
             EosVariant::PengRobinson(eos) => eos.components(),
             EosVariant::Python(eos) => eos.components(),
             EosVariant::Pets(eos) => eos.components(),
@@ -47,6 +51,7 @@ impl EquationOfState for EosVariant {
         match self {
             EosVariant::PcSaft(eos) => eos.compute_max_density(moles),
             EosVariant::GcPcSaft(eos) => eos.compute_max_density(moles),
+            EosVariant::FcSaft(eos) => eos.compute_max_density(moles),
             EosVariant::PengRobinson(eos) => eos.compute_max_density(moles),
             EosVariant::Python(eos) => eos.compute_max_density(moles),
             EosVariant::Pets(eos) => eos.compute_max_density(moles),
@@ -58,6 +63,7 @@ impl EquationOfState for EosVariant {
         match self {
             EosVariant::PcSaft(eos) => Self::PcSaft(eos.subset(component_list)),
             EosVariant::GcPcSaft(eos) => Self::GcPcSaft(eos.subset(component_list)),
+            EosVariant::FcSaft(eos) => Self::FcSaft(eos.subset(component_list)),
             EosVariant::PengRobinson(eos) => Self::PengRobinson(eos.subset(component_list)),
             EosVariant::Python(eos) => Self::Python(eos.subset(component_list)),
             EosVariant::Pets(eos) => Self::Pets(eos.subset(component_list)),
@@ -69,6 +75,7 @@ impl EquationOfState for EosVariant {
         match self {
             EosVariant::PcSaft(eos) => eos.residual(),
             EosVariant::GcPcSaft(eos) => eos.residual(),
+            EosVariant::FcSaft(eos) => eos.residual(),
             EosVariant::PengRobinson(eos) => eos.residual(),
             EosVariant::Python(eos) => eos.residual(),
             EosVariant::Pets(eos) => eos.residual(),
@@ -93,6 +100,7 @@ impl MolarWeight<SIUnit> for EosVariant {
         match self {
             EosVariant::PcSaft(eos) => eos.molar_weight(),
             EosVariant::GcPcSaft(eos) => eos.molar_weight(),
+            EosVariant::FcSaft(eos) => eos.molar_weight(),
             EosVariant::PengRobinson(eos) => eos.molar_weight(),
             EosVariant::Python(eos) => eos.molar_weight(),
             EosVariant::Pets(eos) => eos.molar_weight(),
@@ -256,6 +264,34 @@ impl PyEosVariant {
         Self(Rc::new(EosVariant::GcPcSaft(GcPcSaft::with_options(
             parameters.0,
             options,
+        ))))
+    }
+
+    #[args(
+        max_eta = "0.5",
+        max_iter_cross_assoc = "50",
+        tol_cross_assoc = "1e-10"
+    )]
+    #[staticmethod]
+    #[pyo3(
+        text_signature = "(parameters, max_eta, max_iter_cross_assoc, tol_cross_assoc, model_params=None)"
+    )]
+    fn fcsaft(
+        parameters: PyFcSaftParameters,
+        max_eta: f64,
+        max_iter_cross_assoc: usize,
+        tol_cross_assoc: f64,
+        model_params: Option<[[f64; 7]; 4]>,
+    ) -> Self {
+        let options = FcSaftOptions {
+            max_eta,
+            max_iter_cross_assoc,
+            tol_cross_assoc,
+        };
+        Self(Rc::new(EosVariant::FcSaft(FcSaft::with_options(
+            parameters.0,
+            options,
+            model_params,
         ))))
     }
 

--- a/src/fcsaft.rs
+++ b/src/fcsaft.rs
@@ -1,0 +1,18 @@
+use feos_core::python::joback::PyJobackRecord;
+use feos_core::python::parameter::*;
+use feos_fcsaft::python::{PyFcSaftParameters, PyFcSaftRecord, PySegmentRecord};
+use pyo3::prelude::*;
+
+#[pymodule]
+pub fn fcsaft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyIdentifier>()?;
+    m.add_class::<PyChemicalRecord>()?;
+    m.add_class::<PyJobackRecord>()?;
+
+    m.add_class::<PyFcSaftRecord>()?;
+    m.add_class::<PySegmentRecord>()?;
+    m.add_class::<PyBinaryRecord>()?;
+    m.add_class::<PyBinarySegmentRecord>()?;
+    m.add_class::<PyFcSaftParameters>()?;
+    Ok(())
+}

--- a/src/fit/binary_vle.rs
+++ b/src/fit/binary_vle.rs
@@ -1,0 +1,325 @@
+use std::{fmt::LowerExp, rc::Rc};
+
+use super::{DataSet, FitError};
+use feos_core::{Contributions, EosUnit, EquationOfState, PhaseEquilibrium, State, VLEOptions};
+use ndarray::{arr1, Array1};
+use ndarray_stats::QuantileExt;
+use quantity::{Quantity, QuantityArray1, QuantityScalar};
+
+enum CostFunction {
+    Pressure,
+    ChemicalPotential,
+    Distance,
+}
+
+/// Store experimental vapor pressure data and compare to the equation of state.
+#[derive(Clone)]
+pub struct BinaryTPx<U: EosUnit> {
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    liquid_molefracs: Array1<f64>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> BinaryTPx<U> {
+    pub fn new(
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+        liquid_molefracs: Array1<f64>,
+    ) -> Result<Self, FitError> {
+        let datapoints = temperature.len();
+        Ok(Self {
+            temperature,
+            pressure,
+            liquid_molefracs,
+            datapoints,
+        })
+    }
+
+    fn pressure_cost<E: EquationOfState>(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        Quantity<f64, U>: std::fmt::Display,
+    {
+        let options = (VLEOptions::default(), VLEOptions::default());
+
+        // let reduced_temperatures = (0..self.datapoints)
+        //     .map(|i| (self.temperature.get(i) * tc_inv).into_value().unwrap())
+        //     .collect::<Vec<f64>>();
+
+        // let prediction = &self.predict(eos)?;
+        let mut cost = Array1::zeros(self.datapoints);
+        for i in 0..self.datapoints {
+            let xi = self.liquid_molefracs[i];
+            let prediction = PhaseEquilibrium::bubble_point_tx(
+                eos,
+                self.temperature.get(i),
+                Some(self.pressure.get(i)),
+                &arr1(&vec![xi, 1.0 - xi]),
+                None,
+                options,
+            )?
+            .vapor()
+            .pressure(Contributions::Total);
+
+            cost[i] = ((self.pressure.get(i) - prediction) / self.pressure.get(i)).into_value()?
+        }
+        Ok(cost)
+    }
+
+    fn distance_cost<E: EquationOfState>(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        Quantity<f64, U>: std::fmt::Display,
+    {
+        let dx = 1e-4;
+        let tol = 1e-9;
+        let max_iter = 60;
+        let options = (VLEOptions::default(), VLEOptions::default());
+        let mut cost = Array1::zeros(self.datapoints);
+
+        for i in 0..self.datapoints {
+            let xi = self.liquid_molefracs[i];
+            let mut dxi = if xi < 0.5 { dx } else { -dx };
+            let temperature = self.temperature.get(i);
+            let pressure = self.pressure.get(i);
+            let mut shift = 0.0;
+            'iteration: for i in 0..max_iter {
+                let damping = match i {
+                    i if i <= 2 => 0.75,
+                    i if i > 8 && shift < 1e-5 => 0.5,
+                    i if i > 25 => 0.25,
+                    _ => 1.0,
+                };
+
+                let xi_f = xi + shift * damping;
+                let prediction = PhaseEquilibrium::bubble_point_tx(
+                    eos,
+                    temperature,
+                    Some(pressure),
+                    &arr1(&vec![xi_f, 1.0 - xi_f]),
+                    None,
+                    options,
+                );
+                if prediction.is_err() {
+                    cost[i] = 10.0;
+                    break 'iteration;
+                }
+                let p1 = prediction.unwrap().vapor().pressure(Contributions::Total);
+
+                if xi_f > 1.0 - dxi {
+                    dxi *= -1.0
+                };
+
+                let xi_b = xi_f + dxi;
+                let prediction = PhaseEquilibrium::bubble_point_tx(
+                    eos,
+                    temperature,
+                    Some(pressure),
+                    &arr1(&vec![xi_b, 1.0 - xi_b]),
+                    None,
+                    options,
+                );
+                if prediction.is_err() {
+                    cost[i] = 10.0;
+                    break 'iteration;
+                }
+                let p2 = prediction.unwrap().vapor().pressure(Contributions::Total);
+                let mut line_vec = arr1(&[dxi, (p2 - p1).to_reduced(pressure)?]);
+                line_vec /= line_vec.mapv(|li| li * li).sum().sqrt();
+                let exp_vec = arr1(&[xi - xi_f, (pressure - p1).to_reduced(pressure)?]);
+                cost[i] = (&exp_vec * &exp_vec).sum().sqrt();
+                shift = line_vec[0] * (&line_vec * &exp_vec).sum().sqrt();
+                if shift > xi_f {
+                    shift = xi_f
+                }
+                if shift < -xi_f {
+                    shift = -xi_f
+                }
+                if shift.abs() <= tol {
+                    break 'iteration;
+                }
+            }
+        }
+        Ok(cost)
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for BinaryTPx<U>
+where
+    Quantity<f64, U>: std::fmt::Display + LowerExp,
+{
+    fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError> {
+        self.pressure_cost(eos)
+    }
+}
+
+#[derive(Clone)]
+pub struct BinaryTPy<U: EosUnit> {
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    vapor_molefracs: Array1<f64>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> BinaryTPy<U> {
+    pub fn new(
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+        vapor_molefracs: Array1<f64>,
+    ) -> Result<Self, FitError> {
+        let datapoints = temperature.len();
+        Ok(Self {
+            temperature,
+            pressure,
+            vapor_molefracs,
+            datapoints,
+        })
+    }
+
+    fn pressure_cost<E: EquationOfState>(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        Quantity<f64, U>: std::fmt::Display,
+    {
+        let options = (VLEOptions::default(), VLEOptions::default());
+
+        let mut cost = Array1::zeros(self.datapoints);
+        for i in 0..self.datapoints {
+            let yi = self.vapor_molefracs[i];
+            let prediction = PhaseEquilibrium::dew_point_tx(
+                eos,
+                self.temperature.get(i),
+                Some(self.pressure.get(i)),
+                &arr1(&vec![yi, 1.0 - yi]),
+                None,
+                options,
+            )?
+            .vapor()
+            .pressure(Contributions::Total);
+
+            cost[i] = ((self.pressure.get(i) - prediction) / self.pressure.get(i)).into_value()?
+        }
+        Ok(cost)
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for BinaryTPy<U>
+where
+    Quantity<f64, U>: std::fmt::Display + LowerExp,
+{
+    fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError> {
+        self.pressure_cost(eos)
+    }
+}
+
+#[derive(Clone)]
+pub struct BinaryTPxy<U: EosUnit> {
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    liquid_molefracs: Array1<f64>,
+    vapor_molefracs: Array1<f64>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> BinaryTPxy<U> {
+    pub fn new(
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+        liquid_molefracs: Array1<f64>,
+        vapor_molefracs: Array1<f64>,
+    ) -> Result<Self, FitError> {
+        let datapoints = temperature.len();
+        Ok(Self {
+            temperature,
+            pressure,
+            liquid_molefracs,
+            vapor_molefracs,
+            datapoints,
+        })
+    }
+
+    fn pressure_cost<E: EquationOfState>(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        Quantity<f64, U>: std::fmt::Display,
+    {
+        let options = (VLEOptions::default(), VLEOptions::default());
+
+        let mut cost = Array1::zeros(2 * self.datapoints);
+        for i in 0..self.datapoints {
+            let xi = self.liquid_molefracs[i];
+            let yi = self.vapor_molefracs[i];
+
+            let prediction_liquid = PhaseEquilibrium::bubble_point_tx(
+                eos,
+                self.temperature.get(i),
+                Some(self.pressure.get(i)),
+                &arr1(&vec![xi, 1.0 - xi]),
+                Some(&arr1(&vec![yi, 1.0 - yi])),
+                options,
+            )?
+            .vapor()
+            .pressure(Contributions::Total);
+
+            let prediction_vapor = PhaseEquilibrium::dew_point_tx(
+                eos,
+                self.temperature.get(i),
+                Some(self.pressure.get(i)),
+                &arr1(&vec![yi, 1.0 - yi]),
+                Some(&arr1(&vec![xi, 1.0 - xi])),
+                options,
+            )?
+            .vapor()
+            .pressure(Contributions::Total);
+
+            cost[i] =
+                ((self.pressure.get(i) - prediction_liquid) / self.pressure.get(i)).into_value()?;
+            cost[self.datapoints + i] =
+                ((self.pressure.get(i) - prediction_vapor) / self.pressure.get(i)).into_value()?;
+        }
+        Ok(cost)
+    }
+
+    fn chemical_potential_cost<E: EquationOfState>(
+        &self,
+        eos: &Rc<E>,
+    ) -> Result<Array1<f64>, FitError>
+    where
+        Quantity<f64, U>: std::fmt::Display,
+    {
+        let mut cost = Array1::zeros(self.datapoints);
+        for i in 0..self.datapoints {
+            let xi = self.liquid_molefracs[i];
+            let yi = self.vapor_molefracs[i];
+            let temperature = self.temperature.get(i);
+            let pressure = self.pressure.get(i);
+            let mu_liquid = State::new_npt(
+                eos,
+                temperature,
+                pressure,
+                &(arr1(&[xi, 1.0 - xi]) * U::reference_moles()),
+                feos_core::DensityInitialization::Liquid,
+            )?
+            .chemical_potential(Contributions::Total)
+            .to_reduced(U::reference_molar_energy())?;
+
+            let mu_vapor = State::new_npt(
+                eos,
+                temperature,
+                pressure,
+                &(arr1(&[yi, 1.0 - yi]) * U::reference_moles()),
+                feos_core::DensityInitialization::Vapor,
+            )?
+            .chemical_potential(Contributions::Total)
+            .to_reduced(U::reference_molar_energy())?;
+            cost[i] = (mu_liquid - mu_vapor).mapv(|dmu| dmu * dmu).sum().sqrt();
+        }
+        Ok(cost)
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for BinaryTPxy<U>
+where
+    Quantity<f64, U>: std::fmt::Display + LowerExp,
+{
+    fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError> {
+        self.pressure_cost(eos)
+    }
+}

--- a/src/fit/dataset.rs
+++ b/src/fit/dataset.rs
@@ -1,0 +1,80 @@
+//! The [`DataSet`] trait provides routines that can be used for
+//! optimization of parameters of equations of state given
+//! a `target` which can be values from experimental data or
+//! other models.
+use super::{EstimatorError, Loss};
+use feos_core::EosUnit;
+use feos_core::EquationOfState;
+use ndarray::Array1;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::collections::HashMap;
+use std::fmt;
+use std::rc::Rc;
+
+/// Utilities for working with experimental data.
+///
+/// Functionalities in the context of optimizations of
+/// parameters of equations of state.
+pub trait DataSet<U: EosUnit, E: EquationOfState> {
+    /// Return target quantity.
+    fn target(&self) -> QuantityArray1<U>;
+
+    /// Return the description of the target quantity.
+    fn target_str(&self) -> &str;
+
+    /// Return the descritions of the input quantities needed to compute the target.
+    fn input_str(&self) -> Vec<&str>;
+
+    /// Evaluation of the equation of state for the target quantity.
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp;
+
+    /// Evaluate the cost function.
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp;
+
+    /// Returns the input quantities as HashMap. The keys are the input's descriptions.
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>>;
+
+    /// Returns the number of experimental data points.
+    fn datapoints(&self) -> usize {
+        self.target().len()
+    }
+
+    /// Returns the relative difference between the equation of state and the experimental values.
+    fn relative_difference(&self, eos: &Rc<E>) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let prediction = &self.predict(eos)?;
+        let target = &self.target();
+        Ok(((prediction - target) / target).into_value()?)
+    }
+
+    /// Returns the mean of the absolute relative difference between the equation of state and the experimental values.
+    fn mean_absolute_relative_difference(&self, eos: &Rc<E>) -> Result<f64, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        Ok(self
+            .relative_difference(eos)?
+            .into_iter()
+            .filter(|&x| x.is_finite())
+            .enumerate()
+            .fold(0.0, |mean, (i, x)| mean + (x.abs() - mean) / (i + 1) as f64))
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> fmt::Display for dyn DataSet<U, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DataSet(target: {}, input: {}, datapoints: {}",
+            self.target_str(),
+            self.input_str().join(", "),
+            self.datapoints()
+        )
+    }
+}

--- a/src/fit/diffusion.rs
+++ b/src/fit/diffusion.rs
@@ -1,0 +1,88 @@
+use super::{DataSet, EstimatorError, Loss};
+use feos_core::{DensityInitialization, EntropyScaling, EosUnit, EquationOfState, State};
+use ndarray::{arr1, Array1};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Store experimental diffusion data.
+#[derive(Clone)]
+pub struct Diffusion<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> Diffusion<U> {
+    /// Create a new data set for experimental diffusion data.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+    ) -> Result<Self, EstimatorError> {
+        let datapoints = target.len();
+        Ok(Self {
+            target,
+            temperature,
+            pressure,
+            datapoints,
+        })
+    }
+
+    /// Return temperature.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+
+    /// Return pressure.
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        self.pressure.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Diffusion<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "diffusion"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature", "pressure"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        let moles = arr1(&[1.0]) * U::reference_moles();
+        for i in 0..self.datapoints {
+            let t = self.temperature.get(i);
+            let p = self.pressure.get(i);
+            let state = State::new_npt(eos, t, p, &moles, DensityInitialization::None)?;
+            prediction.try_set(i, state.diffusion()?)?;
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut cost = self.relative_difference(eos)?;
+        loss.apply(&mut cost.view_mut());
+        Ok(cost / self.datapoints as f64)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(1);
+        m.insert("temperature".to_owned(), self.temperature());
+        m.insert("pressure".to_owned(), self.pressure());
+        m
+    }
+}

--- a/src/fit/estimator.rs
+++ b/src/fit/estimator.rs
@@ -1,0 +1,114 @@
+//! The [`Estimator`] struct can be used to store multiple [`DataSet`]s for convenient parameter
+//! optimization.
+use super::{DataSet, EstimatorError, Loss};
+use feos_core::EosUnit;
+use feos_core::EquationOfState;
+use ndarray::{arr1, concatenate, Array1, ArrayView1, Axis};
+use quantity::QuantityArray1;
+use quantity::QuantityScalar;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Write;
+use std::rc::Rc;
+
+/// A collection of [`DataSet`]s and weights that can be used to
+/// evaluate an equation of state versus experimental data.
+pub struct Estimator<U: EosUnit, E: EquationOfState> {
+    data: Vec<Rc<dyn DataSet<U, E>>>,
+    weights: Vec<f64>,
+    losses: Vec<Loss>,
+}
+
+impl<U: EosUnit, E: EquationOfState> Estimator<U, E>
+where
+    QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+{
+    /// Create a new `Estimator` given `DataSet`s and weights.
+    ///
+    /// The weights are normalized and used as multiplicator when the
+    /// cost function across all `DataSet`s is evaluated.
+    pub fn new(data: Vec<Rc<dyn DataSet<U, E>>>, weights: Vec<f64>, losses: Vec<Loss>) -> Self {
+        Self {
+            data,
+            weights,
+            losses,
+        }
+    }
+
+    /// Add a `DataSet` and its weight.
+    pub fn add_data(&mut self, data: &Rc<dyn DataSet<U, E>>, weight: f64, loss: Loss) {
+        self.data.push(data.clone());
+        self.weights.push(weight);
+        self.losses.push(loss);
+    }
+
+    /// Returns the cost of each `DataSet`.
+    ///
+    /// Each cost contains the inverse weight.
+    pub fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, EstimatorError> {
+        let w = arr1(&self.weights) / self.weights.iter().sum::<f64>();
+        let predictions = self
+            .data
+            .iter()
+            .enumerate()
+            .map(|(i, d)| Ok(d.cost(eos, self.losses[i])? * w[i]))
+            .collect::<Result<Vec<_>, EstimatorError>>()?;
+        let aview: Vec<ArrayView1<f64>> = predictions.iter().map(|pi| pi.view()).collect();
+        Ok(concatenate(Axis(0), &aview)?)
+    }
+
+    /// Returns the properties as computed by the equation of state for each `DataSet`.
+    pub fn predict(&self, eos: &Rc<E>) -> Result<Vec<QuantityArray1<U>>, EstimatorError> {
+        self.data.iter().map(|d| d.predict(eos)).collect()
+    }
+
+    /// Returns the relative difference for each `DataSet`.
+    pub fn relative_difference(&self, eos: &Rc<E>) -> Result<Vec<Array1<f64>>, EstimatorError> {
+        self.data
+            .iter()
+            .map(|d| d.relative_difference(eos))
+            .collect()
+    }
+
+    /// Returns the mean absolute relative difference for each `DataSet`.
+    pub fn mean_absolute_relative_difference(
+        &self,
+        eos: &Rc<E>,
+    ) -> Result<Array1<f64>, EstimatorError> {
+        self.data
+            .iter()
+            .map(|d| d.mean_absolute_relative_difference(eos))
+            .collect()
+    }
+
+    /// Returns the stored `DataSet`s.
+    pub fn datasets(&self) -> Vec<Rc<dyn DataSet<U, E>>> {
+        self.data.to_vec()
+    }
+
+    /// Representation as markdown string.
+    pub fn _repr_markdownn_(&self) -> String {
+        let mut f = String::new();
+        write!(f, "| target | input | datapoints |\n|:-|:-|:-|").unwrap();
+        for d in self.data.iter() {
+            write!(
+                f,
+                "\n|{}|{}|{}|",
+                d.target_str(),
+                d.input_str().join(", "),
+                d.datapoints()
+            )
+            .unwrap();
+        }
+        f
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> Display for Estimator<U, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for d in self.data.iter() {
+            writeln!(f, "{}", d)?;
+        }
+        Ok(())
+    }
+}

--- a/src/fit/impl_dataset.rs
+++ b/src/fit/impl_dataset.rs
@@ -1,0 +1,336 @@
+/// Store experimental vapor pressure data and compare to the equation of state.
+#[derive(Clone)]
+pub struct VaporPressure<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    max_temperature: QuantityScalar<U>,
+    datapoints: usize,
+    std_parameters: Vec<f64>,
+}
+
+impl<U: EosUnit> VaporPressure<U> {
+    /// Create a new vapor pressure data set.
+    ///
+    /// Takes the temperature as input and possibly parameters
+    /// that describe the standard deviation of vapor pressure as
+    /// function of temperature. This standard deviation can be used
+    /// as inverse weights in the cost function.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        std_parameters: Vec<f64>,
+    ) -> Result<Self, FitError> {
+        let datapoints = target.len();
+        let max_temperature = *temperature
+            .to_reduced(U::reference_temperature())?
+            .max()
+            .map_err(|_| FitError::IncompatibleInput)?
+            * U::reference_temperature();
+        Ok(Self {
+            target,
+            temperature,
+            max_temperature,
+            datapoints,
+            std_parameters,
+        })
+    }
+
+    /// Return temperature.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+
+    /// Returns inverse standard deviation as weights for cost function.
+    fn weight_from_std(&self, reduced_temperature: &Array1<f64>) -> Array1<f64> {
+        reduced_temperature.map(|t| {
+            1.0 / ((-self.std_parameters[0] * t + self.std_parameters[1]).exp()
+                + self.std_parameters[2])
+        })
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for VaporPressure<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "vapor pressure"
+        // r"$p^\text{sat}$"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, FitError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let tc =
+            State::critical_point(eos, None, Some(self.max_temperature), VLEOptions::default())?
+                .temperature;
+
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        for i in 0..self.datapoints {
+            let t = self.temperature.get(i);
+            if t < tc {
+                let state = PhaseEquilibrium::pure_t(
+                    eos,
+                    self.temperature.get(i),
+                    None,
+                    VLEOptions::default(),
+                );
+                if let Ok(s) = state {
+                    prediction.try_set(i, s.liquid().pressure(Contributions::Total))?;
+                } else {
+                    println!(
+                        "Failed to compute vapor pressure, T = {}",
+                        self.temperature.get(i)
+                    );
+                    prediction.try_set(i, f64::NAN * unit)?;
+                }
+            } else {
+                prediction.try_set(i, f64::NAN * unit)?;
+            }
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let tc_inv = 1.0
+            / State::critical_point(eos, None, Some(self.max_temperature), VLEOptions::default())?
+                .temperature;
+
+        let reduced_temperatures = (0..self.datapoints)
+            .map(|i| (self.temperature.get(i) * tc_inv).into_value()?)
+            .collect();
+        let mut weights = self.weight_from_std(&reduced_temperatures);
+        weights /= weights.sum();
+
+        let prediction = &self.predict(eos)?;
+        let mut cost = Array1::zeros(self.datapoints);
+        for i in 0..self.datapoints {
+            if prediction.get(i).is_nan() {
+                cost[i] = weights[i]
+                    * 5.0
+                    * (self.temperature.get(i) - 1.0 / tc_inv)
+                        .to_reduced(U::reference_temperature())?;
+            } else {
+                cost[i] = weights[i]
+                    * ((self.target.get(i) - prediction.get(i)) / self.target.get(i))
+                        .into_value()?
+            }
+        }
+        Ok(cost)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(1);
+        m.insert("temperature".to_owned(), self.temperature());
+        m
+    }
+}
+
+/// Store experimental data of liquid densities and compare to the equation of state.
+#[derive(Clone)]
+pub struct LiquidDensity<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> LiquidDensity<U> {
+    /// A new data set for liquid densities with pressures and temperatures as input.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+    ) -> Result<Self, FitError> {
+        let datapoints = target.len();
+        Ok(Self {
+            target,
+            temperature,
+            pressure,
+            datapoints,
+        })
+    }
+
+    /// Returns temperature of data points.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+
+    /// Returns pressure of data points.
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        self.pressure.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E> for LiquidDensity<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "liquid density"
+        // r"$\rho^\text{liquid}$"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature", "pressure"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, FitError> {
+        assert_eq!(1, eos.components());
+        let moles = arr1(&[1.0]) * U::reference_moles();
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        for i in 0..self.datapoints {
+            let state = State::new_npt(
+                eos,
+                self.temperature.get(i),
+                self.pressure.get(i),
+                &moles,
+                DensityInitialization::Liquid,
+            );
+            if let Ok(s) = state {
+                prediction.try_set(i, s.mass_density())?;
+            } else {
+                prediction.try_set(i, 1.0e10 * unit)?;
+            }
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let n_inv = 1.0 / self.datapoints as f64;
+        let prediction = &self.predict(eos)?;
+        let mut cost = Array1::zeros(self.datapoints);
+        for i in 0..self.datapoints {
+            cost[i] = n_inv
+                * ((self.target.get(i) - prediction.get(i)) / self.target.get(i)).into_value()?
+        }
+        Ok(cost)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(2);
+        m.insert("temperature".to_owned(), self.temperature());
+        m.insert("pressure".to_owned(), self.pressure());
+        m
+    }
+}
+
+/// Store experimental data of liquid densities at VLE and compare to the equation of state.
+#[derive(Clone)]
+pub struct EquilibriumLiquidDensity<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    max_temperature: QuantityScalar<U>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> EquilibriumLiquidDensity<U> {
+    /// A new data set of liquid densities at VLE given temperatures.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+    ) -> Result<Self, FitError> {
+        let datapoints = target.len();
+        let max_temperature = *temperature
+            .to_reduced(U::reference_temperature())?
+            .max()
+            .map_err(|_| FitError::IncompatibleInput)?
+            * U::reference_temperature();
+        Ok(Self {
+            target,
+            temperature,
+            max_temperature,
+            datapoints,
+        })
+    }
+
+    /// Returns the temperature of data points.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E>
+    for EquilibriumLiquidDensity<U>
+{
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "liquid density (equilibrium)"
+        // r"$\rho^\text{liquid}_\text{equil}$"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, FitError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let tc =
+            State::critical_point(eos, None, Some(self.max_temperature), VLEOptions::default())?
+                .temperature;
+
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        for i in 0..self.datapoints {
+            let t: QuantityScalar<U> = self.temperature.get(i);
+            if t < tc {
+                let state: PhaseEquilibrium<U, E, 2> =
+                    PhaseEquilibrium::pure_t(eos, t, None, VLEOptions::default())?;
+                prediction.try_set(i, state.liquid().mass_density())?;
+            } else {
+                prediction.try_set(i, f64::NAN * unit)?;
+            }
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>) -> Result<Array1<f64>, FitError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let tc =
+            State::critical_point(eos, None, Some(self.max_temperature), VLEOptions::default())?
+                .temperature;
+        let n_inv = 1.0 / self.datapoints as f64;
+        let prediction = &self.predict(eos)?;
+        let mut cost = Array1::zeros(self.datapoints);
+        for i in 0..self.datapoints {
+            if prediction.get(i).is_nan() {
+                cost[i] = n_inv
+                    * 5.0
+                    * (self.temperature.get(i) - tc).to_reduced(U::reference_temperature())?;
+            } else {
+                cost[i] = n_inv
+                    * ((self.target.get(i) - prediction.get(i)) / self.target.get(i))
+                        .into_value()?
+            }
+        }
+        Ok(cost)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(2);
+        m.insert("temperature".to_owned(), self.temperature());
+        m
+    }
+}

--- a/src/fit/liquid_density.rs
+++ b/src/fit/liquid_density.rs
@@ -1,0 +1,177 @@
+use super::{DataSet, EstimatorError, Loss};
+use feos_core::{
+    DensityInitialization, EosUnit, EquationOfState, MolarWeight, PhaseEquilibrium, SolverOptions,
+    State,
+};
+use ndarray::{arr1, Array1};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Liquid mass density data as function of pressure and temperature.
+#[derive(Clone)]
+pub struct LiquidDensity<U: EosUnit> {
+    /// mass density
+    pub target: QuantityArray1<U>,
+    /// temperature
+    temperature: QuantityArray1<U>,
+    /// pressure
+    pressure: QuantityArray1<U>,
+    /// number of data points
+    datapoints: usize,
+}
+
+impl<U: EosUnit> LiquidDensity<U> {
+    /// A new data set for liquid densities with pressures and temperatures as input.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+    ) -> Result<Self, EstimatorError> {
+        let datapoints = target.len();
+        Ok(Self {
+            target,
+            temperature,
+            pressure,
+            datapoints,
+        })
+    }
+
+    /// Returns temperature of data points.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+
+    /// Returns pressure of data points.
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        self.pressure.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E> for LiquidDensity<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "liquid density"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature", "pressure"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError> {
+        let moles = arr1(&[1.0]) * U::reference_moles();
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        for i in 0..self.datapoints {
+            let state = State::new_npt(
+                eos,
+                self.temperature.get(i),
+                self.pressure.get(i),
+                &moles,
+                DensityInitialization::Liquid,
+            );
+            if let Ok(s) = state {
+                prediction.try_set(i, s.mass_density())?;
+            } else {
+                prediction.try_set(i, f64::NAN * unit)?;
+            }
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut cost = self.relative_difference(eos)?;
+        loss.apply(&mut cost.view_mut());
+        Ok(cost / self.datapoints as f64)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(2);
+        m.insert("temperature".to_owned(), self.temperature());
+        m.insert("pressure".to_owned(), self.pressure());
+        m
+    }
+}
+
+/// Store experimental data of liquid densities and compare to the equation of state.
+#[derive(Clone)]
+pub struct EquilibriumLiquidDensity<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> EquilibriumLiquidDensity<U> {
+    /// A new data set for liquid densities with pressures and temperatures as input.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+    ) -> Result<Self, EstimatorError> {
+        let datapoints = target.len();
+        Ok(Self {
+            target,
+            temperature,
+            datapoints,
+        })
+    }
+
+    /// Returns temperature of data points.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E>
+    for EquilibriumLiquidDensity<U>
+{
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "equilibrium liquid density"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let unit = self.target.get(0);
+
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        for i in 0..self.datapoints {
+            let t = self.temperature.get(i);
+            if let Ok(state) = PhaseEquilibrium::pure(eos, t, None, SolverOptions::default()) {
+                prediction.try_set(i, state.liquid().mass_density())?;
+            } else {
+                prediction.try_set(i, f64::NAN * U::reference_mass() / U::reference_volume())?
+            }
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut cost = self.relative_difference(eos)?;
+        loss.apply(&mut cost.view_mut());
+        Ok(cost / self.datapoints as f64)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(2);
+        m.insert("temperature".to_owned(), self.temperature());
+        m
+    }
+}

--- a/src/fit/loss.rs
+++ b/src/fit/loss.rs
@@ -1,0 +1,59 @@
+use ndarray::ArrayViewMut1;
+
+#[derive(Clone, Debug, Copy)]
+pub enum Loss {
+    Linear,
+    SoftL1(f64),
+    Huber(f64),
+    Cauchy(f64),
+    Arctan(f64),
+}
+
+impl Loss {
+    pub fn softl1(scaling_factor: f64) -> Self {
+        Self::SoftL1(scaling_factor)
+    }
+    pub fn huber(scaling_factor: f64) -> Self {
+        Self::Huber(scaling_factor)
+    }
+    pub fn cauchy(scaling_factor: f64) -> Self {
+        Self::Cauchy(scaling_factor)
+    }
+    pub fn arctan(scaling_factor: f64) -> Self {
+        Self::Arctan(scaling_factor)
+    }
+
+    pub fn apply(&self, res: &mut ArrayViewMut1<f64>) {
+        match self {
+            Self::Linear => (),
+            Self::SoftL1(s) => {
+                let s2 = s * s;
+                let s2_inv = 1.0 / s2;
+                res.mapv_inplace(|ri| {
+                    (s2 * (2.0 * (((ri * ri * s2_inv) + 1.0).sqrt() - 1.0))).sqrt()
+                })
+            }
+            Self::Huber(s) => {
+                let s2 = s * s;
+                let s2_inv = 1.0 / s2;
+                res.mapv_inplace(|ri| {
+                    if ri * ri * s2_inv <= 1.0 {
+                        ri
+                    } else {
+                        (s2 * (2.0 * (ri / s).abs() - 1.0)).sqrt()
+                    }
+                })
+            }
+            Self::Cauchy(s) => {
+                let s2 = s * s;
+                let s2_inv = 1.0 / s2;
+                res.mapv_inplace(|ri| (s2 * (1.0 + (ri * ri * s2_inv)).ln()).sqrt())
+            }
+            Self::Arctan(s) => {
+                let s2 = s * s;
+                let s2_inv = 1.0 / s2;
+                res.mapv_inplace(|ri| (s2 * (ri * ri * s2_inv).atan()).sqrt())
+            }
+        }
+    }
+}

--- a/src/fit/mod.rs
+++ b/src/fit/mod.rs
@@ -1,0 +1,39 @@
+use feos_core::EosError;
+use quantity::QuantityError;
+use std::num::ParseFloatError;
+use thiserror::Error;
+
+mod dataset;
+pub use dataset::DataSet;
+// mod binary_vle;
+mod estimator;
+pub use estimator::Estimator;
+mod loss;
+pub use loss::Loss;
+mod vapor_pressure;
+pub use vapor_pressure::VaporPressure;
+mod liquid_density;
+pub use liquid_density::{LiquidDensity, EquilibriumLiquidDensity};
+mod viscosity;
+pub use viscosity::Viscosity;
+mod thermal_conductivity;
+pub use thermal_conductivity::ThermalConductivity;
+mod diffusion;
+pub use diffusion::Diffusion;
+
+#[cfg(feature = "python")]
+pub mod python;
+
+#[derive(Debug, Error)]
+pub enum EstimatorError {
+    #[error("Input has not the same amount of data as the target.")]
+    IncompatibleInput,
+    #[error(transparent)]
+    ShapeError(#[from] ndarray::ShapeError),
+    #[error(transparent)]
+    ParseError(#[from] ParseFloatError),
+    #[error(transparent)]
+    QuantityError(#[from] QuantityError),
+    #[error(transparent)]
+    EosError(#[from] EosError),
+}

--- a/src/fit/python.rs
+++ b/src/fit/python.rs
@@ -1,0 +1,569 @@
+use super::EstimatorError;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::PyErr;
+
+impl From<EstimatorError> for PyErr {
+    fn from(e: EstimatorError) -> PyErr {
+        PyRuntimeError::new_err(e.to_string())
+    }
+}
+
+#[macro_export]
+macro_rules! impl_estimator {
+    ($eos:ty, $py_eos:ty) => {
+        #[pyclass(name = "Loss", unsendable)]
+        #[derive(Clone)]
+        pub struct PyLoss(Loss);
+
+        #[pymethods]
+        impl PyLoss {
+            /// Create a linear loss function.
+            ///
+            /// `loss = s**2 * rho(f**2 / s**2)`
+            /// where `rho(z) = z` and `s = 1`.
+            ///
+            /// Returns
+            /// -------
+            /// Loss
+            #[staticmethod]
+            pub fn linear() -> Self {
+                Self(Loss::Linear)
+            }
+
+            /// Create a loss function according to SoftL1's method.
+            ///
+            /// `loss = s**2 * rho(f**2 / s**2)`
+            /// where `rho(z) = 2 * ((1 + z)**0.5 - 1)`.
+            /// `s` is the scaling factor.
+            ///
+            /// Parameters
+            /// ----------
+            /// scaling_factor : f64
+            ///     Scaling factor for SoftL1 loss function.
+            ///
+            /// Returns
+            /// -------
+            /// Loss
+            #[staticmethod]
+            #[pyo3(text_signature = "(scaling_factor)")]
+            pub fn softl1(scaling_factor: f64) -> Self {
+                Self(Loss::SoftL1(scaling_factor))
+            }
+
+            /// Create a loss function according to Huber's method.
+            ///
+            /// `loss = s**2 * rho(f**2 / s**2)`
+            /// where `rho(z) = z if z <= 1 else 2*z**0.5 - 1`.
+            /// `s` is the scaling factor.
+            ///
+            /// Parameters
+            /// ----------
+            /// scaling_factor : f64
+            ///     Scaling factor for Huber loss function.
+            ///
+            /// Returns
+            /// -------
+            /// Loss
+            #[staticmethod]
+            #[pyo3(text_signature = "(scaling_factor)")]
+            pub fn huber(scaling_factor: f64) -> Self {
+                Self(Loss::Huber(scaling_factor))
+            }
+
+            /// Create a loss function according to Cauchy's method.
+            ///
+            /// `loss = s**2 * rho(f**2 / s**2)`
+            /// where `rho(z) = ln(1 + z)`.
+            /// `s` is the scaling factor.
+            ///
+            /// Parameters
+            /// ----------
+            /// scaling_factor : f64
+            ///     Scaling factor for SoftL1 loss function.
+            ///
+            /// Returns
+            /// -------
+            /// Loss
+            #[staticmethod]
+            #[pyo3(text_signature = "(scaling_factor)")]
+            pub fn cauchy(scaling_factor: f64) -> Self {
+                Self(Loss::Cauchy(scaling_factor))
+            }
+
+            /// Create a loss function according to Arctan's method.
+            ///
+            /// `loss = s**2 * rho(f**2 / s**2)`
+            /// where `rho(z) = arctan(z)`.
+            /// `s` is the scaling factor.
+            ///
+            /// Parameters
+            /// ----------
+            /// scaling_factor : f64
+            ///     Scaling factor for SoftL1 loss function.
+            ///
+            /// Returns
+            /// -------
+            /// Loss
+            #[staticmethod]
+            #[pyo3(text_signature = "(scaling_factor)")]
+            pub fn arctan(scaling_factor: f64) -> Self {
+                Self(Loss::Arctan(scaling_factor))
+            }
+        }
+
+        /// A collection of experimental data that can be used to compute
+        /// cost functions and make predictions using an equation of state.
+        #[pyclass(name = "DataSet", unsendable)]
+        #[derive(Clone)]
+        pub struct PyDataSet(Rc<dyn DataSet<SIUnit, $eos>>);
+
+        #[pymethods]
+        impl PyDataSet {
+            /// Compute the cost function for each input value.
+            ///
+            /// The cost function that is used depends on the
+            /// property. See the class constructors to learn
+            /// about the cost functions of the properties.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray[Float]
+            ///     The cost function evaluated for each experimental data point.
+            #[pyo3(text_signature = "($self, eos)")]
+            fn cost<'py>(
+                &self,
+                eos: &$py_eos,
+                loss: PyLoss,
+                py: Python<'py>,
+            ) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self.0.cost(&eos.0, loss.0)?.view().to_pyarray(py))
+            }
+
+            /// Return the property of interest for each data point
+            /// of the input as computed by the equation of state.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            ///
+            /// See also
+            /// --------
+            /// eos_python.saft.estimator.DataSet.vapor_pressure : ``DataSet`` for vapor pressure.
+            /// eos_python.saft.estimator.DataSet.liquid_density : ``DataSet`` for liquid density.
+            /// eos_python.saft.estimator.DataSet.equilibrium_liquid_density : ``DataSet`` for liquid density at vapor liquid equilibrium.
+            #[pyo3(text_signature = "($self, eos)")]
+            fn predict(&self, eos: &$py_eos) -> PyResult<PySIArray1> {
+                Ok(self.0.predict(&eos.0)?.into())
+            }
+
+            /// Return the relative difference between experimental data
+            /// and prediction of the equation of state.
+            ///
+            /// The relative difference is computed as:
+            ///
+            /// .. math:: \text{Relative Difference} = \frac{x_i^\text{prediction} - x_i^\text{experiment}}{x_i^\text{experiment}}
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray[Float]
+            #[pyo3(text_signature = "($self, eos)")]
+            fn relative_difference<'py>(
+                &self,
+                eos: &$py_eos,
+                py: Python<'py>,
+            ) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self.0.relative_difference(&eos.0)?.view().to_pyarray(py))
+            }
+
+            /// Return the mean absolute relative difference.
+            ///
+            /// The mean absolute relative difference is computed as:
+            ///
+            /// .. math:: \text{MARD} = \frac{1}{N}\sum_{i=1}^{N} \left|\frac{x_i^\text{prediction} - x_i^\text{experiment}}{x_i^\text{experiment}} \right|
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// Float
+            #[pyo3(text_signature = "($self, eos)")]
+            fn mean_absolute_relative_difference(&self, eos: &$py_eos) -> PyResult<f64> {
+                Ok(self.0.mean_absolute_relative_difference(&eos.0)?)
+            }
+
+            /// Create a DataSet with experimental data for vapor pressure.
+            ///
+            /// Parameters
+            /// ----------
+            /// target : SIArray1
+            ///     Experimental data for vapor pressure.
+            /// temperature : SIArray1
+            ///     Temperature for experimental data points.
+            /// extrapolate : bool, optional
+            ///     Use Antoine type equation to extrapolate vapor
+            ///     pressure if experimental data is above critial
+            ///     point of model. Defaults to False.
+            ///
+            /// Returns
+            /// -------
+            /// ``DataSet``
+            #[staticmethod]
+            #[pyo3(text_signature = "(target, temperature, extrapolate)")]
+            fn vapor_pressure(
+                target: &PySIArray1,
+                temperature: &PySIArray1,
+                extrapolate: Option<bool>,
+            ) -> PyResult<Self> {
+                Ok(Self(Rc::new(VaporPressure::<SIUnit>::new(
+                    target.clone().into(),
+                    temperature.clone().into(),
+                    extrapolate.unwrap_or(false),
+                )?)))
+            }
+
+            /// Create a DataSet with experimental data for liquid density.
+            ///
+            /// Parameters
+            /// ----------
+            /// target : SIArray1
+            ///     Experimental data for liquid density.
+            /// temperature : SIArray1
+            ///     Temperature for experimental data points.
+            /// pressure : SIArray1
+            ///     Pressure for experimental data points.
+            ///
+            /// Returns
+            /// -------
+            /// DataSet
+            #[staticmethod]
+            #[pyo3(text_signature = "(target, temperature, pressure)")]
+            fn liquid_density(
+                target: &PySIArray1,
+                temperature: &PySIArray1,
+                pressure: &PySIArray1,
+            ) -> PyResult<Self> {
+                Ok(Self(Rc::new(LiquidDensity::<SIUnit>::new(
+                    target.clone().into(),
+                    temperature.clone().into(),
+                    pressure.clone().into(),
+                )?)))
+            }
+
+            /// Create a DataSet with experimental data for liquid density
+            /// for a vapor liquid equilibrium.
+            ///
+            /// Parameters
+            /// ----------
+            /// target : SIArray1
+            ///     Experimental data for liquid density.
+            /// temperature : SIArray1
+            ///     Temperature for experimental data points.
+            ///
+            /// Returns
+            /// -------
+            /// DataSet
+            #[staticmethod]
+            #[pyo3(text_signature = "(target, temperature)")]
+            fn equilibrium_liquid_density(
+                target: &PySIArray1,
+                temperature: &PySIArray1,
+            ) -> PyResult<Self> {
+                Ok(Self(Rc::new(EquilibriumLiquidDensity::<SIUnit>::new(
+                    target.clone().into(),
+                    temperature.clone().into(),
+                )?)))
+            }
+
+            /// Return `input` as ``Dict[str, SIArray1]``.
+            #[getter]
+            fn get_input(&self) -> HashMap<String, PySIArray1> {
+                let mut m = HashMap::with_capacity(2);
+                self.0.get_input().drain().for_each(|(k, v)| {
+                    m.insert(k, PySIArray1::from(v));
+                });
+                m
+            }
+
+            /// Return `target` as ``SIArray1``.
+            #[getter]
+            fn get_target(&self) -> PySIArray1 {
+                PySIArray1::from(self.0.target())
+            }
+
+            /// Return `target` as ``SIArray1``.
+            #[getter]
+            fn get_datapoints(&self) -> usize {
+                self.0.datapoints()
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+
+        /// A collection `DataSets` that can be used to compute metrics for experimental data.
+        ///
+        /// Parameters
+        /// ----------
+        /// data : List[DataSet]
+        ///     The properties and experimental data points to add to
+        ///     the estimator.
+        /// weights : List[float]
+        ///     The weight of each property. When computing the cost function,
+        ///     the weights are normalized (sum of weights equals unity).
+        /// losses : List[Loss]
+        ///     The loss functions for each property.
+        ///
+        /// Returns
+        /// -------
+        /// Estimator
+        #[pyclass(name = "Estimator", unsendable)]
+        #[pyo3(text_signature = "(data, weights, losses)")]
+        pub struct PyEstimator(Estimator<SIUnit, $eos>);
+
+        #[pymethods]
+        impl PyEstimator {
+            #[new]
+            fn new(data: Vec<PyDataSet>, weights: Vec<f64>, losses: Vec<PyLoss>) -> Self {
+                Self(Estimator::new(
+                    data.iter().map(|d| d.0.clone()).collect(),
+                    weights,
+                    losses.iter().map(|l| l.0.clone()).collect(),
+                ))
+            }
+
+            /// Compute the cost function for each ``DataSet``.
+            ///
+            /// The cost function is:
+            /// - The relative difference between prediction and target value,
+            /// - to which a loss function is applied,
+            /// - and which is weighted according to the number of datapoints,
+            /// - and the relative weights as defined in the Estimator object.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray[Float]
+            ///     The cost function evaluated for each experimental data point
+            ///     of each ``DataSet``.
+            #[pyo3(text_signature = "($self, eos)")]
+            fn cost<'py>(&self, eos: &$py_eos, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self.0.cost(&eos.0)?.view().to_pyarray(py))
+            }
+
+            /// Return the properties as computed by the
+            /// equation of state for each `DataSet`.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// List[SIArray1]
+            #[pyo3(text_signature = "($self, eos)")]
+            fn predict(&self, eos: &$py_eos) -> PyResult<Vec<PySIArray1>> {
+                Ok(self
+                    .0
+                    .predict(&eos.0)?
+                    .iter()
+                    .map(|d| PySIArray1::from(d.clone()))
+                    .collect())
+            }
+
+            /// Return the relative difference between experimental data
+            /// and prediction of the equation of state for each ``DataSet``.
+            ///
+            /// The relative difference is computed as:
+            ///
+            /// .. math:: \text{Relative Difference} = \frac{x_i^\text{prediction} - x_i^\text{experiment}}{x_i^\text{experiment}}
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// List[numpy.ndarray[Float]]
+            #[pyo3(text_signature = "($self, eos)")]
+            fn relative_difference<'py>(
+                &self,
+                eos: &$py_eos,
+                py: Python<'py>,
+            ) -> PyResult<Vec<&'py PyArray1<f64>>> {
+                Ok(self
+                    .0
+                    .relative_difference(&eos.0)?
+                    .iter()
+                    .map(|d| d.view().to_pyarray(py))
+                    .collect())
+            }
+
+            /// Return the mean absolute relative difference for each ``DataSet``.
+            ///
+            /// The mean absolute relative difference is computed as:
+            ///
+            /// .. math:: \text{MARD} = \frac{1}{N}\sum_{i=1}^{N} \left|\frac{x_i^\text{prediction} - x_i^\text{experiment}}{x_i^\text{experiment}} \right|
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : PyEos
+            ///     The equation of state that is used.
+            ///
+            /// Returns
+            /// -------
+            /// numpy.ndarray[Float]
+            #[pyo3(text_signature = "($self, eos)")]
+            fn mean_absolute_relative_difference<'py>(
+                &self,
+                eos: &$py_eos,
+                py: Python<'py>,
+            ) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self
+                    .0
+                    .mean_absolute_relative_difference(&eos.0)?
+                    .view()
+                    .to_pyarray(py))
+            }
+
+            /// Return the stored ``DataSet``s.
+            ///
+            /// Returns
+            /// -------
+            /// List[DataSet]
+            #[getter]
+            fn get_datasets(&self) -> Vec<PyDataSet> {
+                self.0
+                    .datasets()
+                    .iter()
+                    .cloned()
+                    .map(|ds| PyDataSet(ds))
+                    .collect()
+            }
+
+            fn _repr_markdown_(&self) -> String {
+                self.0._repr_markdownn_()
+            }
+
+            fn __repr__(&self) -> PyResult<String> {
+                Ok(self.0.to_string())
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_estimator_entropy_scaling {
+    ($eos:ty, $py_eos:ty) => {
+        #[pymethods]
+        impl PyDataSet {
+            /// Create a DataSet with experimental data for viscosity.
+            ///
+            /// Parameters
+            /// ----------
+            /// target : SIArray1
+            ///     Experimental data for viscosity.
+            /// temperature : SIArray1
+            ///     Temperature for experimental data points.
+            /// pressure : SIArray1
+            ///     Pressure for experimental data points.
+            ///
+            /// Returns
+            /// -------
+            /// DataSet
+            #[staticmethod]
+            #[pyo3(text_signature = "(target, temperature, pressure)")]
+            fn viscosity(
+                target: &PySIArray1,
+                temperature: &PySIArray1,
+                pressure: &PySIArray1,
+            ) -> PyResult<Self> {
+                Ok(Self(Rc::new(Viscosity::<SIUnit>::new(
+                    target.clone().into(),
+                    temperature.clone().into(),
+                    pressure.clone().into(),
+                )?)))
+            }
+
+            /// Create a DataSet with experimental data for thermal conductivity.
+            ///
+            /// Parameters
+            /// ----------
+            /// target : SIArray1
+            ///     Experimental data for thermal conductivity.
+            /// temperature : SIArray1
+            ///     Temperature for experimental data points.
+            /// pressure : SIArray1
+            ///     Pressure for experimental data points.
+            ///
+            /// Returns
+            /// -------
+            /// DataSet
+            #[staticmethod]
+            #[pyo3(text_signature = "(target, temperature, pressure)")]
+            fn thermal_conductivity(
+                target: &PySIArray1,
+                temperature: &PySIArray1,
+                pressure: &PySIArray1,
+            ) -> PyResult<Self> {
+                Ok(Self(Rc::new(ThermalConductivity::<SIUnit>::new(
+                    target.clone().into(),
+                    temperature.clone().into(),
+                    pressure.clone().into(),
+                )?)))
+            }
+
+            /// Create a DataSet with experimental data for diffusion coefficient.
+            ///
+            /// Parameters
+            /// ----------
+            /// target : SIArray1
+            ///     Experimental data for diffusion coefficient.
+            /// temperature : SIArray1
+            ///     Temperature for experimental data points.
+            /// pressure : SIArray1
+            ///     Pressure for experimental data points.
+            ///
+            /// Returns
+            /// -------
+            /// DataSet
+            #[staticmethod]
+            #[pyo3(text_signature = "(target, temperature, pressure)")]
+            fn diffusion(
+                target: &PySIArray1,
+                temperature: &PySIArray1,
+                pressure: &PySIArray1,
+            ) -> PyResult<Self> {
+                Ok(Self(Rc::new(Diffusion::<SIUnit>::new(
+                    target.clone().into(),
+                    temperature.clone().into(),
+                    pressure.clone().into(),
+                )?)))
+            }
+        }
+    };
+}

--- a/src/fit/thermal_conductivity.rs
+++ b/src/fit/thermal_conductivity.rs
@@ -1,0 +1,88 @@
+use super::{DataSet, EstimatorError, Loss};
+use feos_core::{DensityInitialization, EntropyScaling, EosUnit, EquationOfState, State};
+use ndarray::{arr1, Array1};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Store experimental thermal conductivity data.
+#[derive(Clone)]
+pub struct ThermalConductivity<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> ThermalConductivity<U> {
+    /// Create a new data set for experimental thermal conductivity data.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+    ) -> Result<Self, EstimatorError> {
+        let datapoints = target.len();
+        Ok(Self {
+            target,
+            temperature,
+            pressure,
+            datapoints,
+        })
+    }
+
+    /// Return temperature.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+
+    /// Return pressure.
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        self.pressure.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for ThermalConductivity<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "thermal conductivity"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature", "pressure"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        let moles = arr1(&[1.0]) * U::reference_moles();
+        for i in 0..self.datapoints {
+            let t = self.temperature.get(i);
+            let p = self.pressure.get(i);
+            let state = State::new_npt(eos, t, p, &moles, DensityInitialization::None)?;
+            prediction.try_set(i, state.thermal_conductivity()?)?;
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut cost = self.relative_difference(eos)?;
+        loss.apply(&mut cost.view_mut());
+        Ok(cost / self.datapoints as f64)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(1);
+        m.insert("temperature".to_owned(), self.temperature());
+        m.insert("pressure".to_owned(), self.pressure());
+        m
+    }
+}

--- a/src/fit/vapor_pressure.rs
+++ b/src/fit/vapor_pressure.rs
@@ -1,0 +1,117 @@
+use super::{DataSet, EstimatorError, Loss};
+use feos_core::{Contributions, EosUnit, EquationOfState, PhaseEquilibrium, SolverOptions, State};
+use ndarray::Array1;
+use quantity::{QuantityArray1, QuantityScalar};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Store experimental vapor pressure data.
+#[derive(Clone)]
+pub struct VaporPressure<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    max_temperature: QuantityScalar<U>,
+    datapoints: usize,
+    extrapolate: bool,
+}
+
+impl<U: EosUnit> VaporPressure<U> {
+    /// Create a new data set for vapor pressure.
+    ///
+    /// If the equation of state fails to compute the vapor pressure
+    /// (e.g. when it underestimates the critical point) the vapor
+    /// pressure can be estimated.
+    /// If `extrapolate` is `true`, the vapor pressure is estimated by
+    /// calculating the slope of ln(p) over 1/T.
+    /// If `extrapolate` is `false`, it is set to `NAN`.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        extrapolate: bool,
+    ) -> Result<Self, EstimatorError> {
+        let datapoints = target.len();
+        let max_temperature = temperature
+            .to_reduced(U::reference_temperature())?
+            .into_iter()
+            .reduce(|a, b| a.max(b))
+            .unwrap()
+            * U::reference_temperature();
+        Ok(Self {
+            target,
+            temperature,
+            max_temperature,
+            datapoints,
+            extrapolate,
+        })
+    }
+
+    /// Return temperature.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for VaporPressure<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "vapor pressure"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let critical_point = State::critical_point(
+            eos,
+            None,
+            Some(self.max_temperature),
+            SolverOptions::default(),
+        )?;
+        let tc = critical_point.temperature;
+        let pc = critical_point.pressure(Contributions::Total);
+
+        let t0 = 0.9 * tc;
+        let p0 = PhaseEquilibrium::pure(eos, t0, None, SolverOptions::default())?
+            .vapor()
+            .pressure(Contributions::Total);
+
+        let b = pc.to_reduced(p0)?.ln() / (1.0 / tc - 1.0 / t0);
+        let a = pc.to_reduced(U::reference_pressure())?.ln() - b.to_reduced(tc)?;
+
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        for i in 0..self.datapoints {
+            let t = self.temperature.get(i);
+            if let Some(pvap) = PhaseEquilibrium::vapor_pressure(eos, t)[0] {
+                prediction.try_set(i, pvap)?;
+            } else if self.extrapolate {
+                prediction.try_set(i, (a + b.to_reduced(t)?).exp() * U::reference_pressure())?;
+            } else {
+                prediction.try_set(i, f64::NAN * U::reference_pressure())?
+            }
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut cost = self.relative_difference(eos)?;
+        loss.apply(&mut cost.view_mut());
+        Ok(cost / self.datapoints as f64)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(1);
+        m.insert("temperature".to_owned(), self.temperature());
+        m
+    }
+}

--- a/src/fit/viscosity.rs
+++ b/src/fit/viscosity.rs
@@ -1,0 +1,88 @@
+use super::{DataSet, EstimatorError, Loss};
+use feos_core::{DensityInitialization, EntropyScaling, EosUnit, EquationOfState, State};
+use ndarray::{arr1, Array1};
+use quantity::{QuantityArray1, QuantityScalar};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Store experimental viscosity data.
+#[derive(Clone)]
+pub struct Viscosity<U: EosUnit> {
+    pub target: QuantityArray1<U>,
+    temperature: QuantityArray1<U>,
+    pressure: QuantityArray1<U>,
+    datapoints: usize,
+}
+
+impl<U: EosUnit> Viscosity<U> {
+    /// Create a new data set for experimental viscosity data.
+    pub fn new(
+        target: QuantityArray1<U>,
+        temperature: QuantityArray1<U>,
+        pressure: QuantityArray1<U>,
+    ) -> Result<Self, EstimatorError> {
+        let datapoints = target.len();
+        Ok(Self {
+            target,
+            temperature,
+            pressure,
+            datapoints,
+        })
+    }
+
+    /// Return temperature.
+    pub fn temperature(&self) -> QuantityArray1<U> {
+        self.temperature.clone()
+    }
+
+    /// Return pressure.
+    pub fn pressure(&self) -> QuantityArray1<U> {
+        self.pressure.clone()
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Viscosity<U> {
+    fn target(&self) -> QuantityArray1<U> {
+        self.target.clone()
+    }
+
+    fn target_str(&self) -> &str {
+        "viscosity"
+    }
+
+    fn input_str(&self) -> Vec<&str> {
+        vec!["temperature", "pressure"]
+    }
+
+    fn predict(&self, eos: &Rc<E>) -> Result<QuantityArray1<U>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let unit = self.target.get(0);
+        let mut prediction = Array1::zeros(self.datapoints) * unit;
+        let moles = arr1(&[1.0]) * U::reference_moles();
+        for i in 0..self.datapoints {
+            let t = self.temperature.get(i);
+            let p = self.pressure.get(i);
+            let state = State::new_npt(eos, t, p, &moles, DensityInitialization::None)?;
+            prediction.try_set(i, state.viscosity()?)?;
+        }
+        Ok(prediction)
+    }
+
+    fn cost(&self, eos: &Rc<E>, loss: Loss) -> Result<Array1<f64>, EstimatorError>
+    where
+        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    {
+        let mut cost = self.relative_difference(eos)?;
+        loss.apply(&mut cost.view_mut());
+        Ok(cost / self.datapoints as f64)
+    }
+
+    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+        let mut m = HashMap::with_capacity(1);
+        m.insert("temperature".to_owned(), self.temperature());
+        m.insert("pressure".to_owned(), self.pressure());
+        m
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,59 +1,17 @@
 #![warn(clippy::all)]
 #![allow(clippy::too_many_arguments)]
-use pyo3::prelude::*;
-use pyo3::wrap_pymodule;
-use quantity::python::__PYO3_PYMODULE_DEF_QUANTITY;
-mod eos;
-use eos::__PYO3_PYMODULE_DEF_EOS;
-mod dft;
-use dft::__PYO3_PYMODULE_DEF_DFT;
-mod cubic;
-use cubic::__PYO3_PYMODULE_DEF_CUBIC;
-mod pcsaft;
-use pcsaft::__PYO3_PYMODULE_DEF_PCSAFT;
-mod fcsaft;
-use fcsaft::__PYO3_PYMODULE_DEF_FCSAFT;
-mod gc_pcsaft;
-use gc_pcsaft::__PYO3_PYMODULE_DEF_GC_PCSAFT;
-mod pets;
-use pets::__PYO3_PYMODULE_DEF_PETS;
-mod uvtheory;
-use uvtheory::__PYO3_PYMODULE_DEF_UVTHEORY;
 
-#[pymodule]
-pub fn feos(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    m.add_wrapped(wrap_pymodule!(quantity))?;
-    m.add_wrapped(wrap_pymodule!(eos))?;
-    m.add_wrapped(wrap_pymodule!(dft))?;
-    m.add_wrapped(wrap_pymodule!(cubic))?;
-    m.add_wrapped(wrap_pymodule!(pcsaft))?;
-    m.add_wrapped(wrap_pymodule!(gc_pcsaft))?;
-    m.add_wrapped(wrap_pymodule!(fcsaft))?;
-    m.add_wrapped(wrap_pymodule!(pets))?;
-    m.add_wrapped(wrap_pymodule!(uvtheory))?;
-    py.run(
-        "\
-import sys
-quantity.SINumber.__module__ = 'feos.si'
-quantity.SIArray1.__module__ = 'feos.si'
-quantity.SIArray2.__module__ = 'feos.si'
-quantity.SIArray3.__module__ = 'feos.si'
-quantity.SIArray4.__module__ = 'feos.si'
-sys.modules['feos.si'] = quantity
-sys.modules['feos.eos'] = eos
-sys.modules['feos.eos.estimator'] = eos.estimator_eos
-sys.modules['feos.dft'] = dft
-sys.modules['feos.dft.estimator'] = dft.estimator_dft
-sys.modules['feos.cubic'] = cubic
-sys.modules['feos.pcsaft'] = pcsaft
-sys.modules['feos.gc_pcsaft'] = gc_pcsaft
-sys.modules['feos.fcsaft'] = fcsaft
-sys.modules['feos.pets'] = pets
-sys.modules['feos.uvtheory'] = uvtheory
-    ",
-        None,
-        Some(m.dict()),
-    )?;
-    Ok(())
-}
+#[cfg(feature = "fit")]
+pub mod fit;
+#[cfg(feature = "pcsaft")]
+pub mod pcsaft;
+#[cfg(feature = "python")]
+mod python;
+// mod fcsaft;
+// use fcsaft::__PYO3_PYMODULE_DEF_FCSAFT;
+// mod gc_pcsaft;
+// use gc_pcsaft::__PYO3_PYMODULE_DEF_GC_PCSAFT;
+// mod pets;
+// use pets::__PYO3_PYMODULE_DEF_PETS;
+// mod uvtheory;
+// use uvtheory::__PYO3_PYMODULE_DEF_UVTHEORY;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod cubic;
 use cubic::__PYO3_PYMODULE_DEF_CUBIC;
 mod pcsaft;
 use pcsaft::__PYO3_PYMODULE_DEF_PCSAFT;
+mod fcsaft;
+use fcsaft::__PYO3_PYMODULE_DEF_FCSAFT;
 mod gc_pcsaft;
 use gc_pcsaft::__PYO3_PYMODULE_DEF_GC_PCSAFT;
 mod pets;
@@ -27,6 +29,7 @@ pub fn feos(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(cubic))?;
     m.add_wrapped(wrap_pymodule!(pcsaft))?;
     m.add_wrapped(wrap_pymodule!(gc_pcsaft))?;
+    m.add_wrapped(wrap_pymodule!(fcsaft))?;
     m.add_wrapped(wrap_pymodule!(pets))?;
     m.add_wrapped(wrap_pymodule!(uvtheory))?;
     py.run(
@@ -45,6 +48,7 @@ sys.modules['feos.dft.estimator'] = dft.estimator_dft
 sys.modules['feos.cubic'] = cubic
 sys.modules['feos.pcsaft'] = pcsaft
 sys.modules['feos.gc_pcsaft'] = gc_pcsaft
+sys.modules['feos.fcsaft'] = fcsaft
 sys.modules['feos.pets'] = pets
 sys.modules['feos.uvtheory'] = uvtheory
     ",

--- a/src/pcsaft/dft/association.rs
+++ b/src/pcsaft/dft/association.rs
@@ -1,0 +1,187 @@
+use super::PcSaftParameters;
+use crate::pcsaft::eos::association::{
+    assoc_site_frac_a, assoc_site_frac_ab, helmholtz_energy_density_cross_association,
+};
+use feos_core::EosError;
+use feos_dft::{
+    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+};
+use ndarray::*;
+use num_dual::DualNum;
+use std::f64::consts::PI;
+use std::fmt;
+use std::rc::Rc;
+
+pub const N0_CUTOFF: f64 = 1e-9;
+
+#[derive(Clone)]
+pub struct AssociationFunctional {
+    parameters: Rc<PcSaftParameters>,
+    max_iter: usize,
+    tol: f64,
+}
+
+impl AssociationFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>, max_iter: usize, tol: f64) -> Self {
+        Self {
+            parameters,
+            max_iter,
+            tol,
+        }
+    }
+}
+
+impl<N> FunctionalContributionDual<N> for AssociationFunctional
+where
+    N: DualNum<f64> + ScalarOperand,
+{
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let p = &self.parameters;
+        let r = p.hs_diameter(temperature) * 0.5;
+        WeightFunctionInfo::new(Array1::from_shape_fn(r.len(), |i| i), false)
+            .add(
+                WeightFunction::new_scaled(r.clone(), WeightFunctionShape::Delta),
+                false,
+            )
+            .add(
+                WeightFunction {
+                    prefactor: p.m.mapv(N::from),
+                    kernel_radius: r.clone(),
+                    shape: WeightFunctionShape::DeltaVec,
+                },
+                false,
+            )
+            .add(
+                WeightFunction {
+                    prefactor: p.m.mapv(N::from),
+                    kernel_radius: r,
+                    shape: WeightFunctionShape::Theta,
+                },
+                true,
+            )
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> Result<Array1<N>, EosError> {
+        let p = &self.parameters;
+        // number of components
+        let n = p.m.len();
+        // number of dimensions
+        let dim = (weighted_densities.shape()[0] - 1) / n - 1;
+
+        // weighted densities
+        let n0i = weighted_densities.slice_axis(Axis(0), Slice::new(0, Some(n as isize), 1));
+        let n2vi: Vec<_> = (0..dim)
+            .into_iter()
+            .map(|i| {
+                weighted_densities.slice_axis(
+                    Axis(0),
+                    Slice::new((n * (i + 1)) as isize, Some((n * (i + 2)) as isize), 1),
+                )
+            })
+            .collect();
+        let n3 = weighted_densities.index_axis(Axis(0), n * (dim + 1));
+
+        // calculate rho0
+        let r = p.hs_diameter(temperature) * 0.5;
+        let mut n2i = Array::zeros(n0i.raw_dim());
+        for i in 0..n {
+            n2i.index_axis_mut(Axis(0), i)
+                .assign(&(&n0i.index_axis(Axis(0), i) * (r[i].powi(2) * (p.m[i] * 4.0 * PI))));
+        }
+        let mut rho0: Array2<N> = (n2vi
+            .iter()
+            .map(|n2vi| n2vi * n2vi)
+            .fold(Array::zeros(n0i.raw_dim()), |acc, x| acc + x)
+            / -(&n2i * &n2i)
+            + 1.0)
+            * n0i;
+        rho0.iter_mut().zip(&n0i).for_each(|(rho0, &n0i)| {
+            if n0i.re() < N0_CUTOFF {
+                *rho0 = n0i;
+            }
+        });
+
+        // calculate xi
+        let n2v: Vec<_> = n2vi.iter().map(|n2vi| n2vi.sum_axis(Axis(0))).collect();
+        let n2 = n2i.sum_axis(Axis(0));
+        let mut xi = n2v
+            .iter()
+            .map(|n2v| n2v * n2v)
+            .fold(Array::zeros(n3.raw_dim()), |acc, x| acc + x)
+            / -(&n2 * &n2)
+            + 1.0;
+        xi.iter_mut()
+            .zip(&n0i.sum_axis(Axis(0)))
+            .for_each(|(xi, &n0i)| {
+                if n0i.re() < N0_CUTOFF {
+                    *xi = N::one();
+                }
+            });
+
+        // auxiliary variables
+        let n3i = n3.mapv(|n3| (-n3 + 1.0).recip());
+
+        // only one associating component
+        if p.nassoc == 1 {
+            // association strength
+            let a = p.assoc_comp[0];
+            let k = &n2 * &n3i * r[a];
+            let deltarho = (((&k / 18.0 + 0.5) * &k * xi + 1.0) * n3i)
+                * ((temperature.recip() * p.epsilon_k_aibj[(a, a)]).exp_m1()
+                    * (p.sigma[a].powi(3) * p.kappa_aibj[(a, a)]))
+                * rho0.index_axis(Axis(0), a);
+
+            let na = p.na[a];
+            let nb = p.nb[a];
+            let f = |x: N| x.ln() - x * 0.5 + 0.5;
+            if nb > 0.0 {
+                // no cross association, two association sites
+                let xa = deltarho.mapv(|d| assoc_site_frac_ab(d, na, nb));
+                let xb = (&xa - 1.0) * (na / nb) + 1.0;
+                Ok((xa.mapv(f) * na + xb.mapv(f) * nb) * rho0.index_axis(Axis(0), a))
+            } else {
+                // no cross association, one association site
+                let xa = deltarho.mapv(|d| assoc_site_frac_a(d, na));
+
+                Ok(xa.mapv(f) * na * rho0.index_axis(Axis(0), a))
+            }
+        } else {
+            let mut x: Array1<f64> = Array::from_elem(2 * p.nassoc, 0.2);
+            Ok(rho0
+                .view()
+                .into_shape([n, rho0.len() / n])
+                .unwrap()
+                .axis_iter(Axis(1))
+                .zip(n2.iter())
+                .zip(n3i.iter())
+                .zip(xi.iter())
+                .map(|(((rho0, &n2), &n3i), &xi)| {
+                    helmholtz_energy_density_cross_association(
+                        p,
+                        temperature,
+                        &rho0,
+                        &r,
+                        n2,
+                        n3i,
+                        xi,
+                        self.max_iter,
+                        self.tol,
+                        Some(&mut x),
+                    )
+                })
+                .collect::<Result<Array1<N>, _>>()?
+                .into_shape(n2.raw_dim())
+                .unwrap())
+        }
+    }
+}
+
+impl fmt::Display for AssociationFunctional {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Association functional")
+    }
+}

--- a/src/pcsaft/dft/dispersion.rs
+++ b/src/pcsaft/dft/dispersion.rs
@@ -1,0 +1,133 @@
+use super::polar::calculate_helmholtz_energy_density_polar;
+use super::PcSaftParameters;
+use crate::pcsaft::eos::dispersion::{A0, A1, A2, B0, B1, B2};
+use feos_core::EosError;
+use feos_dft::{
+    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+};
+use ndarray::*;
+use num_dual::DualNum;
+use std::f64::consts::{FRAC_PI_3, PI};
+use std::fmt;
+use std::rc::Rc;
+
+/// psi Parameter for DFT (Sauer2017)
+const PSI_DFT: f64 = 1.3862;
+/// psi Parameter for pDGT (Rehner2018)
+const PSI_PDGT: f64 = 1.3286;
+
+#[derive(Clone)]
+pub struct AttractiveFunctional {
+    parameters: Rc<PcSaftParameters>,
+}
+
+impl AttractiveFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>) -> Self {
+        Self { parameters }
+    }
+}
+
+fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
+    p: &PcSaftParameters,
+    psi: f64,
+    temperature: N,
+) -> WeightFunctionInfo<N> {
+    let d = p.hs_diameter(temperature);
+    WeightFunctionInfo::new(Array1::from_shape_fn(d.len(), |i| i), false).add(
+        WeightFunction::new_scaled(d * psi, WeightFunctionShape::Theta),
+        false,
+    )
+}
+
+impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for AttractiveFunctional {
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        att_weight_functions(&self.parameters, PSI_DFT, temperature)
+    }
+
+    fn weight_functions_pdgt(&self, temperature: N) -> WeightFunctionInfo<N> {
+        att_weight_functions(&self.parameters, PSI_PDGT, temperature)
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        density: ArrayView2<N>,
+    ) -> Result<Array1<N>, EosError> {
+        // auxiliary variables
+        let p = &self.parameters;
+        let n = p.m.len();
+
+        // temperature dependent segment radius
+        let r = p.hs_diameter(temperature) * 0.5;
+
+        // packing fraction
+        let eta = density
+            .outer_iter()
+            .zip((&r * &r * &r * &p.m * 4.0 * FRAC_PI_3).into_iter())
+            .fold(
+                Array::zeros(density.raw_dim().remove_axis(Axis(0))),
+                |acc: Array1<N>, (rho, r3m)| acc + &rho * r3m,
+            );
+
+        // mean segment number
+        let mut rhog = Array::zeros(eta.raw_dim());
+        let mut m_bar = Array::zeros(eta.raw_dim());
+        for (rhoi, &mi) in density.axis_iter(Axis(0)).zip(p.m.iter()) {
+            m_bar += &(&rhoi * mi);
+            rhog += &rhoi;
+        }
+        m_bar.iter_mut().zip(rhog.iter()).for_each(|(m, &r)| {
+            if r.re() > f64::EPSILON {
+                *m /= r
+            } else {
+                *m = N::one()
+            }
+        });
+
+        // mixture densities, crosswise interactions of all segments on all chains
+        let mut rho1mix: Array1<N> = Array::zeros(eta.raw_dim());
+        let mut rho2mix: Array1<N> = Array::zeros(eta.raw_dim());
+        for i in 0..n {
+            for j in 0..n {
+                let eps_ij_t = temperature.recip() * p.epsilon_k_ij[(i, j)];
+                let sigma_ij_3 = p.sigma_ij[(i, j)].powi(3);
+                rho1mix = rho1mix
+                    + (&density.index_axis(Axis(0), i) * &density.index_axis(Axis(0), j))
+                        .mapv(|x| x * (eps_ij_t * sigma_ij_3 * p.m[i] * p.m[j]));
+                rho2mix = rho2mix
+                    + (&density.index_axis(Axis(0), i) * &density.index_axis(Axis(0), j))
+                        .mapv(|x| x * (eps_ij_t * eps_ij_t * sigma_ij_3 * p.m[i] * p.m[j]));
+            }
+        }
+
+        // I1, I2 and C1
+        let mut i1: Array1<N> = Array::zeros(eta.raw_dim());
+        let mut i2: Array1<N> = Array::zeros(eta.raw_dim());
+        let mut eta_i: Array1<N> = Array::ones(eta.raw_dim());
+        let m1 = (m_bar.clone() - 1.0) / &m_bar;
+        let m2 = (m_bar.clone() - 2.0) / &m_bar * &m1;
+        for i in 0..=6 {
+            i1 = i1 + (&m2 * A2[i] + &m1 * A1[i] + A0[i]) * &eta_i;
+            i2 = i2 + (&m2 * B2[i] + &m1 * B1[i] + B0[i]) * &eta_i;
+            eta_i = &eta_i * &eta;
+        }
+        let c1 = Zip::from(&eta).and(&m_bar).map_collect(|&eta, &m| {
+            (m * (eta * 8.0 - eta.powi(2) * 2.0) / (eta - 1.0).powi(4)
+                + (eta * (eta * (eta * (eta * 2.0 - 12.0) + 27.0) - 20.0))
+                    / ((eta - 1.0) * (eta - 2.0)).powi(2)
+                    * (m - 1.0)
+                + 1.0)
+                .recip()
+        });
+
+        // Helmholtz energy density
+        let phi_polar = calculate_helmholtz_energy_density_polar(p, temperature, density)?;
+        Ok((-rho1mix * i1 * 2.0 - rho2mix * m_bar * c1 * i2) * PI + phi_polar)
+    }
+}
+
+impl fmt::Display for AttractiveFunctional {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Attractive functional")
+    }
+}

--- a/src/pcsaft/dft/hard_chain.rs
+++ b/src/pcsaft/dft/hard_chain.rs
@@ -1,0 +1,89 @@
+use super::PcSaftParameters;
+use feos_core::EosError;
+use feos_dft::fundamental_measure_theory::FMTProperties;
+use feos_dft::{
+    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+};
+use ndarray::*;
+use num_dual::DualNum;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub struct ChainFunctional {
+    parameters: Rc<PcSaftParameters>,
+}
+
+impl ChainFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>) -> Self {
+        Self { parameters }
+    }
+}
+
+impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for ChainFunctional {
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let p = &self.parameters;
+        let d = p.hs_diameter(temperature);
+        WeightFunctionInfo::new(p.component_index(), true)
+            .add(
+                WeightFunction {
+                    prefactor: p.m.mapv(|m| m.into()) / (&d * 8.0),
+                    kernel_radius: d.clone(),
+                    shape: WeightFunctionShape::Theta,
+                },
+                true,
+            )
+            .add(
+                WeightFunction {
+                    prefactor: p.m.mapv(|m| (m / 8.0).into()),
+                    kernel_radius: d.clone(),
+                    shape: WeightFunctionShape::Theta,
+                },
+                true,
+            )
+            .add(
+                WeightFunction::new_scaled(d, WeightFunctionShape::Delta),
+                false,
+            )
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> Result<Array1<N>, EosError> {
+        let p = &self.parameters;
+        // number of segments
+        let n = (weighted_densities.shape()[0] - 2) / 2;
+
+        // weighted densities
+        let rho = weighted_densities.slice_axis(Axis(0), Slice::new(0, Some(n as isize), 1));
+        // negative lambdas lead to nan, therefore the absolute value is used
+        let lambda = weighted_densities
+            .slice_axis(Axis(0), Slice::new(n as isize, Some(2 * n as isize), 1))
+            .mapv(|l| if l.re() < 0.0 { -l } else { l } + N::from(f64::EPSILON));
+        let zeta2 = weighted_densities.index_axis(Axis(0), 2 * n);
+        let zeta3 = weighted_densities.index_axis(Axis(0), 2 * n + 1);
+
+        // temperature dependent segment diameter
+        let d = p.hs_diameter(temperature);
+
+        let z3i = zeta3.mapv(|z3| (-z3 + 1.0).recip());
+        let mut phi = Array::zeros(zeta2.raw_dim());
+        for (i, (lambdai, rhoi)) in lambda.outer_iter().zip(rho.outer_iter()).enumerate() {
+            // cavity correlation
+            let z2d = zeta2.mapv(|z2| z2 * d[i]);
+            let yi = &z2d * &z3i * &z3i * (z2d * &z3i * 0.5 + 1.5) + &z3i;
+
+            // Helmholtz energy density
+            phi = phi - (yi * lambdai).mapv(|x| x.ln() - 1.0) * rhoi * (p.m[i] - 1.0);
+        }
+        Ok(phi)
+    }
+}
+
+impl fmt::Display for ChainFunctional {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Hard chain functional")
+    }
+}

--- a/src/pcsaft/dft/mod.rs
+++ b/src/pcsaft/dft/mod.rs
@@ -1,0 +1,171 @@
+use super::PcSaftParameters;
+use crate::pcsaft::eos::PcSaftOptions;
+use association::AssociationFunctional;
+use dispersion::AttractiveFunctional;
+use feos_core::joback::Joback;
+use feos_core::parameter::Parameter;
+use feos_core::{IdealGasContribution, MolarWeight};
+use feos_dft::adsorption::FluidParameters;
+use feos_dft::fundamental_measure_theory::{
+    FMTContribution, FMTProperties, FMTVersion, MonomerShape,
+};
+use feos_dft::solvation::PairPotential;
+use feos_dft::{FunctionalContribution, HelmholtzEnergyFunctional, MoleculeShape, DFT};
+use hard_chain::ChainFunctional;
+use ndarray::{Array, Array1, Array2};
+use num_dual::DualNum;
+use num_traits::One;
+use pure_saft_functional::*;
+use quantity::si::*;
+use std::f64::consts::FRAC_PI_6;
+use std::rc::Rc;
+
+mod association;
+mod dispersion;
+mod hard_chain;
+mod polar;
+mod pure_saft_functional;
+
+/// PC-SAFT Helmholtz energy functional.
+pub struct PcSaftFunctional {
+    pub parameters: Rc<PcSaftParameters>,
+    fmt_version: FMTVersion,
+    options: PcSaftOptions,
+    contributions: Vec<Box<dyn FunctionalContribution>>,
+    joback: Joback,
+}
+
+impl PcSaftFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>) -> DFT<Self> {
+        Self::with_options(parameters, FMTVersion::WhiteBear, PcSaftOptions::default())
+    }
+
+    pub fn new_full(parameters: Rc<PcSaftParameters>, fmt_version: FMTVersion) -> DFT<Self> {
+        Self::with_options(parameters, fmt_version, PcSaftOptions::default())
+    }
+
+    pub fn with_options(
+        parameters: Rc<PcSaftParameters>,
+        fmt_version: FMTVersion,
+        saft_options: PcSaftOptions,
+    ) -> DFT<Self> {
+        let mut contributions: Vec<Box<dyn FunctionalContribution>> = Vec::with_capacity(4);
+
+        if matches!(
+            fmt_version,
+            FMTVersion::WhiteBear | FMTVersion::AntiSymWhiteBear
+        ) && parameters.m.len() == 1
+        {
+            let fmt_assoc = PureFMTAssocFunctional::new(parameters.clone(), fmt_version);
+            contributions.push(Box::new(fmt_assoc));
+            if parameters.m.iter().any(|&mi| mi > 1.0) {
+                let chain = PureChainFunctional::new(parameters.clone());
+                contributions.push(Box::new(chain));
+            }
+            let att = PureAttFunctional::new(parameters.clone());
+            contributions.push(Box::new(att));
+        } else {
+            // Hard sphere contribution
+            let hs = FMTContribution::new(&parameters, fmt_version);
+            contributions.push(Box::new(hs));
+
+            // Hard chains
+            if parameters.m.iter().any(|&mi| !mi.is_one()) {
+                let chain = ChainFunctional::new(parameters.clone());
+                contributions.push(Box::new(chain));
+            }
+
+            // Dispersion
+            let att = AttractiveFunctional::new(parameters.clone());
+            contributions.push(Box::new(att));
+
+            // Association
+            if parameters.nassoc > 0 {
+                let assoc = AssociationFunctional::new(
+                    parameters.clone(),
+                    saft_options.max_iter_cross_assoc,
+                    saft_options.tol_cross_assoc,
+                );
+                contributions.push(Box::new(assoc));
+            }
+        }
+
+        let joback = match &parameters.joback_records {
+            Some(joback_records) => Joback::new(joback_records.clone()),
+            None => Joback::default(parameters.m.len()),
+        };
+
+        (Self {
+            parameters,
+            fmt_version,
+            options: saft_options,
+            contributions,
+            joback,
+        })
+        .into()
+    }
+}
+
+impl HelmholtzEnergyFunctional for PcSaftFunctional {
+    fn subset(&self, component_list: &[usize]) -> DFT<Self> {
+        Self::with_options(
+            Rc::new(self.parameters.subset(component_list)),
+            self.fmt_version,
+            self.options,
+        )
+    }
+
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
+        self.options.max_eta * moles.sum()
+            / (FRAC_PI_6 * &self.parameters.m * self.parameters.sigma.mapv(|v| v.powi(3)) * moles)
+                .sum()
+    }
+
+    fn contributions(&self) -> &[Box<dyn FunctionalContribution>] {
+        &self.contributions
+    }
+
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        &self.joback
+    }
+
+    fn molecule_shape(&self) -> MoleculeShape {
+        MoleculeShape::NonSpherical(&self.parameters.m)
+    }
+}
+
+impl MolarWeight<SIUnit> for PcSaftFunctional {
+    fn molar_weight(&self) -> SIArray1 {
+        self.parameters.molarweight.clone() * GRAM / MOL
+    }
+}
+
+impl FMTProperties for PcSaftParameters {
+    fn component_index(&self) -> Array1<usize> {
+        Array::from_shape_fn(self.m.len(), |i| i)
+    }
+
+    fn monomer_shape<N: DualNum<f64>>(&self, _: N) -> MonomerShape<N> {
+        MonomerShape::NonSpherical(self.m.mapv(N::from))
+    }
+
+    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+        self.hs_diameter(temperature)
+    }
+}
+
+impl FluidParameters for PcSaftFunctional {
+    fn epsilon_k_ff(&self) -> Array1<f64> {
+        self.parameters.epsilon_k.clone()
+    }
+
+    fn sigma_ff(&self) -> &Array1<f64> {
+        &self.parameters.sigma
+    }
+}
+
+impl PairPotential for PcSaftFunctional {
+    fn pair_potential(&self, i: usize, r: &Array1<f64>, _: f64) -> Array2<f64> {
+        unimplemented!()
+    }
+}

--- a/src/pcsaft/dft/polar.rs
+++ b/src/pcsaft/dft/polar.rs
@@ -1,0 +1,369 @@
+use super::PcSaftParameters;
+use crate::pcsaft::eos::polar::{
+    MeanSegmentNumbers, Multipole, AD, ADQ, ALPHA, AQ, BD, BDQ, BQ, CD, CDQ, CQ, PI_SQ_43,
+};
+use feos_core::EosError;
+use ndarray::*;
+use num_dual::DualNum;
+use std::f64::consts::{FRAC_PI_3, PI};
+
+pub(super) fn calculate_helmholtz_energy_density_polar<N: DualNum<f64> + ScalarOperand>(
+    parameters: &PcSaftParameters,
+    temperature: N,
+    density: ArrayView2<N>,
+) -> Result<Array1<N>, EosError> {
+    // temperature dependent segment radius
+    let r = parameters.hs_diameter(temperature) * 0.5;
+
+    // packing fraction
+    let eta = density
+        .outer_iter()
+        .zip((&r * &r * &r * &parameters.m * 4.0 * FRAC_PI_3).into_iter())
+        .fold(
+            Array::zeros(density.raw_dim().remove_axis(Axis(0))),
+            |acc: Array1<N>, (rho, r3m)| acc + &rho * r3m,
+        );
+
+    let mut phi = Array::zeros(eta.raw_dim());
+    if parameters.ndipole > 0 {
+        phi += &phi_polar_dipole(parameters, temperature, density, &eta)?;
+    }
+    if parameters.nquadpole > 0 {
+        phi += &phi_polar_quadrupole(parameters, temperature, density, &eta)?;
+    }
+    if parameters.ndipole > 0 && parameters.nquadpole > 0 {
+        phi += &phi_polar_dipole_quadrupole(parameters, temperature, density, &eta)?;
+    }
+    Ok(phi)
+}
+
+pub fn pair_integral_ij<N: DualNum<f64> + ScalarOperand>(
+    mij1: f64,
+    mij2: f64,
+    eta: &Array1<N>,
+    a: &[[f64; 3]],
+    b: &[[f64; 3]],
+    eps_ij_t: N,
+) -> Array1<N> {
+    let eta2 = eta * eta;
+    let etas = [
+        &Array::ones(eta.raw_dim()),
+        eta,
+        &eta2,
+        &(&eta2 * eta),
+        &(&eta2 * &eta2),
+    ];
+    let mut integral = Array::zeros(eta.raw_dim());
+    for i in 0..a.len() {
+        integral += &(etas[i]
+            * (eps_ij_t * (b[i][0] + mij1 * b[i][1] + mij2 * b[i][2])
+                + a[i][0]
+                + mij1 * a[i][1]
+                + mij2 * a[i][2]));
+    }
+    integral
+}
+
+pub fn triplet_integral_ijk<N: DualNum<f64> + ScalarOperand>(
+    mijk1: f64,
+    mijk2: f64,
+    eta: &Array1<N>,
+    c: &[[f64; 3]],
+) -> Array1<N> {
+    let eta2 = eta * eta;
+    let etas = [&Array::ones(eta.raw_dim()), eta, &eta2, &(&eta2 * eta)];
+    let mut integral = Array::zeros(eta.raw_dim());
+    for i in 0..c.len() {
+        integral += &(etas[i] * (c[i][0] + mijk1 * c[i][1] + mijk2 * c[i][2]));
+    }
+    integral
+}
+
+fn triplet_integral_ijk_dq<N: DualNum<f64> + ScalarOperand>(
+    mijk: f64,
+    eta: &Array1<N>,
+    c: &[[f64; 2]],
+) -> Array1<N> {
+    let etas = [&Array::ones(eta.raw_dim()), eta, &(eta * eta)];
+    let mut integral = Array::zeros(eta.raw_dim());
+    for i in 0..c.len() {
+        integral += &(etas[i] * (c[i][0] + mijk * c[i][1]));
+    }
+    integral
+}
+
+fn phi_polar_dipole<N: DualNum<f64> + ScalarOperand>(
+    p: &PcSaftParameters,
+    temperature: N,
+    density: ArrayView2<N>,
+    eta: &Array1<N>,
+) -> Result<Array1<N>, EosError> {
+    // mean segment number
+    let m = MeanSegmentNumbers::new(p, Multipole::Dipole);
+
+    let t_inv = temperature.inv();
+    let eps_ij_t = p.e_k_ij.mapv(|v| t_inv * v);
+    let sig_ij_3 = p.sigma_ij.mapv(|v| v.powi(3));
+    let mu2_term: Array1<N> = p
+        .dipole_comp
+        .iter()
+        .map(|&i| eps_ij_t[[i, i]] * sig_ij_3[[i, i]] * p.mu2[i])
+        .collect();
+
+    let mut phi2 = Array::zeros(eta.raw_dim());
+    let mut phi3 = Array::zeros(eta.raw_dim());
+    for i in 0..p.ndipole {
+        let di = p.dipole_comp[i];
+        phi2 -= &(&density.index_axis(Axis(0), di)
+            * &density.index_axis(Axis(0), di)
+            * pair_integral_ij(
+                m.mij1[[i, i]],
+                m.mij2[[i, i]],
+                eta,
+                &AD,
+                &BD,
+                eps_ij_t[[di, di]],
+            )
+            * (mu2_term[i] * mu2_term[i] / sig_ij_3[[di, di]]));
+        phi3 -= &(&density.index_axis(Axis(0), di)
+            * &density.index_axis(Axis(0), di)
+            * density.index_axis(Axis(0), di)
+            * triplet_integral_ijk(m.mijk1[[i, i, i]], m.mijk2[[i, i, i]], eta, &CD)
+            * (mu2_term[i] * mu2_term[i] * mu2_term[i] / sig_ij_3[[di, di]]));
+        for j in i + 1..p.ndipole {
+            let dj = p.dipole_comp[j];
+            phi2 -= &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), dj)
+                * pair_integral_ij(
+                    m.mij1[[i, j]],
+                    m.mij2[[i, j]],
+                    eta,
+                    &AD,
+                    &BD,
+                    eps_ij_t[[di, dj]],
+                )
+                * (mu2_term[i] * mu2_term[j] / sig_ij_3[[di, dj]] * 2.0));
+            phi3 -= &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), di)
+                * density.index_axis(Axis(0), dj)
+                * triplet_integral_ijk(m.mijk1[[i, i, j]], m.mijk2[[i, i, j]], eta, &CD)
+                * (mu2_term[i] * mu2_term[i] * mu2_term[j]
+                    / (p.sigma_ij[[di, di]] * p.sigma_ij[[di, dj]] * p.sigma_ij[[di, dj]])
+                    * 3.0));
+            phi3 -= &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), dj)
+                * density.index_axis(Axis(0), dj)
+                * triplet_integral_ijk(m.mijk1[[i, j, j]], m.mijk2[[i, j, j]], eta, &CD)
+                * (mu2_term[i] * mu2_term[j] * mu2_term[j]
+                    / (p.sigma_ij[[di, dj]] * p.sigma_ij[[di, dj]] * p.sigma_ij[[dj, dj]])
+                    * 3.0));
+            for k in j + 1..p.ndipole {
+                let dk = p.dipole_comp[k];
+                phi3 -= &(&density.index_axis(Axis(0), di)
+                    * &density.index_axis(Axis(0), dj)
+                    * density.index_axis(Axis(0), dk)
+                    * triplet_integral_ijk(m.mijk1[[i, j, k]], m.mijk2[[i, j, k]], eta, &CD)
+                    * (mu2_term[i] * mu2_term[j] * mu2_term[k]
+                        / (p.sigma_ij[[di, dj]] * p.sigma_ij[[di, dk]] * p.sigma_ij[[dj, dk]])
+                        * 6.0));
+            }
+        }
+    }
+    phi2 = phi2 * PI;
+    phi3 = phi3 * PI_SQ_43;
+    let mut result = &phi2 * &phi2 / (&phi2 - &phi3);
+    result.iter_mut().zip(phi2.iter()).for_each(|(r, &p2)| {
+        if r.re().is_nan() {
+            *r = p2;
+        }
+    });
+    Ok(result)
+}
+
+fn phi_polar_quadrupole<N: DualNum<f64> + ScalarOperand>(
+    p: &PcSaftParameters,
+    temperature: N,
+    density: ArrayView2<N>,
+    eta: &Array1<N>,
+) -> Result<Array1<N>, EosError> {
+    // mean segment number
+    let m = MeanSegmentNumbers::new(p, Multipole::Quadrupole);
+
+    let t_inv = temperature.inv();
+    let eps_ij_t = p.e_k_ij.mapv(|v| t_inv * v);
+    let sig_ij_3 = p.sigma_ij.mapv(|v| v.powi(3));
+    let q2_term: Array1<N> = p
+        .quadpole_comp
+        .iter()
+        .map(|&i| eps_ij_t[[i, i]] * p.sigma[i].powi(5) * p.q2[i])
+        .collect();
+
+    let mut phi2 = Array::zeros(eta.raw_dim());
+    let mut phi3 = Array::zeros(eta.raw_dim());
+    for i in 0..p.nquadpole {
+        let di = p.quadpole_comp[i];
+        phi2 -= &(&density.index_axis(Axis(0), di)
+            * &density.index_axis(Axis(0), di)
+            * pair_integral_ij(
+                m.mij1[[i, i]],
+                m.mij2[[i, i]],
+                eta,
+                &AQ,
+                &BQ,
+                eps_ij_t[[di, di]],
+            )
+            * (q2_term[i] * q2_term[i] / p.sigma_ij[[di, di]].powi(7)));
+        phi3 += &(&density.index_axis(Axis(0), di)
+            * &density.index_axis(Axis(0), di)
+            * density.index_axis(Axis(0), di)
+            * triplet_integral_ijk(m.mijk1[[i, i, i]], m.mijk2[[i, i, i]], eta, &CQ)
+            * (q2_term[i] * q2_term[i] * q2_term[i] / sig_ij_3[[di, di]].powi(3)));
+        for j in i + 1..p.nquadpole {
+            let dj = p.quadpole_comp[j];
+            phi2 -= &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), dj)
+                * pair_integral_ij(
+                    m.mij1[[i, j]],
+                    m.mij2[[i, j]],
+                    eta,
+                    &AQ,
+                    &BQ,
+                    eps_ij_t[[di, dj]],
+                )
+                * (q2_term[i] * q2_term[j] / p.sigma_ij[[di, dj]].powi(7)));
+            phi3 += &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), di)
+                * density.index_axis(Axis(0), dj)
+                * triplet_integral_ijk(m.mijk1[[i, i, j]], m.mijk2[[i, i, j]], eta, &CQ)
+                * (q2_term[i] * q2_term[i] * q2_term[j]
+                    / (sig_ij_3[[di, di]] * sig_ij_3[[di, dj]] * sig_ij_3[[di, dj]])
+                    * 3.0));
+            phi3 += &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), dj)
+                * density.index_axis(Axis(0), dj)
+                * triplet_integral_ijk(m.mijk1[[i, j, j]], m.mijk2[[i, j, j]], eta, &CQ)
+                * (q2_term[i] * q2_term[j] * q2_term[j]
+                    / (sig_ij_3[[di, dj]] * sig_ij_3[[di, dj]] * sig_ij_3[[dj, dj]])
+                    * 3.0));
+            for k in j + 1..p.nquadpole {
+                let dk = p.quadpole_comp[k];
+                phi3 += &(&density.index_axis(Axis(0), di)
+                    * &density.index_axis(Axis(0), dj)
+                    * density.index_axis(Axis(0), dk)
+                    * triplet_integral_ijk(m.mijk1[[i, j, k]], m.mijk2[[i, j, k]], eta, &CQ)
+                    * (q2_term[i] * q2_term[j] * q2_term[k]
+                        / (sig_ij_3[[di, dj]] * sig_ij_3[[di, dk]] * sig_ij_3[[dj, dk]])
+                        * 6.0));
+            }
+        }
+    }
+    phi2 = phi2 * (PI * 0.5625);
+    phi3 = phi3 * (PI * PI * 0.5625);
+    let mut result = &phi2 * &phi2 / (&phi2 - &phi3);
+    result.iter_mut().zip(phi2.iter()).for_each(|(r, &p2)| {
+        if r.re().is_nan() {
+            *r = p2;
+        }
+    });
+    Ok(result)
+}
+
+fn phi_polar_dipole_quadrupole<N: DualNum<f64> + ScalarOperand>(
+    p: &PcSaftParameters,
+    temperature: N,
+    density: ArrayView2<N>,
+    eta: &Array1<N>,
+) -> Result<Array1<N>, EosError> {
+    let t_inv = temperature.inv();
+    let eps_ij_t = p.e_k_ij.mapv(|v| t_inv * v);
+    let mu2_term: Array1<N> = p
+        .dipole_comp
+        .iter()
+        .map(|&i| eps_ij_t[[i, i]] * p.sigma[i].powi(4) * p.mu2[i])
+        .collect();
+    let q2_term: Array1<N> = p
+        .quadpole_comp
+        .iter()
+        .map(|&i| eps_ij_t[[i, i]] * p.sigma[i].powi(4) * p.q2[i])
+        .collect();
+
+    // mean segment number
+    let mut mdq1 = Array2::zeros((p.ndipole, p.nquadpole));
+    let mut mdq2 = Array2::zeros((p.ndipole, p.nquadpole));
+    let mut mdqd = Array3::zeros((p.ndipole, p.nquadpole, p.ndipole));
+    let mut mdqq = Array3::zeros((p.ndipole, p.nquadpole, p.nquadpole));
+    for i in 0..p.ndipole {
+        let di = p.dipole_comp[i];
+        let mi = p.m[di].min(2.0);
+        for j in 0..p.nquadpole {
+            let qj = p.quadpole_comp[j];
+            let mj = p.m[qj].min(2.0);
+            let m = (mi * mj).sqrt();
+            mdq1[[i, j]] = (m - 1.0) / m;
+            mdq2[[i, j]] = mdq1[[i, j]] * (m - 2.0) / m;
+            for k in 0..p.ndipole {
+                let dk = p.dipole_comp[k];
+                let mk = p.m[dk].min(2.0);
+                let m = (mi * mj * mk).cbrt();
+                mdqd[[i, j, k]] = (m - 1.0) / m;
+            }
+            for k in 0..p.nquadpole {
+                let qk = p.quadpole_comp[k];
+                let mk = p.m[qk].min(2.0);
+                let m = (mi * mj * mk).cbrt();
+                mdqq[[i, j, k]] = (m - 1.0) / m;
+            }
+        }
+    }
+
+    let mut phi2 = Array::zeros(eta.raw_dim());
+    let mut phi3 = Array::zeros(eta.raw_dim());
+    for i in 0..p.ndipole {
+        let di = p.dipole_comp[i];
+        for j in 0..p.nquadpole {
+            let qj = p.quadpole_comp[j];
+            phi2 -= &(&density.index_axis(Axis(0), di)
+                * &density.index_axis(Axis(0), qj)
+                * pair_integral_ij(
+                    mdq1[[i, j]],
+                    mdq2[[i, j]],
+                    eta,
+                    &ADQ,
+                    &BDQ,
+                    eps_ij_t[[di, qj]],
+                )
+                * (mu2_term[i] / p.sigma[di] * q2_term[j] * p.sigma[qj]
+                    / p.sigma_ij[[di, qj]].powi(5)));
+            for k in 0..p.ndipole {
+                let dk = p.dipole_comp[k];
+                phi3 += &(&density.index_axis(Axis(0), di)
+                    * &density.index_axis(Axis(0), qj)
+                    * density.index_axis(Axis(0), dk)
+                    * triplet_integral_ijk_dq(mdqd[[i, j, k]], eta, &CDQ)
+                    * (mu2_term[i] * q2_term[j] * mu2_term[k]
+                        / (p.sigma_ij[[di, qj]] * p.sigma_ij[[di, dk]] * p.sigma_ij[[qj, dk]])
+                            .powi(2)));
+            }
+            for k in 0..p.nquadpole {
+                let qk = p.quadpole_comp[k];
+                phi3 += &(&density.index_axis(Axis(0), di)
+                    * &density.index_axis(Axis(0), qj)
+                    * density.index_axis(Axis(0), qk)
+                    * triplet_integral_ijk_dq(mdqq[[i, j, k]], eta, &CDQ)
+                    * (mu2_term[i] * q2_term[j] * q2_term[k]
+                        / (p.sigma_ij[[di, qj]] * p.sigma_ij[[di, qk]] * p.sigma_ij[[qj, qk]])
+                            .powi(2)
+                        * ALPHA));
+            }
+        }
+    }
+    phi2 = phi2 * (PI * 2.25);
+    phi3 = phi3 * (PI * PI);
+    let mut result = &phi2 * &phi2 / (&phi2 - &phi3);
+    result.iter_mut().zip(phi2.iter()).for_each(|(r, &p2)| {
+        if r.re().is_nan() {
+            *r = p2;
+        }
+    });
+    Ok(result)
+}

--- a/src/pcsaft/dft/pure_saft_functional.rs
+++ b/src/pcsaft/dft/pure_saft_functional.rs
@@ -1,0 +1,322 @@
+use super::association::N0_CUTOFF;
+use super::polar::{pair_integral_ij, triplet_integral_ijk};
+use super::PcSaftParameters;
+use crate::pcsaft::eos::association::{assoc_site_frac_a, assoc_site_frac_ab};
+use crate::pcsaft::eos::dispersion::{A0, A1, A2, B0, B1, B2};
+use crate::pcsaft::eos::polar::{AD, AQ, BD, BQ, CD, CQ, PI_SQ_43};
+use feos_core::{EosError, EosResult};
+use feos_dft::fundamental_measure_theory::FMTVersion;
+use feos_dft::{
+    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+};
+use ndarray::*;
+use num_dual::*;
+use std::f64::consts::{FRAC_PI_6, PI};
+use std::fmt;
+use std::rc::Rc;
+
+const PI36M1: f64 = 1.0 / (36.0 * PI);
+const N3_CUTOFF: f64 = 1e-5;
+
+#[derive(Clone)]
+pub struct PureFMTAssocFunctional {
+    parameters: Rc<PcSaftParameters>,
+    version: FMTVersion,
+}
+
+impl PureFMTAssocFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>, version: FMTVersion) -> Self {
+        Self {
+            parameters,
+            version,
+        }
+    }
+}
+
+impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureFMTAssocFunctional {
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let r = self.parameters.hs_diameter(temperature) * 0.5;
+        WeightFunctionInfo::new(arr1(&[0]), false).extend(
+            vec![
+                WeightFunctionShape::Delta,
+                WeightFunctionShape::Theta,
+                WeightFunctionShape::DeltaVec,
+            ]
+            .into_iter()
+            .map(|s| WeightFunction {
+                prefactor: self.parameters.m.mapv(|m| m.into()),
+                kernel_radius: r.clone(),
+                shape: s,
+            })
+            .collect(),
+            false,
+        )
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> EosResult<Array1<N>> {
+        let p = &self.parameters;
+
+        // weighted densities
+        let n2 = weighted_densities.index_axis(Axis(0), 0);
+        let n3 = weighted_densities.index_axis(Axis(0), 1);
+        let n2v = weighted_densities.slice_axis(Axis(0), Slice::new(2, None, 1));
+
+        // temperature dependent segment radius
+        let r = self.parameters.hs_diameter(temperature)[0] * 0.5;
+
+        // auxiliary variables
+        if n3.iter().any(|n3| n3.re() > 1.0) {
+            return Err(EosError::IterationFailed(String::from(
+                "PureFMTAssocFunctional",
+            )));
+        }
+        let ln31 = n3.mapv(|n3| (-n3).ln_1p());
+        let n3rec = n3.mapv(|n3| n3.recip());
+        let n3m1 = n3.mapv(|n3| -n3 + 1.0);
+        let n3m1rec = n3m1.mapv(|n3m1| n3m1.recip());
+        let n1 = n2.mapv(|n2| n2 / (r * 4.0 * PI));
+        let n0 = n2.mapv(|n2| n2 / (r * r * 4.0 * PI));
+        let n1v = n2v.mapv(|n2v| n2v / (r * 4.0 * PI));
+
+        let (n1n2, n2n2) = match self.version {
+            FMTVersion::WhiteBear => (
+                &n1 * &n2 - (&n1v * &n2v).sum_axis(Axis(0)),
+                &n2 * &n2 - (&n2v * &n2v).sum_axis(Axis(0)) * 3.0,
+            ),
+            FMTVersion::AntiSymWhiteBear => {
+                let mut xi2 = (&n2v * &n2v).sum_axis(Axis(0)) / n2.map(|n| n.powi(2));
+                xi2.iter_mut().for_each(|x| {
+                    if x.re() > 1.0 {
+                        *x = N::one()
+                    }
+                });
+                (
+                    &n1 * &n2 - (&n1v * &n2v).sum_axis(Axis(0)),
+                    &n2 * &n2 * xi2.mapv(|x| (-x + 1.0).powi(3)),
+                )
+            }
+            _ => unreachable!(),
+        };
+
+        // The f3 term contains a 0/0, therefore a taylor expansion is used for small values of n3
+        let mut f3 = (&n3m1 * &n3m1 * &ln31 + n3) * &n3rec * n3rec * &n3m1rec * &n3m1rec;
+        f3.iter_mut().zip(n3).for_each(|(f3, &n3)| {
+            if n3.re() < N3_CUTOFF {
+                *f3 = (((n3 * 35.0 / 6.0 + 4.8) * n3 + 3.75) * n3 + 8.0 / 3.0) * n3 + 1.5;
+            }
+        });
+        let mut phi = -(&n0 * &ln31) + n1n2 * &n3m1rec + n2n2 * n2 * PI36M1 * f3;
+
+        // association
+        if p.nassoc == 1 {
+            let mut xi = -(&n2v * &n2v).sum_axis(Axis(0)) / (&n2 * &n2) + 1.0;
+            xi.iter_mut().zip(&n2).for_each(|(xi, &n2)| {
+                if n2.re() < N0_CUTOFF * 4.0 * PI * p.m[0] * r.re().powi(2) {
+                    *xi = N::one();
+                }
+            });
+
+            let k = &n2 * &n3m1rec * r;
+            let deltarho = (((&k / 18.0 + 0.5) * &k * &xi + 1.0) * n3m1rec)
+                * ((temperature.recip() * p.epsilon_k_aibj[(0, 0)]).exp_m1()
+                    * (p.sigma[0].powi(3) * p.kappa_aibj[(0, 0)]))
+                * (&n0 / p.m[0] * &xi);
+
+            let f = |x: N| x.ln() - x * 0.5 + 0.5;
+            phi = phi
+                + if p.nb[0] > 0.0 {
+                    let xa = deltarho.mapv(|d| assoc_site_frac_ab(d, p.na[0], p.nb[0]));
+                    let xb = (xa.clone() - 1.0) * p.na[0] / p.nb[0] + 1.0;
+                    (n0 / p.m[0] * xi) * (xa.mapv(f) * p.na[0] + xb.mapv(f) * p.nb[0])
+                } else {
+                    let xa = deltarho.mapv(|d| assoc_site_frac_a(d, p.na[0]));
+                    n0 / p.m[0] * xi * (xa.mapv(f) * p.na[0])
+                };
+        }
+
+        Ok(phi)
+    }
+}
+
+impl fmt::Display for PureFMTAssocFunctional {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Pure FMT+association")
+    }
+}
+
+#[derive(Clone)]
+pub struct PureChainFunctional {
+    parameters: Rc<PcSaftParameters>,
+}
+
+impl PureChainFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>) -> Self {
+        Self { parameters }
+    }
+}
+
+impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureChainFunctional {
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let d = self.parameters.hs_diameter(temperature);
+        WeightFunctionInfo::new(arr1(&[0]), true)
+            .add(
+                WeightFunction::new_scaled(d.clone(), WeightFunctionShape::Delta),
+                false,
+            )
+            .add(
+                WeightFunction {
+                    prefactor: (&self.parameters.m / 8.0).mapv(|x| x.into()),
+                    kernel_radius: d,
+                    shape: WeightFunctionShape::Theta,
+                },
+                false,
+            )
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        _: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> EosResult<Array1<N>> {
+        let rho = weighted_densities.index_axis(Axis(0), 0);
+        // negative lambdas lead to nan, therefore the absolute value is used
+        let lambda = weighted_densities
+            .index_axis(Axis(0), 1)
+            .map(|&l| if l.re() < 0.0 { -l } else { l } + N::from(f64::EPSILON));
+        let eta = weighted_densities.index_axis(Axis(0), 2);
+
+        let y = eta.mapv(|eta| (eta * 0.5 - 1.0) / (eta - 1.0).powi(3));
+        Ok(-(y * lambda).mapv(|x| (x.ln() - 1.0) * (self.parameters.m[0] - 1.0)) * rho)
+    }
+}
+
+impl fmt::Display for PureChainFunctional {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Pure chain")
+    }
+}
+
+#[derive(Clone)]
+pub struct PureAttFunctional {
+    parameters: Rc<PcSaftParameters>,
+}
+
+impl PureAttFunctional {
+    pub fn new(parameters: Rc<PcSaftParameters>) -> Self {
+        Self { parameters }
+    }
+}
+
+impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureAttFunctional {
+    fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let d = self.parameters.hs_diameter(temperature);
+        const PSI: f64 = 1.3862; // Homosegmented DFT (Sauer2017)
+        WeightFunctionInfo::new(arr1(&[0]), false).add(
+            WeightFunction::new_scaled(d * PSI, WeightFunctionShape::Theta),
+            false,
+        )
+    }
+
+    fn weight_functions_pdgt(&self, temperature: N) -> WeightFunctionInfo<N> {
+        let d = self.parameters.hs_diameter(temperature);
+        const PSI: f64 = 1.3286; // pDGT (Rehner2018)
+        WeightFunctionInfo::new(arr1(&[0]), false).add(
+            WeightFunction::new_scaled(d * PSI, WeightFunctionShape::Theta),
+            false,
+        )
+    }
+
+    fn calculate_helmholtz_energy_density(
+        &self,
+        temperature: N,
+        weighted_densities: ArrayView2<N>,
+    ) -> EosResult<Array1<N>> {
+        let p = &self.parameters;
+        let rho = weighted_densities.index_axis(Axis(0), 0);
+
+        // temperature dependent segment radius
+        let d = p.hs_diameter(temperature)[0];
+
+        let eta = rho.mapv(|rho| rho * FRAC_PI_6 * p.m[0] * d.powi(3));
+        let m1 = (p.m[0] - 1.0) / p.m[0];
+        let m2 = m1 * (p.m[0] - 2.0) / p.m[0];
+        let e = temperature.recip() * p.epsilon_k[0];
+        let s3 = p.sigma[0].powi(3);
+
+        // I1, I2 and C1
+        let mut i1: Array1<N> = Array::zeros(eta.raw_dim());
+        let mut i2: Array1<N> = Array::zeros(eta.raw_dim());
+        for i in 0..=6 {
+            i1 = i1 + eta.mapv(|eta| eta.powi(i as i32) * (A0[i] + m1 * A1[i] + m2 * A2[i]));
+            i2 = i2 + eta.mapv(|eta| eta.powi(i as i32) * (B0[i] + m1 * B1[i] + m2 * B2[i]));
+        }
+        let c1 = eta.mapv(|eta| {
+            ((eta * 8.0 - eta.powi(2) * 2.0) / (eta - 1.0).powi(4) * p.m[0]
+                + (eta * 20.0 - eta.powi(2) * 27.0 + eta.powi(3) * 12.0 - eta.powi(4) * 2.0)
+                    / ((eta - 1.0) * (eta - 2.0)).powi(2)
+                    * (1.0 - p.m[0])
+                + 1.0)
+                .recip()
+        });
+        let mut phi = rho.mapv(|rho| -(rho * p.m[0]).powi(2) * e * s3 * PI)
+            * (i1 * 2.0 + c1 * i2.mapv(|i2| i2 * p.m[0] * e));
+
+        // dipoles
+        if p.ndipole > 0 {
+            let mu2_term = e * s3 * p.mu2[0];
+            let m = p.m[0].min(2.0);
+            let m1 = (m - 1.0) / m;
+            let m2 = m1 * (m - 2.0) / m;
+
+            let phi2 = -(&rho * &rho)
+                * pair_integral_ij(m1, m2, &eta, &AD, &BD, e)
+                * (mu2_term * mu2_term / s3 * PI);
+            let phi3 = -(&rho * &rho * rho)
+                * triplet_integral_ijk(m1, m2, &eta, &CD)
+                * (mu2_term * mu2_term * mu2_term / s3 * PI_SQ_43);
+
+            let mut phi_d = &phi2 * &phi2 / (&phi2 - &phi3);
+            phi_d.iter_mut().zip(phi2.iter()).for_each(|(p, &p2)| {
+                if p.re().is_nan() {
+                    *p = p2;
+                }
+            });
+            phi += &phi_d;
+        }
+
+        // quadrupoles
+        if p.nquadpole > 0 {
+            let q2_term = e * p.sigma[0].powi(5) * p.q2[0];
+            let m = p.m[0].min(2.0);
+            let m1 = (m - 1.0) / m;
+            let m2 = m1 * (m - 2.0) / m;
+
+            let phi2 = -(&rho * &rho)
+                * pair_integral_ij(m1, m2, &eta, &AQ, &BQ, e)
+                * (q2_term * q2_term / p.sigma[0].powi(7) * PI * 0.5625);
+            let phi3 = (&rho * &rho * rho)
+                * triplet_integral_ijk(m1, m2, &eta, &CQ)
+                * (q2_term * q2_term * q2_term / s3.powi(3) * PI * PI * 0.5625);
+
+            let mut phi_q = &phi2 * &phi2 / (&phi2 - &phi3);
+            phi_q.iter_mut().zip(phi2.iter()).for_each(|(p, &p2)| {
+                if p.re().is_nan() {
+                    *p = p2;
+                }
+            });
+            phi += &phi_q;
+        }
+
+        Ok(phi)
+    }
+}
+
+impl fmt::Display for PureAttFunctional {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Pure attractive")
+    }
+}

--- a/src/pcsaft/eos/association.rs
+++ b/src/pcsaft/eos/association.rs
@@ -1,0 +1,294 @@
+use super::PcSaftParameters;
+use feos_core::{EosError, HelmholtzEnergyDual, StateHD};
+use ndarray::*;
+use num_dual::linalg::{norm, LU};
+use num_dual::*;
+use std::f64::consts::{FRAC_PI_3, PI};
+use std::fmt;
+use std::rc::Rc;
+
+pub struct Association {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+pub struct CrossAssociation {
+    pub parameters: Rc<PcSaftParameters>,
+    pub max_iter: usize,
+    pub tol: f64,
+}
+
+fn association_strength<D: DualNum<f64>>(
+    p: &PcSaftParameters,
+    temperature: D,
+    r: &Array1<D>,
+    n2: D,
+    n3i: D,
+    xi: D,
+    ai: usize,
+    aj: usize,
+) -> D {
+    let k = r[ai] * r[aj] / (r[ai] + r[aj]) * (n2 * n3i * 2.0);
+    n3i * (k * xi * (k / 18.0 + 0.5) + 1.0)
+        * (0.5 * (p.sigma[ai] + p.sigma[aj])).powi(3)
+        * p.kappa_aibj[(ai, aj)]
+        * (temperature.recip() * p.epsilon_k_aibj[(ai, aj)]).exp_m1()
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Association {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let p = &self.parameters;
+        let a = p.assoc_comp[0];
+
+        // temperature dependent segment radius
+        let r = p.hs_diameter(state.temperature) * 0.5;
+
+        // auxiliary variables
+        let n2 = (&state.partial_density * &p.m * &r * &r).sum() * 4.0 * PI;
+        let n3 = (&state.partial_density * &p.m * &r * &r * &r).sum() * 4.0 * FRAC_PI_3;
+        let n3i = (-n3 + 1.0).recip();
+
+        // association strength
+        let deltarho = association_strength(p, state.temperature, &r, n2, n3i, D::one(), a, a)
+            * state.partial_density[a];
+
+        let na = p.na[a];
+        let nb = p.nb[a];
+        if nb > 0.0 {
+            // no cross association, two association sites
+            let xa = assoc_site_frac_ab(deltarho, na, nb);
+            let xb = (xa - 1.0) * (na / nb) + 1.0;
+
+            state.moles[a] * ((xa.ln() - xa * 0.5 + 0.5) * na + (xb.ln() - xb * 0.5 + 0.5) * nb)
+        } else {
+            // no cross association, one association site
+            let xa = assoc_site_frac_a(deltarho, na);
+
+            state.moles[a] * (xa.ln() - xa * 0.5 + 0.5) * na
+        }
+    }
+}
+
+impl fmt::Display for Association {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Association")
+    }
+}
+
+pub(crate) fn assoc_site_frac_ab<D: DualNum<f64>>(deltarho: D, na: f64, nb: f64) -> D {
+    if deltarho.re() > f64::EPSILON.sqrt() {
+        (((deltarho * (na - nb) + 1.0).powi(2) + deltarho * nb * 4.0).sqrt()
+            - (deltarho * (nb - na) + 1.0))
+            / (deltarho * na * 2.0)
+    } else {
+        D::one() + deltarho * nb * (deltarho * (nb + na) - 1.0)
+    }
+}
+
+pub(crate) fn assoc_site_frac_a<D: DualNum<f64>>(deltarho: D, na: f64) -> D {
+    if deltarho.re() > f64::EPSILON.sqrt() {
+        ((deltarho * na * 4.0 + 1.0).powi(2) - 1.0).sqrt() / (deltarho * na * 2.0)
+    } else {
+        D::one() + deltarho * na * (deltarho * na * 2.0 - 1.0)
+    }
+}
+
+impl<D: DualNum<f64> + ScalarOperand> HelmholtzEnergyDual<D> for CrossAssociation {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let p = &self.parameters;
+
+        // temperature dependent segment radius
+        let r = p.hs_diameter(state.temperature) * 0.5;
+
+        // auxiliary variables
+        let n2 = (&state.partial_density * &p.m * &r * &r).sum() * 4.0 * PI;
+        let n3 = (&state.partial_density * &p.m * &r * &r * &r).sum() * 4.0 * FRAC_PI_3;
+        let n3i = (-n3 + 1.0).recip();
+
+        // Helmholtz energy
+        helmholtz_energy_density_cross_association(
+            p,
+            state.temperature,
+            &state.partial_density,
+            &r,
+            n2,
+            n3i,
+            D::one(),
+            self.max_iter,
+            self.tol,
+            None,
+        )
+        .unwrap()
+            * state.volume
+    }
+}
+
+impl fmt::Display for CrossAssociation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cross-association")
+    }
+}
+
+pub fn helmholtz_energy_density_cross_association<S, D: DualNum<f64> + ScalarOperand>(
+    p: &PcSaftParameters,
+    temperature: D,
+    density: &ArrayBase<S, Ix1>,
+    r: &Array1<D>,
+    n2: D,
+    n3i: D,
+    xi: D,
+    max_iter: usize,
+    tol: f64,
+    x0: Option<&mut Array1<f64>>,
+) -> Result<D, EosError>
+where
+    S: Data<Elem = D>,
+{
+    // check if density is close to 0
+    if density.sum().re() < f64::EPSILON {
+        if let Some(x0) = x0 {
+            x0.fill(1.0);
+        }
+        return Ok(D::zero());
+    }
+
+    // association strength
+    let delta = Array::from_shape_fn((p.nassoc, p.nassoc), |(i, j)| {
+        association_strength(
+            p,
+            temperature,
+            r,
+            n2,
+            n3i,
+            xi,
+            p.assoc_comp[i],
+            p.assoc_comp[j],
+        )
+    });
+
+    // extract parameters of associating components
+    let na = Array::from_shape_fn(p.nassoc, |i| p.na[p.assoc_comp[i]]);
+    let nb = Array::from_shape_fn(p.nassoc, |i| p.nb[p.assoc_comp[i]]);
+    let rho = Array::from_shape_fn(p.nassoc, |i| density[p.assoc_comp[i]]);
+
+    // cross-association according to Michelsen2006
+    // initialize monomer fraction
+    let mut x = match &x0 {
+        Some(x0) => (*x0).clone(),
+        None => Array::from_elem(2 * p.nassoc, 0.2),
+    };
+
+    for k in 0..max_iter {
+        if newton_step_cross_association::<f64>(
+            &mut x,
+            p,
+            &delta.map(D::re),
+            &na,
+            &nb,
+            &rho.map(D::re),
+            tol,
+        )? {
+            break;
+        }
+        if k == max_iter - 1 {
+            return Err(EosError::NotConverged("Cross association".into()));
+        }
+    }
+
+    // calculate derivatives
+    let mut x_dual = x.mapv(D::from);
+    for _ in 0..D::NDERIV {
+        newton_step_cross_association(&mut x_dual, p, &delta, &na, &nb, &rho, tol)?;
+    }
+
+    // save monomer fraction
+    if let Some(x0) = x0 {
+        *x0 = x;
+    }
+
+    // Helmholtz energy density
+    let xa = x_dual.slice(s![..p.nassoc]);
+    let xb = x_dual.slice(s![p.nassoc..]);
+    let f = |x: D| x.ln() - x * 0.5 + 0.5;
+    Ok((rho * (xa.mapv(f) * na + xb.mapv(f) * nb)).sum())
+}
+
+fn newton_step_cross_association<D: DualNum<f64> + ScalarOperand>(
+    x: &mut Array1<D>,
+    p: &PcSaftParameters,
+    delta: &Array2<D>,
+    na: &Array1<f64>,
+    nb: &Array1<f64>,
+    rho: &Array1<D>,
+    tol: f64,
+) -> Result<bool, EosError> {
+    // gradient
+    let mut g: Array1<D> = Array::zeros(2 * p.nassoc);
+    // Hessian
+    let mut h: Array2<D> = Array::zeros((2 * p.nassoc, 2 * p.nassoc));
+
+    // slice arrays
+    let (xa, xb) = x.multi_slice_mut((s![..p.nassoc], s![p.nassoc..]));
+    let (mut ga, mut gb) = g.multi_slice_mut((s![..p.nassoc], s![p.nassoc..]));
+    let (mut haa, mut hab, mut hba, mut hbb) = h.multi_slice_mut((
+        s![..p.nassoc, ..p.nassoc],
+        s![..p.nassoc, p.nassoc..],
+        s![p.nassoc.., ..p.nassoc],
+        s![p.nassoc.., p.nassoc..],
+    ));
+
+    // calculate gradients and approximate Hessian
+    for i in 0..p.nassoc {
+        let d = &delta.index_axis(Axis(0), i) * rho;
+
+        let dnx = (&xb * nb * &d).sum() + 1.0;
+        ga[i] = xa[i].recip() - dnx;
+        hab.index_axis_mut(Axis(0), i).assign(&(&d * &(-nb)));
+        haa[(i, i)] = -dnx / xa[i];
+
+        let dnx = (&xa * na * &d).sum() + 1.0;
+        gb[i] = xb[i].recip() - dnx;
+        hba.index_axis_mut(Axis(0), i).assign(&(&d * &(-na)));
+        hbb[(i, i)] = -dnx / xb[i];
+    }
+
+    // Newton step
+    x.assign(&(&*x - &LU::new(h)?.solve(&g)));
+
+    // check convergence
+    Ok(norm(&g.map(D::re)) < tol)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcsaft::parameters::utils::water_parameters;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn helmholtz_energy() {
+        let assoc = Association {
+            parameters: Rc::new(water_parameters()),
+        };
+        let t = 350.0;
+        let v = 41.248289328513216;
+        let n = 1.23;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a_rust = assoc.helmholtz_energy(&s) / n;
+        assert_relative_eq!(a_rust, -4.229878997054543, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn helmholtz_energy_cross() {
+        let assoc = CrossAssociation {
+            parameters: Rc::new(water_parameters()),
+            max_iter: 50,
+            tol: 1e-10,
+        };
+        let t = 350.0;
+        let v = 41.248289328513216;
+        let n = 1.23;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a_rust = assoc.helmholtz_energy(&s) / n;
+        assert_relative_eq!(a_rust, -4.229878997054543, epsilon = 1e-10);
+    }
+}

--- a/src/pcsaft/eos/dispersion.rs
+++ b/src/pcsaft/eos/dispersion.rs
@@ -1,0 +1,168 @@
+use super::PcSaftParameters;
+use feos_core::{HelmholtzEnergyDual, StateHD};
+use num_dual::DualNum;
+use std::f64::consts::{FRAC_PI_3, PI};
+use std::fmt;
+use std::rc::Rc;
+
+pub const A0: [f64; 7] = [
+    0.91056314451539,
+    0.63612814494991,
+    2.68613478913903,
+    -26.5473624914884,
+    97.7592087835073,
+    -159.591540865600,
+    91.2977740839123,
+];
+pub const A1: [f64; 7] = [
+    -0.30840169182720,
+    0.18605311591713,
+    -2.50300472586548,
+    21.4197936296668,
+    -65.2558853303492,
+    83.3186804808856,
+    -33.7469229297323,
+];
+pub const A2: [f64; 7] = [
+    -0.09061483509767,
+    0.45278428063920,
+    0.59627007280101,
+    -1.72418291311787,
+    -4.13021125311661,
+    13.7766318697211,
+    -8.67284703679646,
+];
+pub const B0: [f64; 7] = [
+    0.72409469413165,
+    2.23827918609380,
+    -4.00258494846342,
+    -21.00357681484648,
+    26.8556413626615,
+    206.5513384066188,
+    -355.60235612207947,
+];
+pub const B1: [f64; 7] = [
+    -0.57554980753450,
+    0.69950955214436,
+    3.89256733895307,
+    -17.21547164777212,
+    192.6722644652495,
+    -161.8264616487648,
+    -165.2076934555607,
+];
+pub const B2: [f64; 7] = [
+    0.09768831158356,
+    -0.25575749816100,
+    -9.15585615297321,
+    20.64207597439724,
+    -38.80443005206285,
+    93.6267740770146,
+    -29.66690558514725,
+];
+
+pub struct Dispersion {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dispersion {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        // auxiliary variables
+        let n = self.parameters.m.len();
+        let p = &self.parameters;
+        let rho = &state.partial_density;
+
+        // temperature dependent segment radius
+        let r = p.hs_diameter(state.temperature) * 0.5;
+
+        // packing fraction
+        let eta = (rho * &p.m * &r * &r * &r).sum() * 4.0 * FRAC_PI_3;
+
+        // mean segment number
+        let m = (&state.molefracs * &p.m).sum();
+
+        // mixture densities, crosswise interactions of all segments on all chains
+        let mut rho1mix = D::zero();
+        let mut rho2mix = D::zero();
+        for i in 0..n {
+            for j in 0..n {
+                let eps_ij = state.temperature.recip() * p.epsilon_k_ij[(i, j)];
+                let sigma_ij = p.sigma_ij[[i, j]].powi(3);
+                rho1mix += rho[i] * rho[j] * p.m[i] * p.m[j] * eps_ij * sigma_ij;
+                rho2mix += rho[i] * rho[j] * p.m[i] * p.m[j] * eps_ij * eps_ij * sigma_ij;
+            }
+        }
+
+        // I1, I2 and C1
+        let mut i1 = D::zero();
+        let mut i2 = D::zero();
+        let mut eta_i = D::one();
+        for i in 0..=6 {
+            i1 += ((m - 1.0) / m * ((m - 2.0) / m * A2[i] + A1[i]) + A0[i]) * eta_i;
+            i2 += ((m - 1.0) / m * ((m - 2.0) / m * B2[i] + B1[i]) + B0[i]) * eta_i;
+            eta_i *= eta;
+        }
+        let c1 = (m * (eta * 8.0 - eta.powi(2) * 2.0) / (eta - 1.0).powi(4)
+            + (D::one() - m)
+                * (eta * 20.0 - eta.powi(2) * 27.0 + eta.powi(3) * 12.0 - eta.powi(4) * 2.0)
+                / ((eta - 1.0) * (eta - 2.0)).powi(2)
+            + 1.0)
+            .recip();
+
+        // Helmholtz energy
+        (-rho1mix * i1 * 2.0 - rho2mix * m * c1 * i2) * PI * state.volume
+    }
+}
+
+impl fmt::Display for Dispersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Dispersion")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcsaft::parameters::utils::{
+        butane_parameters, propane_butane_parameters, propane_parameters,
+    };
+    use approx::assert_relative_eq;
+    use ndarray::arr1;
+
+    #[test]
+    fn helmholtz_energy() {
+        let disp = Dispersion {
+            parameters: propane_parameters(),
+        };
+        let t = 250.0;
+        let v = 1000.0;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a_rust = disp.helmholtz_energy(&s);
+        assert_relative_eq!(a_rust, -1.0622531100351962, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn mix() {
+        let c1 = Dispersion {
+            parameters: propane_parameters(),
+        };
+        let c2 = Dispersion {
+            parameters: butane_parameters(),
+        };
+        let c12 = Dispersion {
+            parameters: propane_butane_parameters(),
+        };
+        let t = 250.0;
+        let v = 2.5e28;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a1 = c1.helmholtz_energy(&s);
+        let a2 = c2.helmholtz_energy(&s);
+        let s1m = StateHD::new(t, v, arr1(&[n, 0.0]));
+        let a1m = c12.helmholtz_energy(&s1m);
+        let s2m = StateHD::new(t, v, arr1(&[0.0, n]));
+        let a2m = c12.helmholtz_energy(&s2m);
+        assert_relative_eq!(a1, a1m, epsilon = 1e-14);
+        assert_relative_eq!(a2, a2m, epsilon = 1e-14);
+    }
+}

--- a/src/pcsaft/eos/hard_chain.rs
+++ b/src/pcsaft/eos/hard_chain.rs
@@ -1,0 +1,81 @@
+use super::hard_sphere::zeta;
+use super::PcSaftParameters;
+use feos_core::{HelmholtzEnergyDual, StateHD};
+use ndarray::Array;
+use num_dual::*;
+use std::fmt;
+use std::rc::Rc;
+
+pub struct HardChain {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardChain {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let d = self.parameters.hs_diameter(state.temperature);
+        let zeta = zeta(&self.parameters.m, &state.partial_density, &d);
+        let frac_1mz3 = -(zeta[3] - 1.0).recip();
+        let c = zeta[2] * frac_1mz3 * frac_1mz3;
+        let g_hs =
+            d.mapv(|d| frac_1mz3 + d * c * 1.5 - d.powi(2) * c.powi(2) * (zeta[3] - 1.0) * 0.5);
+        Array::from_shape_fn(self.parameters.m.len(), |i| {
+            state.partial_density[i] * (1.0 - self.parameters.m[i]) * g_hs[i].ln()
+        })
+        .sum()
+            * state.volume
+    }
+}
+
+impl fmt::Display for HardChain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Hard Chain")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcsaft::parameters::utils::{
+        butane_parameters, propane_butane_parameters, propane_parameters,
+    };
+    use approx::assert_relative_eq;
+    use ndarray::arr1;
+
+    #[test]
+    fn helmholtz_energy() {
+        let hc = HardChain {
+            parameters: propane_parameters(),
+        };
+        let t = 250.0;
+        let v = 1000.0;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a_rust = hc.helmholtz_energy(&s);
+        assert_relative_eq!(a_rust, -0.12402626171926148, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn mix() {
+        let c1 = HardChain {
+            parameters: propane_parameters(),
+        };
+        let c2 = HardChain {
+            parameters: butane_parameters(),
+        };
+        let c12 = HardChain {
+            parameters: propane_butane_parameters(),
+        };
+        let t = 250.0;
+        let v = 2.5e28;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a1 = c1.helmholtz_energy(&s);
+        let a2 = c2.helmholtz_energy(&s);
+        let s1m = StateHD::new(t, v, arr1(&[n, 0.0]));
+        let a1m = c12.helmholtz_energy(&s1m);
+        let s2m = StateHD::new(t, v, arr1(&[0.0, n]));
+        let a2m = c12.helmholtz_energy(&s2m);
+        assert_relative_eq!(a1, a1m, epsilon = 1e-14);
+        assert_relative_eq!(a2, a2m, epsilon = 1e-14);
+    }
+}

--- a/src/pcsaft/eos/hard_sphere.rs
+++ b/src/pcsaft/eos/hard_sphere.rs
@@ -1,0 +1,112 @@
+use super::PcSaftParameters;
+use feos_core::{HelmholtzEnergyDual, StateHD};
+use ndarray::*;
+use num_dual::DualNum;
+use std::fmt;
+use std::rc::Rc;
+
+impl PcSaftParameters {
+    pub fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+        let ti = temperature.recip() * -3.0;
+        Array::from_shape_fn(self.sigma.len(), |i| {
+            -((ti * self.epsilon_k[i]).exp() * 0.12 - 1.0) * self.sigma[i]
+        })
+    }
+}
+
+pub struct HardSphere {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardSphere {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let d = self.parameters.hs_diameter(state.temperature);
+        let zeta = zeta(&self.parameters.m, &state.partial_density, &d);
+        let frac_1mz3 = -(zeta[3] - 1.0).recip();
+        let zeta_23 = zeta_23(&self.parameters.m, &state.molefracs, &d);
+        state.volume * 6.0 / std::f64::consts::PI
+            * (zeta[1] * zeta[2] * frac_1mz3 * 3.0
+                + zeta[2].powi(2) * frac_1mz3.powi(2) * zeta_23
+                + (zeta[2] * zeta_23.powi(2) - zeta[0]) * (zeta[3] * (-1.0)).ln_1p())
+    }
+}
+
+impl fmt::Display for HardSphere {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Hard Sphere")
+    }
+}
+
+pub fn zeta<D: DualNum<f64>>(
+    m: &Array1<f64>,
+    partial_density: &Array1<D>,
+    diameter: &Array1<D>,
+) -> [D; 4] {
+    let mut zeta: [D; 4] = [D::zero(), D::zero(), D::zero(), D::zero()];
+    for i in 0..m.len() {
+        for (k, z) in zeta.iter_mut().enumerate() {
+            *z += partial_density[i]
+                * diameter[i].powi(k as i32)
+                * (std::f64::consts::PI / 6.0 * m[i]);
+        }
+    }
+    zeta
+}
+
+pub fn zeta_23<D: DualNum<f64>>(m: &Array1<f64>, molefracs: &Array1<D>, diameter: &Array1<D>) -> D {
+    let mut zeta: [D; 2] = [D::zero(), D::zero()];
+    for i in 0..m.len() {
+        for (k, z) in zeta.iter_mut().enumerate() {
+            *z += molefracs[i] * diameter[i].powi((k + 2) as i32) * m[i];
+        }
+    }
+    zeta[0] / zeta[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcsaft::parameters::utils::{
+        butane_parameters, propane_butane_parameters, propane_parameters,
+    };
+    use approx::assert_relative_eq;
+    use ndarray::arr1;
+
+    #[test]
+    fn helmholtz_energy() {
+        let hs = HardSphere {
+            parameters: propane_parameters(),
+        };
+        let t = 250.0;
+        let v = 1000.0;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a_rust = hs.helmholtz_energy(&s);
+        assert_relative_eq!(a_rust, 0.410610492598808, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn mix() {
+        let c1 = HardSphere {
+            parameters: propane_parameters(),
+        };
+        let c2 = HardSphere {
+            parameters: butane_parameters(),
+        };
+        let c12 = HardSphere {
+            parameters: propane_butane_parameters(),
+        };
+        let t = 250.0;
+        let v = 2.5e28;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a1 = c1.helmholtz_energy(&s);
+        let a2 = c2.helmholtz_energy(&s);
+        let s1m = StateHD::new(t, v, arr1(&[n, 0.0]));
+        let a1m = c12.helmholtz_energy(&s1m);
+        let s2m = StateHD::new(t, v, arr1(&[0.0, n]));
+        let a2m = c12.helmholtz_energy(&s2m);
+        assert_relative_eq!(a1, a1m, epsilon = 1e-14);
+        assert_relative_eq!(a2, a2m, epsilon = 1e-14);
+    }
+}

--- a/src/pcsaft/eos/mod.rs
+++ b/src/pcsaft/eos/mod.rs
@@ -1,0 +1,513 @@
+use super::parameters::PcSaftParameters;
+use feos_core::joback::Joback;
+use feos_core::parameter::Parameter;
+use feos_core::{
+    Contributions, EntropyScaling, EosError, EosResult, EquationOfState, HelmholtzEnergy,
+    IdealGasContribution, MolarWeight, State,
+};
+use ndarray::Array1;
+use quantity::si::*;
+use std::f64::consts::{FRAC_PI_6, PI};
+use std::rc::Rc;
+
+pub(crate) mod association;
+pub(crate) mod dispersion;
+pub(crate) mod hard_chain;
+pub(crate) mod hard_sphere;
+pub(crate) mod polar;
+mod qspr;
+use association::{Association, CrossAssociation};
+use dispersion::Dispersion;
+use hard_chain::HardChain;
+use hard_sphere::HardSphere;
+use polar::{DQVariants, Dipole, DipoleQuadrupole, Quadrupole};
+use qspr::QSPR;
+
+#[allow(clippy::upper_case_acronyms)]
+enum IdealGasContributions {
+    QSPR(QSPR),
+    Joback(Joback),
+}
+
+/// Customization options for the PC-SAFT equation of state and functional.
+#[derive(Copy, Clone)]
+pub struct PcSaftOptions {
+    pub max_eta: f64,
+    pub max_iter_cross_assoc: usize,
+    pub tol_cross_assoc: f64,
+    pub dq_variant: DQVariants,
+}
+
+impl Default for PcSaftOptions {
+    fn default() -> Self {
+        Self {
+            max_eta: 0.5,
+            max_iter_cross_assoc: 50,
+            tol_cross_assoc: 1e-10,
+            dq_variant: DQVariants::DQ35,
+        }
+    }
+}
+
+/// PC-SAFT equation of state.
+pub struct PcSaft {
+    parameters: Rc<PcSaftParameters>,
+    options: PcSaftOptions,
+    contributions: Vec<Box<dyn HelmholtzEnergy>>,
+    ideal_gas: IdealGasContributions,
+}
+
+impl PcSaft {
+    pub fn new(parameters: Rc<PcSaftParameters>) -> Self {
+        Self::with_options(parameters, PcSaftOptions::default())
+    }
+
+    pub fn with_options(parameters: Rc<PcSaftParameters>, options: PcSaftOptions) -> Self {
+        let mut contributions: Vec<Box<dyn HelmholtzEnergy>> = Vec::with_capacity(7);
+        contributions.push(Box::new(HardSphere {
+            parameters: parameters.clone(),
+        }));
+        contributions.push(Box::new(HardChain {
+            parameters: parameters.clone(),
+        }));
+        contributions.push(Box::new(Dispersion {
+            parameters: parameters.clone(),
+        }));
+        if parameters.ndipole > 0 {
+            contributions.push(Box::new(Dipole {
+                parameters: parameters.clone(),
+            }));
+        };
+        if parameters.nquadpole > 0 {
+            contributions.push(Box::new(Quadrupole {
+                parameters: parameters.clone(),
+            }));
+        };
+        if parameters.ndipole > 0 && parameters.nquadpole > 0 {
+            contributions.push(Box::new(DipoleQuadrupole {
+                parameters: parameters.clone(),
+                variant: options.dq_variant,
+            }));
+        };
+        match parameters.nassoc {
+            0 => (),
+            1 => contributions.push(Box::new(Association {
+                parameters: parameters.clone(),
+            })),
+            _ => contributions.push(Box::new(CrossAssociation {
+                parameters: parameters.clone(),
+                max_iter: options.max_iter_cross_assoc,
+                tol: options.tol_cross_assoc,
+            })),
+        };
+
+        let joback_records = parameters.joback_records.clone();
+
+        Self {
+            parameters: parameters.clone(),
+            options,
+            contributions,
+            ideal_gas: joback_records.map_or(
+                IdealGasContributions::QSPR(QSPR { parameters }),
+                |joback_records| IdealGasContributions::Joback(Joback::new(joback_records)),
+            ),
+        }
+    }
+}
+
+impl EquationOfState for PcSaft {
+    fn components(&self) -> usize {
+        self.parameters.pure_records.len()
+    }
+
+    fn subset(&self, component_list: &[usize]) -> Self {
+        Self::with_options(
+            Rc::new(self.parameters.subset(component_list)),
+            self.options,
+        )
+    }
+
+    fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
+        self.options.max_eta * moles.sum()
+            / (FRAC_PI_6 * &self.parameters.m * self.parameters.sigma.mapv(|v| v.powi(3)) * moles)
+                .sum()
+    }
+
+    fn residual(&self) -> &[Box<dyn HelmholtzEnergy>] {
+        &self.contributions
+    }
+
+    fn ideal_gas(&self) -> &dyn IdealGasContribution {
+        match &self.ideal_gas {
+            IdealGasContributions::QSPR(qspr) => qspr,
+            IdealGasContributions::Joback(joback) => joback,
+        }
+    }
+}
+
+impl MolarWeight<SIUnit> for PcSaft {
+    fn molar_weight(&self) -> SIArray1 {
+        self.parameters.molarweight.clone() * GRAM / MOL
+    }
+}
+
+fn omega11(t: f64) -> f64 {
+    1.06036 * t.powf(-0.15610)
+        + 0.19300 * (-0.47635 * t).exp()
+        + 1.03587 * (-1.52996 * t).exp()
+        + 1.76474 * (-3.89411 * t).exp()
+}
+
+fn omega22(t: f64) -> f64 {
+    1.16145 * t.powf(-0.14874) + 0.52487 * (-0.77320 * t).exp() + 2.16178 * (-2.43787 * t).exp()
+        - 6.435e-4 * t.powf(0.14874) * (18.0323 * t.powf(-0.76830) - 7.27371).sin()
+}
+
+#[inline]
+fn chapman_enskog_thermal_conductivity(
+    temperature: SINumber,
+    molarweight: SINumber,
+    m: f64,
+    sigma: f64,
+    epsilon_k: f64,
+) -> SINumber {
+    let t = temperature.to_reduced(KELVIN).unwrap();
+    0.083235 * (t * m / molarweight.to_reduced(GRAM / MOL).unwrap()).sqrt()
+        / sigma.powi(2)
+        / omega22(t / epsilon_k)
+        * WATT
+        / METER
+        / KELVIN
+}
+
+impl EntropyScaling<SIUnit> for PcSaft {
+    fn viscosity_reference(
+        &self,
+        temperature: SINumber,
+        _: SINumber,
+        moles: &SIArray1,
+    ) -> EosResult<SINumber> {
+        let p = &self.parameters;
+        let mw = &p.molarweight;
+        let x = moles.to_reduced(moles.sum())?;
+        let ce: Array1<SINumber> = (0..self.components())
+            .map(|i| {
+                let tr = (temperature / p.epsilon_k[i] / KELVIN)
+                    .into_value()
+                    .unwrap();
+                5.0 / 16.0
+                    * (mw[i] * GRAM / MOL * KB / NAV * temperature / PI)
+                        .sqrt()
+                        .unwrap()
+                    / omega22(tr)
+                    / (p.sigma[i] * ANGSTROM).powi(2)
+            })
+            .collect();
+        let mut ce_mix = 0.0 * MILLI * PASCAL * SECOND;
+        for i in 0..self.components() {
+            let denom: f64 = (0..self.components())
+                .map(|j| {
+                    x[j] * (1.0
+                        + (ce[i] / ce[j]).into_value().unwrap().sqrt()
+                            * (mw[j] / mw[i]).powf(1.0 / 4.0))
+                    .powi(2)
+                        / (8.0 * (1.0 + mw[i] / mw[j])).sqrt()
+                })
+                .sum();
+            ce_mix += ce[i] * x[i] / denom
+        }
+        Ok(ce_mix)
+    }
+
+    fn viscosity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64> {
+        let coefficients = self
+            .parameters
+            .viscosity
+            .as_ref()
+            .expect("Missing viscosity coefficients.");
+        let m = (x * &self.parameters.m).sum();
+        let s = s_res / m;
+        let pref = (x * &self.parameters.m) / m;
+        let a: f64 = (&coefficients.row(0) * x).sum();
+        let b: f64 = (&coefficients.row(1) * &pref).sum();
+        let c: f64 = (&coefficients.row(2) * &pref).sum();
+        let d: f64 = (&coefficients.row(3) * &pref).sum();
+        Ok(a + b * s + c * s.powi(2) + d * s.powi(3))
+    }
+
+    fn diffusion_reference(
+        &self,
+        temperature: SINumber,
+        volume: SINumber,
+        moles: &SIArray1,
+    ) -> EosResult<SINumber> {
+        if self.components() != 1 {
+            return Err(EosError::IncompatibleComponents(self.components(), 1));
+        }
+        let p = &self.parameters;
+        let density = moles.sum() / volume;
+        let res: Array1<SINumber> = (0..self.components())
+            .map(|i| {
+                let tr = (temperature / p.epsilon_k[i] / KELVIN)
+                    .into_value()
+                    .unwrap();
+                3.0 / 8.0 / (p.sigma[i] * ANGSTROM).powi(2) / omega11(tr) / (density * NAV)
+                    * (temperature * RGAS / PI / (p.molarweight[i] * GRAM / MOL))
+                        .sqrt()
+                        .unwrap()
+            })
+            .collect();
+        Ok(res[0])
+    }
+
+    fn diffusion_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64> {
+        if self.components() != 1 {
+            return Err(EosError::IncompatibleComponents(self.components(), 1));
+        }
+        let coefficients = self
+            .parameters
+            .diffusion
+            .as_ref()
+            .expect("Missing diffusion coefficients.");
+        let m = (x * &self.parameters.m).sum();
+        let s = s_res / m;
+        let pref = (x * &self.parameters.m).mapv(|v| v / m);
+        let a: f64 = (&coefficients.row(0) * x).sum();
+        let b: f64 = (&coefficients.row(1) * &pref).sum();
+        let c: f64 = (&coefficients.row(2) * &pref).sum();
+        let d: f64 = (&coefficients.row(3) * &pref).sum();
+        let e: f64 = (&coefficients.row(4) * &pref).sum();
+        Ok(a + b * s - c * (1.0 - s.exp()) * s.powi(2) - d * s.powi(4) - e * s.powi(8))
+    }
+
+    // Equation 4 of DOI: 10.1021/acs.iecr.9b04289
+    fn thermal_conductivity_reference(
+        &self,
+        temperature: SINumber,
+        volume: SINumber,
+        moles: &SIArray1,
+    ) -> EosResult<SINumber> {
+        if self.components() != 1 {
+            return Err(EosError::IncompatibleComponents(self.components(), 1));
+        }
+        let p = &self.parameters;
+        let mws = self.molar_weight();
+        let state = State::new_nvt(&Rc::new(Self::new(p.clone())), temperature, volume, moles)?;
+        let res: Array1<SINumber> = (0..self.components())
+            .map(|i| {
+                let tr = (temperature / p.epsilon_k[i] / KELVIN)
+                    .into_value()
+                    .unwrap();
+                let s_res_reduced = state
+                    .molar_entropy(Contributions::ResidualNvt)
+                    .to_reduced(RGAS)
+                    .unwrap()
+                    / p.m[i];
+                let ref_ce = chapman_enskog_thermal_conductivity(
+                    temperature,
+                    mws.get(i),
+                    p.m[i],
+                    p.sigma[i],
+                    p.epsilon_k[i],
+                );
+                let alpha_visc = (-s_res_reduced / -0.5).exp();
+                let ref_ts = (-0.0167141 * tr / p.m[i] + 0.0470581 * (tr / p.m[i]).powi(2))
+                    * (p.m[i] * p.m[i] * p.sigma[i].powi(3) * p.epsilon_k[i])
+                    * 1e-5
+                    * WATT
+                    / METER
+                    / KELVIN;
+                ref_ce + ref_ts * alpha_visc
+            })
+            .collect();
+        Ok(res[0])
+    }
+
+    fn thermal_conductivity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64> {
+        if self.components() != 1 {
+            return Err(EosError::IncompatibleComponents(self.components(), 1));
+        }
+        let coefficients = self
+            .parameters
+            .thermal_conductivity
+            .as_ref()
+            .expect("Missing thermal conductivity coefficients");
+        let m = (x * &self.parameters.m).sum();
+        let s = s_res / m;
+        let pref = (x * &self.parameters.m).mapv(|v| v / m);
+        let a: f64 = (&coefficients.row(0) * x).sum();
+        let b: f64 = (&coefficients.row(1) * &pref).sum();
+        let c: f64 = (&coefficients.row(2) * &pref).sum();
+        let d: f64 = (&coefficients.row(3) * &pref).sum();
+        Ok(a + b * s + c * (1.0 - s.exp()) + d * s.powi(2))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcsaft::parameters::utils::{
+        butane_parameters, propane_butane_parameters, propane_parameters,
+    };
+    use approx::assert_relative_eq;
+    use feos_core::{Contributions, DensityInitialization, PhaseEquilibrium, State};
+    use ndarray::arr1;
+    use quantity::si::{BAR, KELVIN, METER, PASCAL, RGAS, SECOND};
+
+    #[test]
+    fn ideal_gas_pressure() {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 200.0 * KELVIN;
+        let v = 1e-3 * METER.powi(3);
+        let n = arr1(&[1.0]) * MOL;
+        let s = State::new_nvt(&e, t, v, &n).unwrap();
+        let p_ig = s.total_moles * RGAS * t / v;
+        assert_relative_eq!(s.pressure(Contributions::IdealGas), p_ig, epsilon = 1e-10);
+        assert_relative_eq!(
+            s.pressure(Contributions::IdealGas) + s.pressure(Contributions::ResidualNvt),
+            s.pressure(Contributions::Total),
+            epsilon = 1e-10
+        );
+    }
+
+    #[test]
+    fn ideal_gas_heat_capacity_joback() {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 200.0 * KELVIN;
+        let v = 1e-3 * METER.powi(3);
+        let n = arr1(&[1.0]) * MOL;
+        let s = State::new_nvt(&e, t, v, &n).unwrap();
+        let p_ig = s.total_moles * RGAS * t / v;
+        assert_relative_eq!(s.pressure(Contributions::IdealGas), p_ig, epsilon = 1e-10);
+        assert_relative_eq!(
+            s.pressure(Contributions::IdealGas) + s.pressure(Contributions::ResidualNvt),
+            s.pressure(Contributions::Total),
+            epsilon = 1e-10
+        );
+    }
+
+    #[test]
+    fn new_tpn() {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 300.0 * KELVIN;
+        let p = BAR;
+        let m = arr1(&[1.0]) * MOL;
+        let s = State::new_npt(&e, t, p, &m, DensityInitialization::None);
+        let p_calc = if let Ok(state) = s {
+            state.pressure(Contributions::Total)
+        } else {
+            0.0 * PASCAL
+        };
+        assert_relative_eq!(p, p_calc, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn vle_pure() {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 300.0 * KELVIN;
+        let vle = PhaseEquilibrium::pure(&e, t, None, Default::default());
+        if let Ok(v) = vle {
+            assert_relative_eq!(
+                v.vapor().pressure(Contributions::Total),
+                v.liquid().pressure(Contributions::Total),
+                epsilon = 1e-6
+            )
+        }
+    }
+
+    #[test]
+    fn critical_point() {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 300.0 * KELVIN;
+        let cp = State::critical_point(&e, None, Some(t), Default::default());
+        if let Ok(v) = cp {
+            assert_relative_eq!(v.temperature, 375.1244078318015 * KELVIN, epsilon = 1e-8)
+        }
+    }
+
+    #[test]
+    fn speed_of_sound() {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 300.0 * KELVIN;
+        let p = BAR;
+        let m = arr1(&[1.0]) * MOL;
+        let s = State::new_npt(&e, t, p, &m, DensityInitialization::None).unwrap();
+        assert_relative_eq!(
+            s.speed_of_sound(),
+            245.00185709137546 * METER / SECOND,
+            epsilon = 1e-4
+        )
+    }
+
+    #[test]
+    fn mix_single() {
+        let e1 = Rc::new(PcSaft::new(propane_parameters()));
+        let e2 = Rc::new(PcSaft::new(butane_parameters()));
+        let e12 = Rc::new(PcSaft::new(propane_butane_parameters()));
+        let t = 300.0 * KELVIN;
+        let v = 0.02456883872966545 * METER.powi(3);
+        let m1 = arr1(&[2.0]) * MOL;
+        let m1m = arr1(&[2.0, 0.0]) * MOL;
+        let m2m = arr1(&[0.0, 2.0]) * MOL;
+        let s1 = State::new_nvt(&e1, t, v, &m1).unwrap();
+        let s2 = State::new_nvt(&e2, t, v, &m1).unwrap();
+        let s1m = State::new_nvt(&e12, t, v, &m1m).unwrap();
+        let s2m = State::new_nvt(&e12, t, v, &m2m).unwrap();
+        assert_relative_eq!(
+            s1.pressure(Contributions::Total),
+            s1m.pressure(Contributions::Total),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            s2.pressure(Contributions::Total),
+            s2m.pressure(Contributions::Total),
+            epsilon = 1e-12
+        )
+    }
+
+    #[test]
+    fn viscosity() -> EosResult<()> {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 300.0 * KELVIN;
+        let p = BAR;
+        let n = arr1(&[1.0]) * MOL;
+        let s = State::new_npt(&e, t, p, &n, DensityInitialization::None).unwrap();
+        assert_relative_eq!(
+            s.viscosity()?,
+            0.00797 * MILLI * PASCAL * SECOND,
+            epsilon = 1e-5
+        );
+        assert_relative_eq!(
+            s.ln_viscosity_reduced()?,
+            (s.viscosity()? / e.viscosity_reference(s.temperature, s.volume, &s.moles)?)
+                .into_value()
+                .unwrap()
+                .ln(),
+            epsilon = 1e-15
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn diffusion() -> EosResult<()> {
+        let e = Rc::new(PcSaft::new(propane_parameters()));
+        let t = 300.0 * KELVIN;
+        let p = BAR;
+        let n = arr1(&[1.0]) * MOL;
+        let s = State::new_npt(&e, t, p, &n, DensityInitialization::None).unwrap();
+        assert_relative_eq!(
+            s.diffusion()?,
+            0.01505 * (CENTI * METER).powi(2) / SECOND,
+            epsilon = 1e-5
+        );
+        assert_relative_eq!(
+            s.ln_diffusion_reduced()?,
+            (s.diffusion()? / e.diffusion_reference(s.temperature, s.volume, &s.moles)?)
+                .into_value()
+                .unwrap()
+                .ln(),
+            epsilon = 1e-15
+        );
+        Ok(())
+    }
+}

--- a/src/pcsaft/eos/polar.rs
+++ b/src/pcsaft/eos/polar.rs
@@ -1,0 +1,557 @@
+use super::PcSaftParameters;
+use feos_core::{HelmholtzEnergyDual, StateHD};
+use ndarray::prelude::*;
+use num_dual::DualNum;
+use std::f64::consts::{FRAC_PI_3, PI};
+use std::fmt;
+use std::rc::Rc;
+
+pub const ALPHA: f64 = 1.1937350;
+
+// Dipole parameters
+pub const AD: [[f64; 3]; 5] = [
+    [0.30435038064, 0.95346405973, -1.16100802773],
+    [-0.13585877707, -1.83963831920, 4.52586067320],
+    [1.44933285154, 2.01311801180, 0.97512223853],
+    [0.35569769252, -7.37249576667, -12.2810377713],
+    [-2.06533084541, 8.23741345333, 5.93975747420],
+];
+
+pub const BD: [[f64; 3]; 5] = [
+    [0.21879385627, -0.58731641193, 3.48695755800],
+    [-1.18964307357, 1.24891317047, -14.9159739347],
+    [1.16268885692, -0.50852797392, 15.3720218600],
+    [0.0; 3],
+    [0.0; 3],
+];
+
+pub const CD: [[f64; 3]; 4] = [
+    [-0.06467735252, -0.95208758351, -0.62609792333],
+    [0.19758818347, 2.99242575222, 1.29246858189],
+    [-0.80875619458, -2.38026356489, 1.65427830900],
+    [0.69028490492, -0.27012609786, -3.43967436378],
+];
+
+// Quadrupole parameters
+pub const AQ: [[f64; 3]; 5] = [
+    [1.237830788, 1.285410878, 1.794295401],
+    [2.435503144, -11.46561451, 0.769510293],
+    [1.633090469, 22.08689285, 7.264792255],
+    [-1.611815241, 7.46913832, 94.48669892],
+    [6.977118504, -17.19777208, -77.1484579],
+];
+
+pub const BQ: [[f64; 3]; 5] = [
+    [0.454271755, -0.813734006, 6.868267516],
+    [-4.501626435, 10.06402986, -5.173223765],
+    [3.585886783, -10.87663092, -17.2402066],
+    [0.0; 3],
+    [0.0; 3],
+];
+
+pub const CQ: [[f64; 3]; 4] = [
+    [-0.500043713, 2.000209381, 3.135827145],
+    [6.531869153, -6.78386584, 7.247588801],
+    [-16.01477983, 20.38324603, 3.075947834],
+    [14.42597018, -10.89598394, 0.0],
+];
+
+// Dipole-Quadrupole parameters
+pub const ADQ: [[f64; 3]; 4] = [
+    [0.697094963, -0.673459279, 0.670340770],
+    [-0.633554144, -1.425899106, -4.338471826],
+    [2.945509028, 4.19441392, 7.234168360],
+    [-1.467027314, 1.0266216, 0.0],
+];
+
+pub const BDQ: [[f64; 3]; 4] = [
+    [-0.484038322, 0.67651011, -1.167560146],
+    [1.970405465, -3.013867512, 2.13488432],
+    [-2.118572671, 0.46742656, 0.0],
+    [0.0; 3],
+];
+
+pub const CDQ: [[f64; 2]; 3] = [
+    [0.795009692, -2.099579397],
+    [3.386863396, -5.941376392],
+    [0.475106328, -0.178820384],
+];
+
+pub const PI_SQ_43: f64 = 4.0 * PI * FRAC_PI_3;
+
+pub struct MeanSegmentNumbers {
+    pub mij1: Array2<f64>,
+    pub mij2: Array2<f64>,
+    pub mijk1: Array3<f64>,
+    pub mijk2: Array3<f64>,
+}
+
+pub enum Multipole {
+    Dipole,
+    Quadrupole,
+}
+
+impl MeanSegmentNumbers {
+    pub fn new(parameters: &PcSaftParameters, polarity: Multipole) -> Self {
+        let (npoles, comp) = match polarity {
+            Multipole::Dipole => (parameters.ndipole, &parameters.dipole_comp),
+            Multipole::Quadrupole => (parameters.nquadpole, &parameters.quadpole_comp),
+        };
+
+        let mut mi;
+        let mut mj;
+        let mut mk;
+        let mut mij;
+        let mut mijk;
+        let mut mij1 = Array2::zeros((npoles, npoles));
+        let mut mij2 = Array2::zeros((npoles, npoles));
+        let mut mijk1 = Array3::zeros((npoles, npoles, npoles));
+        let mut mijk2 = Array3::zeros((npoles, npoles, npoles));
+        for i in 0..npoles {
+            let dci = comp[i];
+            mi = parameters.m[dci].min(2.0);
+            mij1[[i, i]] = (mi - 1.0) / mi;
+            mij2[[i, i]] = mij1[[i, i]] * (mi - 2.0) / mi;
+
+            mijk1[[i, i, i]] = mij1[[i, i]];
+            mijk2[[i, i, i]] = mij2[[i, i]];
+            for j in i + 1..npoles {
+                let dcj = comp[j];
+                mj = parameters.m[dcj].min(2.0);
+                mij = (mi * mj).sqrt();
+                mij1[[i, j]] = (mij - 1.0) / mij;
+                mij2[[i, j]] = mij1[[i, j]] * (mij - 2.0) / mij;
+                mijk = (mi * mi * mj).cbrt();
+                mijk1[[i, i, j]] = (mijk - 1.0) / mijk;
+                mijk2[[i, i, j]] = mijk1[[i, i, j]] * (mijk - 2.0) / mijk;
+                mijk = (mi * mj * mj).cbrt();
+                mijk1[[i, j, j]] = (mijk - 1.0) / mijk;
+                mijk2[[i, j, j]] = mijk1[[i, j, j]] * (mijk - 2.0) / mijk;
+                for k in j + 1..npoles {
+                    let dck = comp[k];
+                    mk = parameters.m[dck].min(2.0);
+                    mijk = (mi * mj * mk).cbrt();
+                    mijk1[[i, j, k]] = (mijk - 1.0) / mijk;
+                    mijk2[[i, j, k]] = mijk1[[i, j, k]] * (mijk - 2.0) / mijk;
+                }
+            }
+        }
+        Self {
+            mij1,
+            mij2,
+            mijk1,
+            mijk2,
+        }
+    }
+}
+
+fn pair_integral_ij<D: DualNum<f64>>(
+    mij1: f64,
+    mij2: f64,
+    eta: D,
+    a: &[[f64; 3]],
+    b: &[[f64; 3]],
+    eps_ij_t: D,
+) -> D {
+    let eta2 = eta * eta;
+    let etas = [D::one(), eta, eta2, eta2 * eta, eta2 * eta2];
+    (0..a.len())
+        .map(|i| {
+            etas[i]
+                * (eps_ij_t * (b[i][0] + mij1 * b[i][1] + mij2 * b[i][2])
+                    + a[i][0]
+                    + mij1 * a[i][1]
+                    + mij2 * a[i][2])
+        })
+        .sum()
+}
+
+fn triplet_integral_ijk<D: DualNum<f64>>(mijk1: f64, mijk2: f64, eta: D, c: &[[f64; 3]]) -> D {
+    let eta2 = eta * eta;
+    let etas = [D::one(), eta, eta2, eta2 * eta];
+    (0..c.len())
+        .map(|i| etas[i] * (c[i][0] + mijk1 * c[i][1] + mijk2 * c[i][2]))
+        .sum()
+}
+
+fn triplet_integral_ijk_dq<D: DualNum<f64>>(mijk: f64, eta: D, c: &[[f64; 2]]) -> D {
+    let etas = [D::one(), eta, eta * eta];
+    (0..c.len())
+        .map(|i| etas[i] * (c[i][0] + mijk * c[i][1]))
+        .sum()
+}
+
+pub struct Dipole {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dipole {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let m = MeanSegmentNumbers::new(&self.parameters, Multipole::Dipole);
+        let p = &self.parameters;
+
+        let t_inv = state.temperature.inv();
+        let eps_ij_t = p.e_k_ij.mapv(|v| t_inv * v);
+        let sig_ij_3 = p.sigma_ij.mapv(|v| v.powi(3));
+        let mu2_term: Array1<D> = p
+            .dipole_comp
+            .iter()
+            .map(|&i| t_inv * sig_ij_3[[i, i]] * p.epsilon_k[i] * p.mu2[i])
+            .collect();
+
+        let rho = &state.partial_density;
+        let r = p.hs_diameter(state.temperature) * 0.5;
+        let eta = (rho * &p.m * &r * &r * &r).sum() * 4.0 * FRAC_PI_3;
+
+        let mut phi2 = D::zero();
+        let mut phi3 = D::zero();
+        for i in 0..p.ndipole {
+            let di = p.dipole_comp[i];
+            phi2 -= rho[di]
+                * rho[di]
+                * mu2_term[i]
+                * mu2_term[i]
+                * pair_integral_ij(
+                    m.mij1[[i, i]],
+                    m.mij2[[i, i]],
+                    eta,
+                    &AD,
+                    &BD,
+                    eps_ij_t[[di, di]],
+                )
+                / sig_ij_3[[di, di]];
+            phi3 -= rho[di]
+                * rho[di]
+                * rho[di]
+                * mu2_term[i]
+                * mu2_term[i]
+                * mu2_term[i]
+                * triplet_integral_ijk(m.mijk1[[i, i, i]], m.mijk2[[i, i, i]], eta, &CD)
+                / sig_ij_3[[di, di]];
+            for j in (i + 1)..p.ndipole {
+                let dj = p.dipole_comp[j];
+                phi2 -= rho[di]
+                    * rho[dj]
+                    * mu2_term[i]
+                    * mu2_term[j]
+                    * pair_integral_ij(
+                        m.mij1[[i, j]],
+                        m.mij2[[i, j]],
+                        eta,
+                        &AD,
+                        &BD,
+                        eps_ij_t[[di, dj]],
+                    )
+                    / sig_ij_3[[di, dj]]
+                    * 2.0;
+                phi3 -= rho[di] * rho[di] * rho[dj] * mu2_term[i] * mu2_term[i] * mu2_term[j]
+                    / (p.sigma_ij[[di, di]] * p.sigma_ij[[di, dj]] * p.sigma_ij[[di, dj]])
+                    * triplet_integral_ijk(m.mijk1[[i, i, j]], m.mijk2[[i, i, j]], eta, &CD)
+                    * 3.0;
+                phi3 -= rho[di] * rho[dj] * rho[dj] * mu2_term[i] * mu2_term[j] * mu2_term[j]
+                    / (p.sigma_ij[[di, dj]] * p.sigma_ij[[di, dj]] * p.sigma_ij[[dj, dj]])
+                    * triplet_integral_ijk(m.mijk1[[i, j, j]], m.mijk2[[i, j, j]], eta, &CD)
+                    * 3.0;
+                for k in (j + 1)..p.ndipole {
+                    let dk = p.dipole_comp[k];
+                    phi3 -= rho[di] * rho[dj] * rho[dk] * mu2_term[i] * mu2_term[j] * mu2_term[k]
+                        / (p.sigma_ij[[di, dj]] * p.sigma_ij[[di, dk]] * p.sigma_ij[[dj, dk]])
+                        * triplet_integral_ijk(m.mijk1[[i, j, k]], m.mijk2[[i, j, k]], eta, &CD)
+                        * 6.0;
+                }
+            }
+        }
+        phi2 *= PI;
+        phi3 *= PI_SQ_43;
+        let mut result = phi2 * phi2 / (phi2 - phi3) * state.volume;
+        if result.re().is_nan() {
+            result = phi2 * state.volume
+        }
+        result
+    }
+}
+
+impl fmt::Display for Dipole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Dipole")
+    }
+}
+
+pub struct Quadrupole {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Quadrupole {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let m = MeanSegmentNumbers::new(&self.parameters, Multipole::Quadrupole);
+        let p = &self.parameters;
+
+        let t_inv = state.temperature.inv();
+        let eps_ij_t = p.e_k_ij.mapv(|v| t_inv * v);
+        let sig_ij_3 = p.sigma_ij.mapv(|v| v.powi(3));
+        let q2_term: Array1<D> = p
+            .quadpole_comp
+            .iter()
+            .map(|&i| t_inv * p.sigma[i].powi(5) * p.epsilon_k[i] * p.q2[i])
+            .collect();
+
+        let rho = &state.partial_density;
+        let r = p.hs_diameter(state.temperature) * 0.5;
+        let eta = (rho * &p.m * &r * &r * &r).sum() * 4.0 * FRAC_PI_3;
+
+        let mut phi2 = D::zero();
+        let mut phi3 = D::zero();
+        for i in 0..p.nquadpole {
+            let di = p.quadpole_comp[i];
+            phi2 -= (rho[di]
+                * rho[di]
+                * q2_term[i]
+                * q2_term[i]
+                * pair_integral_ij(
+                    m.mij1[[i, i]],
+                    m.mij2[[i, i]],
+                    eta,
+                    &AQ,
+                    &BQ,
+                    eps_ij_t[[di, di]],
+                ))
+                / p.sigma_ij[[di, di]].powi(7);
+            phi3 += (rho[di]
+                * rho[di]
+                * rho[di]
+                * q2_term[i]
+                * q2_term[i]
+                * q2_term[i]
+                * triplet_integral_ijk(m.mijk1[[i, i, i]], m.mijk2[[i, i, i]], eta, &CQ))
+                / sig_ij_3[[di, di]].powi(3);
+            for j in (i + 1)..p.nquadpole {
+                let dj = p.quadpole_comp[j];
+                phi2 -= (rho[di]
+                    * rho[dj]
+                    * q2_term[i]
+                    * q2_term[j]
+                    * pair_integral_ij(
+                        m.mij1[[i, j]],
+                        m.mij2[[i, j]],
+                        eta,
+                        &AQ,
+                        &BQ,
+                        eps_ij_t[[di, dj]],
+                    ))
+                    / p.sigma_ij[[di, di]].powi(7)
+                    * 2.0;
+                phi3 += rho[di] * rho[di] * rho[dj] * q2_term[i] * q2_term[i] * q2_term[j]
+                    / (sig_ij_3[[di, di]] * sig_ij_3[[di, dj]] * sig_ij_3[[di, dj]])
+                    * triplet_integral_ijk(m.mijk1[[i, i, j]], m.mijk2[[i, i, j]], eta, &CQ)
+                    * 3.0;
+                phi3 += rho[di] * rho[dj] * rho[dj] * q2_term[i] * q2_term[j] * q2_term[j]
+                    / (sig_ij_3[[di, dj]] * sig_ij_3[[di, dj]] * sig_ij_3[[dj, dj]])
+                    * triplet_integral_ijk(m.mijk1[[i, j, j]], m.mijk2[[i, j, j]], eta, &CQ)
+                    * 3.0;
+                for k in (j + 1)..p.nquadpole {
+                    let dk = p.quadpole_comp[k];
+                    phi3 += rho[di] * rho[dj] * rho[dk] * q2_term[i] * q2_term[j] * q2_term[k]
+                        / (sig_ij_3[[di, dj]] * sig_ij_3[[di, dk]] * sig_ij_3[[dj, dk]])
+                        * triplet_integral_ijk(m.mijk1[[i, j, k]], m.mijk2[[i, j, k]], eta, &CQ)
+                        * 6.0;
+                }
+            }
+        }
+
+        phi2 *= PI * 0.5625;
+        phi3 *= PI * PI * 0.5625;
+        let mut result = phi2 * phi2 / (phi2 - phi3) * state.volume;
+        if result.re().is_nan() {
+            result = phi2 * state.volume
+        }
+        result
+    }
+}
+
+impl fmt::Display for Quadrupole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Quadrupole")
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum DQVariants {
+    DQ35,
+    DQ44,
+}
+
+pub struct DipoleQuadrupole {
+    pub parameters: Rc<PcSaftParameters>,
+    pub variant: DQVariants,
+}
+
+impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for DipoleQuadrupole {
+    fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
+        let p = &self.parameters;
+
+        let t_inv = state.temperature.inv();
+        let eps_ij_t = p.e_k_ij.mapv(|v| t_inv * v);
+
+        let q2_term: Array1<D> = p
+            .quadpole_comp
+            .iter()
+            .map(|&i| t_inv * p.sigma[i].powi(4) * p.epsilon_k[i] * p.q2[i])
+            .collect();
+        let mu2_term: Array1<D> = p
+            .dipole_comp
+            .iter()
+            .map(|&i| t_inv * p.sigma[i].powi(4) * p.epsilon_k[i] * p.mu2[i])
+            .collect();
+
+        let rho = &state.partial_density;
+        let r = p.hs_diameter(state.temperature) * 0.5;
+        let eta = (rho * &p.m * &r * &r * &r).sum() * 4.0 * FRAC_PI_3;
+
+        // mean segment number
+        let mut mdq1 = Array2::zeros((p.ndipole, p.nquadpole));
+        let mut mdq2 = Array2::zeros((p.ndipole, p.nquadpole));
+        let mut mdqd = Array3::zeros((p.ndipole, p.nquadpole, p.ndipole));
+        let mut mdqq = Array3::zeros((p.ndipole, p.nquadpole, p.nquadpole));
+        for i in 0..p.ndipole {
+            let di = p.dipole_comp[i];
+            let mi = p.m[di].min(2.0);
+            for j in 0..p.nquadpole {
+                let qj = p.quadpole_comp[j];
+                let mj = p.m[qj].min(2.0);
+                let m = (mi * mj).sqrt();
+                mdq1[[i, j]] = (m - 1.0) / m;
+                mdq2[[i, j]] = mdq1[[i, j]] * (m - 2.0) / m;
+                for k in 0..p.ndipole {
+                    let dk = p.dipole_comp[k];
+                    let mk = p.m[dk].min(2.0);
+                    let m = (mi * mj * mk).cbrt();
+                    mdqd[[i, j, k]] = (m - 1.0) / m;
+                }
+                for k in 0..p.nquadpole {
+                    let qk = p.quadpole_comp[k];
+                    let mk = p.m[qk].min(2.0);
+                    let m = (mi * mj * mk).cbrt();
+                    mdqq[[i, j, k]] = (m - 1.0) / m;
+                }
+            }
+        }
+
+        let mut phi2 = D::zero();
+        let mut phi3 = D::zero();
+        for i in 0..p.ndipole {
+            for j in 0..p.nquadpole {
+                let di = p.dipole_comp[i];
+                let qj = p.quadpole_comp[j];
+                let mu2_q2_term = match self.variant {
+                    DQVariants::DQ35 => mu2_term[i] / p.sigma[di] * q2_term[j] * p.sigma[qj],
+                    DQVariants::DQ44 => mu2_term[i] * q2_term[j],
+                };
+                phi2 -= rho[di] * rho[qj] * mu2_q2_term / p.sigma_ij[[di, qj]].powi(5)
+                    * pair_integral_ij(
+                        mdq1[[i, j]],
+                        mdq2[[i, j]],
+                        eta,
+                        &ADQ,
+                        &BDQ,
+                        eps_ij_t[[di, qj]],
+                    );
+                for k in 0..p.ndipole {
+                    let dk = p.dipole_comp[k];
+                    phi3 += rho[di] * rho[qj] * rho[dk] * mu2_term[i] * q2_term[j] * mu2_term[k]
+                        / (p.sigma_ij[[di, qj]] * p.sigma_ij[[di, dk]] * p.sigma_ij[[qj, dk]])
+                            .powi(2)
+                        * triplet_integral_ijk_dq(mdqd[[i, j, k]], eta, &CDQ);
+                }
+                for k in 0..p.nquadpole {
+                    let qk = p.quadpole_comp[k];
+                    phi3 += rho[di] * rho[qj] * rho[qk] * mu2_term[i] * q2_term[j] * q2_term[k]
+                        / (p.sigma_ij[[di, qj]] * p.sigma_ij[[di, qk]] * p.sigma_ij[[qj, qk]])
+                            .powi(2)
+                        * ALPHA
+                        * triplet_integral_ijk_dq(mdqq[[i, j, k]], eta, &CDQ);
+                }
+            }
+        }
+
+        phi2 *= PI * 2.25;
+        phi3 *= PI * PI;
+        let mut result = phi2 * phi2 / (phi2 - phi3) * state.volume;
+        if result.re().is_nan() {
+            result = phi2 * state.volume
+        }
+        result
+    }
+}
+
+impl fmt::Display for DipoleQuadrupole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DipoleQuadrupole")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcsaft::eos::dispersion::Dispersion;
+    use crate::pcsaft::parameters::utils::{
+        carbon_dioxide_parameters, dme_co2_parameters, dme_parameters,
+    };
+    use approx::assert_relative_eq;
+    use feos_core::StateHD;
+
+    #[test]
+    fn test_dipolar_contribution() {
+        let dp = Dipole {
+            parameters: Rc::new(dme_parameters()),
+        };
+        let t = 350.0;
+        let v = 1000.0;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a = dp.helmholtz_energy(&s);
+        assert_relative_eq!(a, -1.40501033595417E-002, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_quadrupolar_contribution() {
+        let qp = Quadrupole {
+            parameters: Rc::new(carbon_dioxide_parameters()),
+        };
+        let t = 350.0;
+        let v = 1000.0;
+        let n = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n]));
+        let a = qp.helmholtz_energy(&s);
+        assert_relative_eq!(a, -4.38559558854186E-002, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_dipolar_quadrupolar_contribution() {
+        let dp = Dipole {
+            parameters: Rc::new(dme_co2_parameters()),
+        };
+        let qp = Quadrupole {
+            parameters: Rc::new(dme_co2_parameters()),
+        };
+        // let dpqp = DipoleQuadrupole {
+        //     parameters: Rc::new(dme_co2_parameters()),
+        //     variant: DQVariants::DQ35,
+        // };
+        let disp = Dispersion {
+            parameters: Rc::new(dme_co2_parameters()),
+        };
+        let t = 350.0;
+        let v = 1000.0;
+        let n_dme = 1.0;
+        let n_co2 = 1.0;
+        let s = StateHD::new(t, v, arr1(&[n_dme, n_co2]));
+        // let a_dpqp = dpqp.helmholtz_energy(&s);
+        let a_disp = disp.helmholtz_energy(&s);
+        let a_qp = qp.helmholtz_energy(&s);
+        let a_dp = dp.helmholtz_energy(&s);
+        assert_relative_eq!(a_disp, -1.6283622072860044, epsilon = 1e-6);
+        assert_relative_eq!(a_dp, -1.35361827881345E-002, epsilon = 1e-6);
+        assert_relative_eq!(a_qp, -4.20168059082731E-002, epsilon = 1e-6);
+        // assert_relative_eq!(a_dpqp, -2.2316252638709004E-002, epsilon = 1e-6);
+    }
+}

--- a/src/pcsaft/eos/qspr.rs
+++ b/src/pcsaft/eos/qspr.rs
@@ -1,0 +1,128 @@
+use super::PcSaftParameters;
+use feos_core::IdealGasContributionDual;
+use ndarray::Array1;
+use num_dual::*;
+use std::fmt;
+use std::rc::Rc;
+
+const RGAS: f64 = 6.022140857 * 1.38064852;
+const KB: f64 = 1.38064852e-23;
+const T300: f64 = 300.0;
+const T400: f64 = 400.0;
+const T0: f64 = 298.15;
+const P0: f64 = 1.0e5;
+const A3: f64 = 1e-30;
+
+// Heat capacity parameters @ T = 300 K (col 1) and T = 400 K (col 2)
+const NA_NP_300: [f64; 6] = [
+    -5763.04893,
+    1232.30607,
+    -239.3513996,
+    0.0,
+    0.0,
+    -15174.28321,
+];
+const NA_NP_400: [f64; 6] = [
+    -8171.26676935062,
+    1498.01217504596,
+    -315.515836223387,
+    0.0,
+    0.0,
+    -19389.5468655708,
+];
+const NA_P_300: [f64; 6] = [
+    5177.19095226181,
+    919.565206504576,
+    -108.829105648889,
+    0.0,
+    -3.93917830677682,
+    -13504.5671858292,
+];
+const NA_P_400: [f64; 6] = [
+    10656.1018362315,
+    1146.10782703748,
+    -131.023645998081,
+    0.0,
+    -9.93789225413177,
+    -24430.12952497,
+];
+const AP_300: [f64; 6] = [
+    3600.32322462175,
+    1006.20461224949,
+    -151.688378113974,
+    7.81876773647109e-07,
+    8.01001754473385,
+    -8959.37140957179,
+];
+const AP_400: [f64; 6] = [
+    7248.0697641199,
+    1267.44346171358,
+    -208.738557800023,
+    0.000170238690157906,
+    -6.7841792685616,
+    -12669.4196622924,
+];
+
+#[allow(clippy::upper_case_acronyms)]
+pub struct QSPR {
+    pub parameters: Rc<PcSaftParameters>,
+}
+
+impl<D: DualNum<f64>> IdealGasContributionDual<D> for QSPR {
+    fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D> {
+        let (c_300, c_400) = match self.parameters.nassoc {
+            0 => match self.parameters.ndipole + self.parameters.nquadpole {
+                0 => (NA_NP_300, NA_NP_400),
+                _ => (NA_P_300, NA_P_400),
+            },
+            _ => (AP_300, AP_400),
+        };
+
+        Array1::from_shape_fn(components, |i| {
+            let epsilon_kt = temperature.recip() * self.parameters.epsilon_k[i];
+            let sigma3 = self.parameters.sigma[i].powi(3);
+
+            let p1 = epsilon_kt * self.parameters.m[i];
+            let p2 = sigma3 * self.parameters.m[i];
+            let p3 = epsilon_kt * p2;
+            let p4 = (temperature.recip() * self.parameters.epsilon_k_ab[i]).exp_m1()
+                * p2
+                * sigma3
+                * self.parameters.kappa_ab[i];
+            let p5 = p2 * self.parameters.q[i];
+            let p6 = 1.0;
+
+            let icpc300 = (p1 * c_300[0] / T300
+                + p2 * c_300[1]
+                + p3 * c_300[2] / T300
+                + p4 * c_300[3] / T300
+                + p5 * c_300[4]
+                + p6 * c_300[5])
+                * 0.001;
+            let icpc400 = (p1 * c_400[0] / T400
+                + p2 * c_400[1]
+                + p3 * c_400[2] / T400
+                + p4 * c_400[3] / T400
+                + p5 * c_400[4]
+                + p6 * c_400[5])
+                * 0.001;
+
+            // linear approximation
+            let b = (icpc400 - icpc300) / (T400 - T300);
+            let a = icpc300 - b * T300;
+
+            // integration
+            let k = a * (temperature - T0 - temperature * (temperature / T0).ln())
+                - b * (temperature - T0).powi(2) * 0.5;
+
+            // de Broglie wavelength
+            k / (temperature * RGAS) + (temperature * KB / (P0 * A3)).ln()
+        })
+    }
+}
+
+impl fmt::Display for QSPR {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ideal gas (QSPR)")
+    }
+}

--- a/src/pcsaft/mod.rs
+++ b/src/pcsaft/mod.rs
@@ -1,0 +1,15 @@
+#![warn(clippy::all)]
+#![allow(clippy::too_many_arguments)]
+
+#[cfg(feature = "dft")]
+mod dft;
+mod eos;
+mod parameters;
+
+#[cfg(feature = "dft")]
+pub use dft::PcSaftFunctional;
+pub use eos::{PcSaft, PcSaftOptions};
+pub use parameters::{PcSaftParameters, PcSaftRecord};
+
+#[cfg(feature = "python")]
+pub mod python;

--- a/src/pcsaft/parameters.rs
+++ b/src/pcsaft/parameters.rs
@@ -1,0 +1,1144 @@
+use conv::ValueInto;
+use feos_core::joback::JobackRecord;
+use feos_core::parameter::{
+    FromSegments, FromSegmentsBinary, Parameter, ParameterError, PureRecord,
+};
+use ndarray::{Array, Array1, Array2};
+use num_traits::Zero;
+use quantity::si::{JOULE, KB, KELVIN};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Write;
+
+/// PC-SAFT pure-component parameters.
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct PcSaftRecord {
+    /// Segment number
+    pub m: f64,
+    /// Segment diameter in units of Angstrom
+    pub sigma: f64,
+    /// Energetic parameter in units of Kelvin
+    pub epsilon_k: f64,
+    /// Dipole moment in units of Debye
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mu: Option<f64>,
+    /// Quadrupole moment in units of Debye
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub q: Option<f64>,
+    /// Association volume parameter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kappa_ab: Option<f64>,
+    /// Association energy parameter in units of Kelvin
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epsilon_k_ab: Option<f64>,
+    /// \# of association sites of type A
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub na: Option<f64>,
+    /// \# of association sites of type B
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nb: Option<f64>,
+    /// Entropy scaling coefficients for the viscosity
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub viscosity: Option<[f64; 4]>,
+    /// Entropy scaling coefficients for the diffusion coefficient
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diffusion: Option<[f64; 5]>,
+    /// Entropy scaling coefficients for the thermal conductivity
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thermal_conductivity: Option<[f64; 4]>,
+}
+
+impl FromSegments<f64> for PcSaftRecord {
+    fn from_segments(segments: &[(Self, f64)]) -> Result<Self, ParameterError> {
+        let mut m = 0.0;
+        let mut sigma3 = 0.0;
+        let mut epsilon_k = 0.0;
+
+        segments.iter().for_each(|(s, n)| {
+            m += s.m * n;
+            sigma3 += s.m * s.sigma.powi(3) * n;
+            epsilon_k += s.m * s.epsilon_k * n;
+        });
+
+        let q = segments
+            .iter()
+            .filter_map(|(s, n)| s.q.map(|q| q * n))
+            .reduce(|a, b| a + b);
+        let mu = segments
+            .iter()
+            .filter_map(|(s, n)| s.mu.map(|mu| mu * n))
+            .reduce(|a, b| a + b);
+        let kappa_ab = segments
+            .iter()
+            .filter_map(|(s, n)| s.kappa_ab.map(|k| k * n))
+            .reduce(|a, b| a + b);
+        let epsilon_k_ab = segments
+            .iter()
+            .filter_map(|(s, n)| s.epsilon_k_ab.map(|e| e * n))
+            .reduce(|a, b| a + b);
+        let na = segments
+            .iter()
+            .filter_map(|(s, n)| s.na.map(|na| na * n))
+            .reduce(|a, b| a + b);
+        let nb = segments
+            .iter()
+            .filter_map(|(s, n)| s.nb.map(|nb| nb * n))
+            .reduce(|a, b| a + b);
+
+        // entropy scaling
+        let mut viscosity = if segments
+            .iter()
+            .all(|(record, _)| record.viscosity.is_some())
+        {
+            Some([0.0; 4])
+        } else {
+            None
+        };
+        let mut thermal_conductivity = if segments
+            .iter()
+            .all(|(record, _)| record.thermal_conductivity.is_some())
+        {
+            Some([0.0; 4])
+        } else {
+            None
+        };
+        let diffusion = if segments
+            .iter()
+            .all(|(record, _)| record.diffusion.is_some())
+        {
+            Some([0.0; 5])
+        } else {
+            None
+        };
+
+        let n_t = segments.iter().fold(0.0, |acc, (_, n)| acc + n);
+        segments.iter().for_each(|(s, n)| {
+            let s3 = s.m * s.sigma.powi(3) * n;
+            if let Some(p) = viscosity.as_mut() {
+                let [a, b, c, d] = s.viscosity.unwrap();
+                p[0] += s3 * a;
+                p[1] += s3 * b / sigma3.powf(0.45);
+                p[2] += n * c;
+                p[3] += n * d;
+            }
+            if let Some(p) = thermal_conductivity.as_mut() {
+                let [a, b, c, d] = s.thermal_conductivity.unwrap();
+                p[0] += n * a;
+                p[1] += n * b;
+                p[2] += n * c;
+                p[3] += n_t * d;
+            }
+            // if let Some(p) = diffusion.as_mut() {
+            //     let [a, b, c, d, e] = s.diffusion.unwrap();
+            //     p[0] += s3 * a;
+            //     p[1] += s3 * b / sigma3.powf(0.45);
+            //     p[2] += *n * c;
+            //     p[3] += *n * d;
+            // }
+        });
+        // correction due to difference in Chapman-Enskog reference between GC and regular formulation.
+        viscosity = viscosity.map(|v| [v[0] - 0.5 * m.ln(), v[1], v[2], v[3]]);
+
+        Ok(Self {
+            m,
+            sigma: (sigma3 / m).cbrt(),
+            epsilon_k: epsilon_k / m,
+            mu,
+            q,
+            kappa_ab,
+            epsilon_k_ab,
+            na,
+            nb,
+            viscosity,
+            diffusion,
+            thermal_conductivity,
+        })
+    }
+}
+
+impl FromSegments<usize> for PcSaftRecord {
+    fn from_segments(segments: &[(Self, usize)]) -> Result<Self, ParameterError> {
+        // We do not allow more than a single segment for q, mu, kappa_ab, epsilon_k_ab
+        let quadpole_comps = segments.iter().filter_map(|(s, _)| s.q).count();
+        if quadpole_comps > 1 {
+            return Err(ParameterError::IncompatibleParameters(format!(
+                "{quadpole_comps} segments with quadrupole moment."
+            )));
+        };
+        let dipole_comps = segments.iter().filter_map(|(s, _)| s.mu).count();
+        if dipole_comps > 1 {
+            return Err(ParameterError::IncompatibleParameters(format!(
+                "{dipole_comps} segment with dipole moment."
+            )));
+        };
+        let faulty_assoc_comps = segments
+            .iter()
+            .filter_map(|(s, _)| s.kappa_ab.xor(s.epsilon_k_ab))
+            .count();
+        if faulty_assoc_comps > 0 {
+            return Err(ParameterError::IncompatibleParameters(format!(
+                "Incorrectly specified association sites on {faulty_assoc_comps} segment(s)"
+            )));
+        }
+        let assoc_comps = segments
+            .iter()
+            .filter_map(|(s, _)| s.kappa_ab.and(s.epsilon_k_ab))
+            .count();
+        if assoc_comps > 1 {
+            return Err(ParameterError::IncompatibleParameters(format!(
+                "{assoc_comps} segments with association sites."
+            )));
+        }
+        let segments: Vec<_> = segments
+            .iter()
+            .cloned()
+            .map(|(s, c)| (s, c as f64))
+            .collect();
+        Self::from_segments(&segments)
+    }
+}
+
+impl std::fmt::Display for PcSaftRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PcSaftRecord(m={}", self.m)?;
+        write!(f, ", sigma={}", self.sigma)?;
+        write!(f, ", epsilon_k={}", self.epsilon_k)?;
+        if let Some(n) = &self.mu {
+            write!(f, ", mu={}", n)?;
+        }
+        if let Some(n) = &self.q {
+            write!(f, ", q={}", n)?;
+        }
+        if let Some(n) = &self.kappa_ab {
+            write!(f, ", kappa_ab={}", n)?;
+        }
+        if let Some(n) = &self.epsilon_k_ab {
+            write!(f, ", epsilon_k_ab={}", n)?;
+        }
+        if let Some(n) = &self.na {
+            write!(f, ", na={}", n)?;
+        }
+        if let Some(n) = &self.nb {
+            write!(f, ", nb={}", n)?;
+        }
+        if let Some(n) = &self.viscosity {
+            write!(f, ", viscosity={:?}", n)?;
+        }
+        if let Some(n) = &self.diffusion {
+            write!(f, ", diffusion={:?}", n)?;
+        }
+        if let Some(n) = &self.thermal_conductivity {
+            write!(f, ", thermal_conductivity={:?}", n)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl PcSaftRecord {
+    pub fn new(
+        m: f64,
+        sigma: f64,
+        epsilon_k: f64,
+        mu: Option<f64>,
+        q: Option<f64>,
+        kappa_ab: Option<f64>,
+        epsilon_k_ab: Option<f64>,
+        na: Option<f64>,
+        nb: Option<f64>,
+        viscosity: Option<[f64; 4]>,
+        diffusion: Option<[f64; 5]>,
+        thermal_conductivity: Option<[f64; 4]>,
+    ) -> PcSaftRecord {
+        PcSaftRecord {
+            m,
+            sigma,
+            epsilon_k,
+            mu,
+            q,
+            kappa_ab,
+            epsilon_k_ab,
+            na,
+            nb,
+            viscosity,
+            diffusion,
+            thermal_conductivity,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct PcSaftBinaryRecord {
+    k_ij: f64,
+}
+
+impl From<f64> for PcSaftBinaryRecord {
+    fn from(k_ij: f64) -> Self {
+        Self { k_ij }
+    }
+}
+
+impl From<PcSaftBinaryRecord> for f64 {
+    fn from(binary_record: PcSaftBinaryRecord) -> Self {
+        binary_record.k_ij
+    }
+}
+
+impl<T: Copy + ValueInto<f64>> FromSegmentsBinary<T> for PcSaftBinaryRecord {
+    fn from_segments_binary(segments: &[(Self, T, T)]) -> Result<Self, ParameterError> {
+        let k_ij = segments
+            .iter()
+            .map(|(br, n1, n2)| br.k_ij * (*n1).value_into().unwrap() * (*n2).value_into().unwrap())
+            .sum();
+        Ok(Self { k_ij })
+    }
+}
+
+impl std::fmt::Display for PcSaftBinaryRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PcSaftBinaryRecord(k_ij={})", self.k_ij)
+    }
+}
+
+/// Parameter set required for the PC-SAFT equation of state and Helmholtz energy functional.
+pub struct PcSaftParameters {
+    pub molarweight: Array1<f64>,
+    pub m: Array1<f64>,
+    pub sigma: Array1<f64>,
+    pub epsilon_k: Array1<f64>,
+    pub mu: Array1<f64>,
+    pub q: Array1<f64>,
+    pub mu2: Array1<f64>,
+    pub q2: Array1<f64>,
+    pub kappa_ab: Array1<f64>,
+    pub epsilon_k_ab: Array1<f64>,
+    pub na: Array1<f64>,
+    pub nb: Array1<f64>,
+    pub kappa_aibj: Array2<f64>,
+    pub epsilon_k_aibj: Array2<f64>,
+    pub k_ij: Array2<f64>,
+    pub sigma_ij: Array2<f64>,
+    pub epsilon_k_ij: Array2<f64>,
+    pub e_k_ij: Array2<f64>,
+    pub ndipole: usize,
+    pub nquadpole: usize,
+    pub nassoc: usize,
+    pub dipole_comp: Array1<usize>,
+    pub quadpole_comp: Array1<usize>,
+    pub assoc_comp: Array1<usize>,
+    pub viscosity: Option<Array2<f64>>,
+    pub diffusion: Option<Array2<f64>>,
+    pub thermal_conductivity: Option<Array2<f64>>,
+    pub pure_records: Vec<PureRecord<PcSaftRecord, JobackRecord>>,
+    pub binary_records: Array2<PcSaftBinaryRecord>,
+    pub joback_records: Option<Vec<JobackRecord>>,
+}
+
+impl Parameter for PcSaftParameters {
+    type Pure = PcSaftRecord;
+    type IdealGas = JobackRecord;
+    type Binary = PcSaftBinaryRecord;
+
+    fn from_records(
+        pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
+        binary_records: Array2<PcSaftBinaryRecord>,
+    ) -> Self {
+        let n = pure_records.len();
+
+        let mut molarweight = Array::zeros(n);
+        let mut m = Array::zeros(n);
+        let mut sigma = Array::zeros(n);
+        let mut epsilon_k = Array::zeros(n);
+        let mut mu = Array::zeros(n);
+        let mut q = Array::zeros(n);
+        let mut na = Array::zeros(n);
+        let mut nb = Array::zeros(n);
+        let mut kappa_ab = Array::zeros(n);
+        let mut epsilon_k_ab = Array::zeros(n);
+        let mut viscosity = Vec::with_capacity(n);
+        let mut diffusion = Vec::with_capacity(n);
+        let mut thermal_conductivity = Vec::with_capacity(n);
+
+        let mut component_index = HashMap::with_capacity(n);
+
+        for (i, record) in pure_records.iter().enumerate() {
+            component_index.insert(record.identifier.clone(), i);
+            let r = &record.model_record;
+            m[i] = r.m;
+            sigma[i] = r.sigma;
+            epsilon_k[i] = r.epsilon_k;
+            mu[i] = r.mu.unwrap_or(0.0);
+            q[i] = r.q.unwrap_or(0.0);
+            na[i] = r.na.unwrap_or(1.0);
+            nb[i] = r.nb.unwrap_or(1.0);
+            kappa_ab[i] = r.kappa_ab.unwrap_or(0.0);
+            epsilon_k_ab[i] = r.epsilon_k_ab.unwrap_or(0.0);
+            viscosity.push(r.viscosity);
+            diffusion.push(r.diffusion);
+            thermal_conductivity.push(r.thermal_conductivity);
+            molarweight[i] = record.molarweight;
+        }
+
+        let mu2 = &mu * &mu / (&m * &sigma * &sigma * &sigma * &epsilon_k)
+            * 1e-19
+            * (JOULE / KELVIN / KB).into_value().unwrap();
+        let q2 = &q * &q / (&m * &sigma.mapv(|s| s.powi(5)) * &epsilon_k)
+            * 1e-19
+            * (JOULE / KELVIN / KB).into_value().unwrap();
+        let dipole_comp: Array1<usize> = mu2
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &mu2)| (mu2.abs() > 0.0).then(|| i))
+            .collect();
+        let ndipole = dipole_comp.len();
+        let quadpole_comp: Array1<usize> = q2
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &q2)| (q2.abs() > 0.0).then(|| i))
+            .collect();
+        let nquadpole = quadpole_comp.len();
+        let assoc_comp: Array1<usize> = kappa_ab
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &k)| (k.abs() > 0.0).then(|| i))
+            .collect();
+        let nassoc = assoc_comp.len();
+
+        let mut kappa_aibj = Array::zeros([n, n]);
+        let mut epsilon_k_aibj = Array::zeros([n, n]);
+        for i in 0..nassoc {
+            for j in 0..nassoc {
+                let ai = assoc_comp[i];
+                let bj = assoc_comp[j];
+                kappa_aibj[[ai, bj]] = (kappa_ab[ai] * kappa_ab[bj]).sqrt()
+                    * (2.0 * (sigma[ai] * sigma[bj]).sqrt() / (sigma[ai] + sigma[bj])).powf(3.0);
+                epsilon_k_aibj[[ai, bj]] = 0.5 * (epsilon_k_ab[ai] + epsilon_k_ab[bj]);
+            }
+        }
+
+        let k_ij = binary_records.map(|br| br.k_ij);
+        let mut epsilon_k_ij = Array::zeros((n, n));
+        let mut sigma_ij = Array::zeros((n, n));
+        let mut e_k_ij = Array::zeros((n, n));
+        for i in 0..n {
+            for j in 0..n {
+                e_k_ij[[i, j]] = (epsilon_k[i] * epsilon_k[j]).sqrt();
+                epsilon_k_ij[[i, j]] = (1.0 - k_ij[[i, j]]) * e_k_ij[[i, j]];
+                sigma_ij[[i, j]] = 0.5 * (sigma[i] + sigma[j]);
+            }
+        }
+
+        let viscosity_coefficients = if viscosity.iter().any(|v| v.is_none()) {
+            None
+        } else {
+            let mut v = Array2::zeros((4, viscosity.len()));
+            for (i, vi) in viscosity.iter().enumerate() {
+                v.column_mut(i).assign(&Array1::from(vi.unwrap().to_vec()));
+            }
+            Some(v)
+        };
+
+        let diffusion_coefficients = if diffusion.iter().any(|v| v.is_none()) {
+            None
+        } else {
+            let mut v = Array2::zeros((5, diffusion.len()));
+            for (i, vi) in diffusion.iter().enumerate() {
+                v.column_mut(i).assign(&Array1::from(vi.unwrap().to_vec()));
+            }
+            Some(v)
+        };
+
+        let thermal_conductivity_coefficients = if thermal_conductivity.iter().any(|v| v.is_none())
+        {
+            None
+        } else {
+            let mut v = Array2::zeros((4, thermal_conductivity.len()));
+            for (i, vi) in thermal_conductivity.iter().enumerate() {
+                v.column_mut(i).assign(&Array1::from(vi.unwrap().to_vec()));
+            }
+            Some(v)
+        };
+
+        let joback_records = pure_records
+            .iter()
+            .map(|r| r.ideal_gas_record.clone())
+            .collect();
+
+        Self {
+            molarweight,
+            m,
+            sigma,
+            epsilon_k,
+            mu,
+            q,
+            mu2,
+            q2,
+            kappa_ab,
+            epsilon_k_ab,
+            na,
+            nb,
+            kappa_aibj,
+            epsilon_k_aibj,
+            k_ij,
+            sigma_ij,
+            epsilon_k_ij,
+            e_k_ij,
+            ndipole,
+            nquadpole,
+            nassoc,
+            dipole_comp,
+            quadpole_comp,
+            assoc_comp,
+            viscosity: viscosity_coefficients,
+            diffusion: diffusion_coefficients,
+            thermal_conductivity: thermal_conductivity_coefficients,
+            pure_records,
+            binary_records,
+            joback_records,
+        }
+    }
+
+    fn records(
+        &self,
+    ) -> (
+        &[PureRecord<PcSaftRecord, JobackRecord>],
+        &Array2<PcSaftBinaryRecord>,
+    ) {
+        (&self.pure_records, &self.binary_records)
+    }
+}
+
+impl PcSaftParameters {
+    pub fn to_markdown(&self) -> String {
+        let mut output = String::new();
+        let o = &mut output;
+        write!(
+            o,
+            "|component|molarweight|$m$|$\\sigma$|$\\varepsilon$|$\\mu$|$Q$|$\\kappa_{{AB}}$|$\\varepsilon_{{AB}}$|$N_A$|$N_B$|\n|-|-|-|-|-|-|-|-|-|-|-|"
+        )
+        .unwrap();
+        for i in 0..self.m.len() {
+            let component = self.pure_records[i].identifier.name.clone();
+            let component = component.unwrap_or(format!("Component {}", i + 1));
+            write!(
+                o,
+                "\n|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|",
+                component,
+                self.molarweight[i],
+                self.m[i],
+                self.sigma[i],
+                self.epsilon_k[i],
+                self.mu[i],
+                self.q[i],
+                self.kappa_ab[i],
+                self.epsilon_k_ab[i],
+                self.na[i],
+                self.nb[i]
+            )
+            .unwrap();
+        }
+
+        output
+    }
+}
+
+impl std::fmt::Display for PcSaftParameters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PcSaftParameters(")?;
+        write!(f, "\n\tmolarweight={}", self.molarweight)?;
+        write!(f, "\n\tm={}", self.m)?;
+        write!(f, "\n\tsigma={}", self.sigma)?;
+        write!(f, "\n\tepsilon_k={}", self.epsilon_k)?;
+        if !self.dipole_comp.is_empty() {
+            write!(f, "\n\tmu={}", self.mu)?;
+        }
+        if !self.quadpole_comp.is_empty() {
+            write!(f, "\n\tq={}", self.q)?;
+        }
+        if !self.assoc_comp.is_empty() {
+            write!(f, "\n\tkappa_ab={}", self.kappa_ab)?;
+            write!(f, "\n\tepsilon_k_ab={}", self.epsilon_k_ab)?;
+            write!(f, "\n\tna={}", self.na)?;
+            write!(f, "\n\tnb={}", self.nb)?;
+        }
+        if !self.k_ij.iter().all(|k| k.is_zero()) {
+            write!(f, "\n\tk_ij=\n{}", self.k_ij)?;
+        }
+        write!(f, "\n)")
+    }
+}
+
+#[cfg(test)]
+pub mod utils {
+    use super::*;
+    use feos_core::joback::JobackRecord;
+    use std::rc::Rc;
+    // use feos_core::parameter::SegmentRecord;
+
+    // pub fn pure_record_vec() -> Vec<PureRecord<PcSaftRecord, JobackRecord>> {
+    //     let records = r#"[
+    //         {
+    //             "identifier": {
+    //                 "cas": "74-98-6",
+    //                 "name": "propane",
+    //                 "iupac_name": "propane",
+    //                 "smiles": "CCC",
+    //                 "inchi": "InChI=1/C3H8/c1-3-2/h3H2,1-2H3",
+    //                 "formula": "C3H8"
+    //             },
+    //             "model_record": {
+    //                 "m": 2.0018290000000003,
+    //                 "sigma": 3.618353,
+    //                 "epsilon_k": 208.1101
+    //             },
+    //             "molarweight": 44.0962,
+    //             "chemical_record": {
+    //                 "segments": ["CH3", "CH2", "CH3"]
+    //             }
+    //         },
+    //         {
+    //             "identifier": {
+    //                 "cas": "106-97-8",
+    //                 "name": "butane",
+    //                 "iupac_name": "butane",
+    //                 "smiles": "CCCC",
+    //                 "inchi": "InChI=1/C4H10/c1-3-4-2/h3-4H2,1-2H3",
+    //                 "formula": "C4H10"
+    //             },
+    //             "model_record": {
+    //                 "m": 2.331586,
+    //                 "sigma": 3.7086010000000003,
+    //                 "epsilon_k": 222.8774
+    //             },
+    //             "molarweight": 58.123,
+    //             "chemical_record": {
+    //                 "segments": ["CH3", "CH2", "CH2", "CH3"]
+    //             }
+    //         },
+    //         {
+    //             "identifier": {
+    //                 "cas": "74-82-8",
+    //                 "name": "methane",
+    //                 "iupac_name": "methane",
+    //                 "smiles": "C",
+    //                 "inchi": "InChI=1/CH4/h1H4",
+    //                 "formula": "CH4"
+    //             },
+    //             "model_record": {
+    //                 "m": 1.0,
+    //                 "sigma": 3.7039,
+    //                 "epsilon_k": 150.034
+    //             },
+    //             "molarweight": 16.0426
+    //         },
+    //         {
+    //             "identifier": {
+    //                 "cas": "124-38-9",
+    //                 "name": "carbon-dioxide",
+    //                 "iupac_name": "carbon dioxide",
+    //                 "smiles": "O=C=O",
+    //                 "inchi": "InChI=1/CO2/c2-1-3",
+    //                 "formula": "CO2"
+    //             },
+    //             "molarweight": 44.0098,
+    //             "model_record": {
+    //                 "m": 1.5131,
+    //                 "sigma": 3.1869,
+    //                 "epsilon_k": 163.333,
+    //                 "q": 4.4
+    //             }
+    //         }
+    //     ]"#;
+    //     serde_json::from_str(records).expect("Unable to parse json.")
+    // }
+
+    // pub fn segments_vec() -> Vec<SegmentRecord<PcSaftRecord, JobackRecord>> {
+    //     let segments_json = r#"[
+    //     {
+    //       "identifier": "CH3",
+    //       "model_record": {
+    //         "m": 0.77247,
+    //         "sigma": 3.6937,
+    //         "epsilon_k": 181.49
+    //       },
+    //       "molarweight": 15.0345
+    //     },
+    //     {
+    //       "identifier": "CH2",
+    //       "model_record": {
+    //         "m": 0.7912,
+    //         "sigma": 3.0207,
+    //         "epsilon_k": 157.23
+    //       },
+    //       "molarweight": 14.02658
+    //     },
+
+    //     {
+    //       "identifier": ">CH",
+    //       "model_record": {
+    //         "m": 0.52235,
+    //         "sigma": 0.99912,
+    //         "epsilon_k": 269.84
+    //       },
+    //       "molarweight": 13.01854
+    //     },
+    //     {
+    //       "identifier": ">C<",
+    //       "model_record": {
+    //         "m": -0.70131,
+    //         "sigma": 0.54350,
+    //         "epsilon_k": 0.0
+    //       },
+    //       "molarweight": 12.0107
+    //     },
+    //     {
+    //       "identifier": "=CH2",
+    //       "model_record": {
+    //         "m": 0.70581,
+    //         "sigma": 3.1630,
+    //         "epsilon_k": 171.34
+    //       },
+    //       "molarweight": 14.02658
+    //     },
+    //     {
+    //       "identifier": "=CH",
+    //       "model_record": {
+    //         "m": 0.90182,
+    //         "sigma": 2.8864,
+    //         "epsilon_k": 158.90
+    //       },
+    //       "molarweight": 13.01854
+    //     }
+    //     ]"#;
+    //     serde_json::from_str(segments_json).expect("Unable to parse json.")
+    // }
+
+    // pub fn methane_parameters() -> PcSaftParameters {
+    //     let methane_json = r#"
+    //         {
+    //             "identifier": {
+    //                 "cas": "74-82-8",
+    //                 "name": "methane",
+    //                 "iupac_name": "methane",
+    //                 "smiles": "C",
+    //                 "inchi": "InChI=1/CH4/h1H4",
+    //                 "formula": "CH4"
+    //             },
+    //             "model_record": {
+    //                 "m": 1.0,
+    //                 "sigma": 3.7039,
+    //                 "epsilon_k": 150.034
+    //             },
+    //             "molarweight": 16.0426
+    //         }"#;
+    //     let methane_record: PureRecord<PcSaftRecord, JobackRecord> =
+    //         serde_json::from_str(methane_json).expect("Unable to parse json.");
+    //     PcSaftParameters::from_records(vec![methane_record], None).unwrap()
+    // }
+
+    pub fn propane_parameters() -> Rc<PcSaftParameters> {
+        let propane_json = r#"
+            {
+                "identifier": {
+                    "cas": "74-98-6",
+                    "name": "propane",
+                    "iupac_name": "propane",
+                    "smiles": "CCC",
+                    "inchi": "InChI=1/C3H8/c1-3-2/h3H2,1-2H3",
+                    "formula": "C3H8"
+                },
+                "model_record": {
+                    "m": 2.001829,
+                    "sigma": 3.618353,
+                    "epsilon_k": 208.1101,
+                    "viscosity": [-0.8013, -1.9972,-0.2907, -0.0467],
+                    "thermal_conductivity": [-0.15348,  -0.6388, 1.21342, -0.01664],
+                    "diffusion": [-0.675163251512047, 0.3212017677695878, 0.100175249144429, 0.0, 0.0]
+                },
+                "molarweight": 44.0962
+            }"#;
+        let propane_record: PureRecord<PcSaftRecord, JobackRecord> =
+            serde_json::from_str(propane_json).expect("Unable to parse json.");
+        Rc::new(PcSaftParameters::new_pure(propane_record))
+    }
+
+    // pub fn propane_homogc_parameters() -> PcSaftParameters {
+    //     let propane_json = r#"
+    //         {
+    //             "identifier": {
+    //                 "cas": "74-98-6",
+    //                 "name": "propane",
+    //                 "iupac_name": "propane",
+    //                 "smiles": "CCC",
+    //                 "inchi": "InChI=1/C3H8/c1-3-2/h3H2,1-2H3",
+    //                 "formula": "C3H8"
+    //             },
+    //             "chemical_record": {
+    //                 "molarweight": 44.0962,
+    //                 "segments": ["CH3", "CH2", "CH3"]
+    //             }
+    //         }"#;
+    //     let segments_json = r#"[
+    //     {
+    //         "identifier": "CH3",
+    //         "model_record": {
+    //             "m": 0.61198,
+    //             "sigma": 3.7202,
+    //             "epsilon_k": 229.90
+    //         },
+    //         "molarweight": 15.0345
+    //     },
+    //     {
+    //         "identifier": "CH2",
+    //         "model_record": {
+    //             "m": 0.45606,
+    //             "sigma": 3.8900,
+    //             "epsilon_k": 239.01
+    //             },
+    //         "molarweight": 14.02658
+    //     }
+    // ]"#;
+    //     let propane_record: PureRecord =
+    //         serde_json::from_str(&propane_json).expect("Unable to parse json.");
+    //     let segment_records: Vec<SegmentRecord> =
+    //         serde_json::from_str(&segments_json).expect("Unable to parse json.");
+    //     ParameterBuilder::new()
+    //         .molecule_records(Some(&vec![propane_record]), None)
+    //         .segment_records(Some(&segment_records), None)
+    //         .build(BuilderOption::HomoGC)
+    //         .unwrap()
+    // }
+
+    pub fn carbon_dioxide_parameters() -> PcSaftParameters {
+        let co2_json = r#"
+        {
+            "identifier": {
+                "cas": "124-38-9",
+                "name": "carbon-dioxide",
+                "iupac_name": "carbon dioxide",
+                "smiles": "O=C=O",
+                "inchi": "InChI=1/CO2/c2-1-3",
+                "formula": "CO2"
+            },
+            "molarweight": 44.0098,
+            "model_record": {
+                "m": 1.5131,
+                "sigma": 3.1869,
+                "epsilon_k": 163.333,
+                "q": 4.4
+            }
+        }"#;
+        let co2_record: PureRecord<PcSaftRecord, JobackRecord> =
+            serde_json::from_str(co2_json).expect("Unable to parse json.");
+        PcSaftParameters::new_pure(co2_record)
+    }
+
+    pub fn butane_parameters() -> Rc<PcSaftParameters> {
+        let butane_json = r#"
+            {
+                "identifier": {
+                    "cas": "106-97-8",
+                    "name": "butane",
+                    "iupac_name": "butane",
+                    "smiles": "CCCC",
+                    "inchi": "InChI=1/C4H10/c1-3-4-2/h3-4H2,1-2H3",
+                    "formula": "C4H10"
+                },
+                "model_record": {
+                    "m": 2.331586,
+                    "sigma": 3.7086010000000003,
+                    "epsilon_k": 222.8774
+                },
+                "molarweight": 58.123
+            }"#;
+        let butane_record: PureRecord<PcSaftRecord, JobackRecord> =
+            serde_json::from_str(butane_json).expect("Unable to parse json.");
+        Rc::new(PcSaftParameters::new_pure(butane_record))
+    }
+
+    pub fn dme_parameters() -> PcSaftParameters {
+        let dme_json = r#"
+            {
+                "identifier": {
+                    "cas": "115-10-6",
+                    "name": "dimethyl-ether",
+                    "iupac_name": "methoxymethane",
+                    "smiles": "COC",
+                    "inchi": "InChI=1/C2H6O/c1-3-2/h1-2H3",
+                    "formula": "C2H6O"
+                },
+                "model_record": {
+                    "m": 2.2634,
+                    "sigma": 3.2723,
+                    "epsilon_k": 210.29,
+                    "mu": 1.3
+                },
+                "molarweight": 46.0688
+            }"#;
+        let dme_record: PureRecord<PcSaftRecord, JobackRecord> =
+            serde_json::from_str(dme_json).expect("Unable to parse json.");
+        PcSaftParameters::new_pure(dme_record)
+    }
+
+    pub fn water_parameters() -> PcSaftParameters {
+        let water_json = r#"
+            {
+                "identifier": {
+                    "cas": "7732-18-5",
+                    "name": "water_np",
+                    "iupac_name": "oxidane",
+                    "smiles": "O",
+                    "inchi": "InChI=1/H2O/h1H2",
+                    "formula": "H2O"
+                },
+                "model_record": {
+                    "m": 1.065587,
+                    "sigma": 3.000683,
+                    "epsilon_k": 366.5121,
+                    "kappa_ab": 0.034867983,
+                    "epsilon_k_ab": 2500.6706
+                },
+                "molarweight": 18.0152
+            }"#;
+        let water_record: PureRecord<PcSaftRecord, JobackRecord> =
+            serde_json::from_str(water_json).expect("Unable to parse json.");
+        PcSaftParameters::new_pure(water_record)
+    }
+
+    pub fn dme_co2_parameters() -> PcSaftParameters {
+        let binary_json = r#"[
+            {
+                "identifier": {
+                    "cas": "115-10-6",
+                    "name": "dimethyl-ether",
+                    "iupac_name": "methoxymethane",
+                    "smiles": "COC",
+                    "inchi": "InChI=1/C2H6O/c1-3-2/h1-2H3",
+                    "formula": "C2H6O"
+                },
+                "molarweight": 46.0688,
+                "model_record": {
+                    "m": 2.2634,
+                    "sigma": 3.2723,
+                    "epsilon_k": 210.29,
+                    "mu": 1.3
+                }
+            },
+            {
+                "identifier": {
+                    "cas": "124-38-9",
+                    "name": "carbon-dioxide",
+                    "iupac_name": "carbon dioxide",
+                    "smiles": "O=C=O",
+                    "inchi": "InChI=1/CO2/c2-1-3",
+                    "formula": "CO2"
+                },
+                "molarweight": 44.0098,
+                "model_record": {
+                    "m": 1.5131,
+                    "sigma": 3.1869,
+                    "epsilon_k": 163.333,
+                    "q": 4.4
+                }
+            }
+        ]"#;
+        let binary_record: Vec<PureRecord<PcSaftRecord, JobackRecord>> =
+            serde_json::from_str(binary_json).expect("Unable to parse json.");
+        PcSaftParameters::new_binary(binary_record, None)
+    }
+
+    pub fn propane_butane_parameters() -> Rc<PcSaftParameters> {
+        let binary_json = r#"[
+            {
+                "identifier": {
+                    "cas": "74-98-6",
+                    "name": "propane",
+                    "iupac_name": "propane",
+                    "smiles": "CCC",
+                    "inchi": "InChI=1/C3H8/c1-3-2/h3H2,1-2H3",
+                    "formula": "C3H8"
+                },
+                "model_record": {
+                    "m": 2.0018290000000003,
+                    "sigma": 3.618353,
+                    "epsilon_k": 208.1101,
+                    "viscosity": [-0.8013, -1.9972, -0.2907, -0.0467],
+                    "thermal_conductivity": [-0.15348, -0.6388, 1.21342, -0.01664],
+                    "diffusion": [-0.675163251512047, 0.3212017677695878, 0.100175249144429, 0.0, 0.0]
+                },
+                "molarweight": 44.0962
+            },
+            {
+                "identifier": {
+                    "cas": "106-97-8",
+                    "name": "butane",
+                    "iupac_name": "butane",
+                    "smiles": "CCCC",
+                    "inchi": "InChI=1/C4H10/c1-3-4-2/h3-4H2,1-2H3",
+                    "formula": "C4H10"
+                },
+                "model_record": {
+                    "m": 2.331586,
+                    "sigma": 3.7086010000000003,
+                    "epsilon_k": 222.8774,
+                    "viscosity": [-0.9763, -2.2413, -0.3690, -0.0605],
+                    "diffusion": [-0.8985872992958458, 0.3428584416613513, 0.10236616087103916, 0.0, 0.0]
+                },
+                "molarweight": 58.123
+            }
+        ]"#;
+        let binary_record: Vec<PureRecord<PcSaftRecord, JobackRecord>> =
+            serde_json::from_str(binary_json).expect("Unable to parse json.");
+        Rc::new(PcSaftParameters::new_binary(binary_record, None))
+    }
+
+    // pub fn water_hexane_parameters() -> PcSaftParameters {
+    //     let binary_json = r#"[
+    //     {
+    //         "identifier": {
+    //             "cas": "7732-18-5",
+    //             "name": "water_np",
+    //             "iupac_name": "oxidane",
+    //             "smiles": "O",
+    //             "inchi": "InChI=1/H2O/h1H2",
+    //             "formula": "H2O"
+    //         },
+    //         "model_record": {
+    //             "m": 1.065587,
+    //             "sigma": 3.000683,
+    //             "epsilon_k": 366.5121,
+    //             "kappa_ab": 0.034867983,
+    //             "epsilon_k_ab": 2500.6706
+    //         },
+    //         "molarweight": 18.0152
+    //     },
+    //     {
+    //         "identifier": {
+    //             "cas": "110-54-3",
+    //             "name": "hexane",
+    //             "iupac_name": "hexane",
+    //             "smiles": "CCCCCC",
+    //             "inchi": "InChI=1/C6H14/c1-3-5-6-4-2/h3-6H2,1-2H3",
+    //             "formula": "C6H14"
+    //         },
+    //         "model_record": {
+    //             "m": 3.0576,
+    //             "sigma": 3.7983,
+    //             "epsilon_k": 236.77
+    //         },
+    //         "molarweight": 86.177
+    //     }
+    //     ]"#;
+    //     let binary_record: Vec<PureRecord<PcSaftRecord, JobackRecord>> =
+    //         serde_json::from_str(binary_json).expect("Unable to parse json.");
+    //     PcSaftParameters::from_records(binary_record, None).unwrap()
+    // }
+
+    // pub fn dodecane_nitrogen_parameters() -> PcSaftParameters {
+    //     let binary_json = r#"[
+    //     {
+    //         "identifier": {
+    //             "cas": "112-40-3",
+    //             "name": "dodecane",
+    //             "iupac_name": "dodecane",
+    //             "smiles": "CCCCCCCCCCCC",
+    //             "inchi": "InChI=1/C12H26/c1-3-5-7-9-11-12-10-8-6-4-2/h3-12H2,1-2H3",
+    //             "formula": "C12H26"
+    //         },
+    //         "model_record": {
+    //             "m": 5.305758999999999,
+    //             "sigma": 3.895892,
+    //             "epsilon_k": 249.2145,
+    //             "viscosity": [
+    //                 -1.6719,
+    //                 -3.39020393,
+    //                 -0.6956429590000001,
+    //                 -0.154563667
+    //             ],
+    //             "diffusion": [
+    //                 -1.709976456320196,
+    //                 0.4350370700652692,
+    //                 0.3567181896779805,
+    //                 0.0,
+    //                 0.0
+    //             ]
+    //         },
+    //         "molarweight": 170.3374
+    //     },
+    //     {
+    //         "identifier": {
+    //             "cas": "7727-37-9",
+    //             "name": "nitrogen",
+    //             "iupac_name": "molecular nitrogen",
+    //             "smiles": "N#N",
+    //             "inchi": "InChI=1/N2/c1-2",
+    //             "formula": "N2"
+    //         },
+    //         "model_record": {
+    //             "m": 1.1504,
+    //             "sigma": 3.3848,
+    //             "epsilon_k": 91.4,
+    //             "q": 1.43,
+    //             "viscosity": [
+    //                 -0.196376646,
+    //                 -0.9460855,
+    //                 -0.0309718769,
+    //                 -0.0303367687
+    //             ],
+    //             "diffusion": [
+    //                 -0.12855765455212295,
+    //                 0.24885131958296933,
+    //                 0.08052800000000002,
+    //                 0.0,
+    //                 0.0
+    //             ]
+    //         },
+    //         "molarweight": 28.0134
+    //     }
+    //     ]"#;
+    //     let kij_json = r#"[
+    //     {
+    //       "id1": {
+    //               "cas": "7727-37-9",
+    //               "name": "nitrogen",
+    //               "iupac_name": "molecular nitrogen",
+    //               "smiles": "N#N",
+    //               "inchi": "InChI=1/N2/c1-2",
+    //               "formula": "N2"
+    //           },
+    //       "id2": {
+    //               "cas": "112-40-3",
+    //               "name": "dodecane",
+    //               "iupac_name": "dodecane",
+    //               "smiles": "CCCCCCCCCCCC",
+    //               "inchi": "InChI=1/C12H26/c1-3-5-7-9-11-12-10-8-6-4-2/h3-12H2,1-2H3",
+    //               "formula": "C12H26"
+    //           },
+    //       "k_ij": 0.1661
+    //     },
+    //     {
+    //       "id1": {
+    //               "cas": "7727-37-9",
+    //               "name": "nitrogen",
+    //               "iupac_name": "molecular nitrogen",
+    //               "smiles": "N#N",
+    //               "inchi": "InChI=1/N2/c1-2",
+    //               "formula": "N2"
+    //           },
+    //       "id2": {
+    //               "cas": "74-98-6",
+    //               "name": "propane",
+    //               "iupac_name": "propane",
+    //               "smiles": "CCC",
+    //               "inchi": "InChI=1/C3H8/c1-3-2/h3H2,1-2H3",
+    //               "formula": "C3H8"
+    //           },
+    //       "k_ij": 0.02512
+    //     }
+    //   ]"#;
+    //     let binary_record: Vec<PureRecord<PcSaftRecord, JobackRecord>> =
+    //         serde_json::from_str(binary_json).expect("Unable to parse json.");
+    //     let kij_record: Vec<BinaryRecord<Identifier, f64>> =
+    //         serde_json::from_str(kij_json).expect("Unable to parse binary json.");
+    //     PcSaftParameters::from_records(binary_record, Some(kij_record)).unwrap()
+    // }
+}

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -1,0 +1,203 @@
+use super::eos::polar::DQVariants;
+use super::parameters::{PcSaftBinaryRecord, PcSaftParameters, PcSaftRecord};
+use feos_core::joback::JobackRecord;
+use feos_core::parameter::{
+    BinaryRecord, Identifier, IdentifierOption, Parameter, ParameterError, PureRecord,
+    SegmentRecord,
+};
+use feos_core::python::joback::PyJobackRecord;
+use feos_core::python::parameter::*;
+use feos_core::*;
+use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use std::convert::{TryFrom, TryInto};
+use std::rc::Rc;
+
+impl From<&str> for DQVariants {
+    fn from(str: &str) -> Self {
+        match str {
+            "dq35" => Self::DQ35,
+            "dq44" => Self::DQ44,
+            _ => panic!("dq_variant must be either \"dq35\" or \"dq44\""),
+        }
+    }
+}
+
+/// Create a set of PC-Saft parameters from records.
+#[pyclass(name = "PcSaftRecord", unsendable)]
+#[pyo3(
+    text_signature = "(m, sigma, epsilon_k, mu=None, q=None, kappa_ab=None, epsilon_k_ab=None, na=None, nb=None, viscosity=None, diffusion=None, thermal_conductivity=None)"
+)]
+#[derive(Clone)]
+pub struct PyPcSaftRecord(PcSaftRecord);
+
+#[pymethods]
+impl PyPcSaftRecord {
+    #[new]
+    fn new(
+        m: f64,
+        sigma: f64,
+        epsilon_k: f64,
+        mu: Option<f64>,
+        q: Option<f64>,
+        kappa_ab: Option<f64>,
+        epsilon_k_ab: Option<f64>,
+        na: Option<f64>,
+        nb: Option<f64>,
+        viscosity: Option<[f64; 4]>,
+        diffusion: Option<[f64; 5]>,
+        thermal_conductivity: Option<[f64; 4]>,
+    ) -> Self {
+        Self(PcSaftRecord::new(
+            m,
+            sigma,
+            epsilon_k,
+            mu,
+            q,
+            kappa_ab,
+            epsilon_k_ab,
+            na,
+            nb,
+            viscosity,
+            diffusion,
+            thermal_conductivity,
+        ))
+    }
+
+    #[getter]
+    fn get_m(&self) -> f64 {
+        self.0.m
+    }
+
+    #[getter]
+    fn get_sigma(&self) -> f64 {
+        self.0.sigma
+    }
+
+    #[getter]
+    fn get_epsilon_k(&self) -> f64 {
+        self.0.epsilon_k
+    }
+
+    #[getter]
+    fn get_mu(&self) -> Option<f64> {
+        self.0.mu
+    }
+
+    #[getter]
+    fn get_q(&self) -> Option<f64> {
+        self.0.q
+    }
+
+    #[getter]
+    fn get_kappa_ab(&self) -> Option<f64> {
+        self.0.kappa_ab
+    }
+
+    #[getter]
+    fn get_epsilon_k_ab(&self) -> Option<f64> {
+        self.0.epsilon_k_ab
+    }
+
+    #[getter]
+    fn get_na(&self) -> Option<f64> {
+        self.0.na
+    }
+
+    #[getter]
+    fn get_nb(&self) -> Option<f64> {
+        self.0.nb
+    }
+
+    #[getter]
+    fn get_viscosity(&self) -> Option<[f64; 4]> {
+        self.0.viscosity
+    }
+
+    #[getter]
+    fn get_diffusion(&self) -> Option<[f64; 5]> {
+        self.0.diffusion
+    }
+
+    #[getter]
+    fn get_thermal_conductivity(&self) -> Option<[f64; 4]> {
+        self.0.thermal_conductivity
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl_json_handling!(PyPcSaftRecord);
+
+impl_pure_record!(PcSaftRecord, PyPcSaftRecord, JobackRecord, PyJobackRecord);
+impl_segment_record!(PcSaftRecord, PyPcSaftRecord, JobackRecord, PyJobackRecord);
+
+#[pyclass(name = "PcSaftBinaryRecord", unsendable)]
+#[pyo3(
+    text_signature = "(pure_records, binary_records=None, substances=None, search_option='Name')"
+)]
+#[derive(Clone)]
+pub struct PyPcSaftBinaryRecord(PcSaftBinaryRecord);
+impl_binary_record!(PcSaftBinaryRecord, PyPcSaftBinaryRecord);
+
+/// Create a set of PC-SAFT parameters from records.
+///
+/// Parameters
+/// ----------
+/// pure_records : List[PureRecord]
+///     pure substance records.
+/// binary_records : List[BinaryRecord], optional
+///     binary saft parameter records
+/// substances : List[str], optional
+///     The substances to use. Filters substances from `pure_records` according to
+///     `search_option`.
+///     When not provided, all entries of `pure_records` are used.
+/// search_option : {'Name', 'Cas', 'Inchi', 'IupacName', 'Formula', 'Smiles'}, optional, defaults to 'Name'.
+///     Identifier that is used to search substance.
+///
+/// Returns
+/// -------
+/// PcSaftParameters
+#[pyclass(name = "PcSaftParameters", unsendable)]
+#[pyo3(
+    text_signature = "(pure_records, binary_records=None, substances=None, search_option='Name')"
+)]
+#[derive(Clone)]
+pub struct PyPcSaftParameters(pub Rc<PcSaftParameters>);
+
+impl_parameter!(PcSaftParameters, PyPcSaftParameters);
+impl_parameter_from_segments!(PcSaftParameters, PyPcSaftParameters);
+
+#[pymethods]
+impl PyPcSaftParameters {
+    #[getter]
+    fn get_k_ij<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
+        self.0.k_ij.view().to_pyarray(py)
+    }
+
+    fn _repr_markdown_(&self) -> String {
+        self.0.to_markdown()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+#[pymodule]
+pub fn pcsaft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyIdentifier>()?;
+    m.add_class::<PyChemicalRecord>()?;
+    m.add_class::<PyJobackRecord>()?;
+
+    m.add_class::<PyPcSaftRecord>()?;
+    m.add_class::<PyPureRecord>()?;
+    m.add_class::<PySegmentRecord>()?;
+    m.add_class::<PyBinaryRecord>()?;
+    m.add_class::<PyBinarySegmentRecord>()?;
+    m.add_class::<PyPcSaftParameters>()?;
+    Ok(())
+}

--- a/src/pcsaft/python_module.rs
+++ b/src/pcsaft/python_module.rs
@@ -1,7 +1,9 @@
-use feos_pcsaft::python::{PyPcSaftParameters, PyPcSaftRecord, PyPureRecord, PySegmentRecord};
-use pyo3::prelude::*;
-use feos_core::python::parameter::*;
 use feos_core::python::joback::PyJobackRecord;
+use feos_core::python::parameter::*;
+use feos_pcsaft::python::{
+    PyBinaryRecord, PyPcSaftParameters, PyPcSaftRecord, PyPureRecord, PySegmentRecord,
+};
+use pyo3::prelude::*;
 
 #[pymodule]
 pub fn pcsaft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {

--- a/src/python/cubic.rs
+++ b/src/python/cubic.rs
@@ -1,6 +1,6 @@
+use feos_core::python::cubic::*;
 use feos_core::python::joback::PyJobackRecord;
 use feos_core::python::parameter::*;
-use feos_core::python::cubic::*;
 use pyo3::prelude::*;
 
 #[pymodule]

--- a/src/python/dft.rs
+++ b/src/python/dft.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "fit")]
+use crate::fit::*;
+#[cfg(feature = "fit")]
+use crate::impl_estimator;
 use feos_core::*;
 use feos_dft::adsorption::*;
 use feos_dft::fundamental_measure_theory::{FMTFunctional, FMTVersion};
@@ -5,19 +9,22 @@ use feos_dft::interface::*;
 use feos_dft::python::*;
 use feos_dft::solvation::*;
 use feos_dft::*;
-use feos_estimator::*;
-use feos_gc_pcsaft::python::PyGcPcSaftFunctionalParameters;
-use feos_gc_pcsaft::{GcPcSaftFunctional, GcPcSaftOptions};
-use feos_pcsaft::python::PyPcSaftParameters;
-use feos_pcsaft::{PcSaftFunctional, PcSaftOptions};
-use feos_pets::python::PyPetsParameters;
-use feos_pets::{PetsFunctional, PetsOptions};
+// use feos_fcsaft::FcSaftFunctional;
+// use feos_gc_pcsaft::python::PyGcPcSaftFunctionalParameters;
+// use feos_gc_pcsaft::{GcPcSaftFunctional, GcPcSaftOptions};
+#[cfg(feature = "pcsaft")]
+use crate::pcsaft::python::PyPcSaftParameters;
+#[cfg(feature = "pcsaft")]
+use crate::pcsaft::{PcSaftFunctional, PcSaftOptions};
+// use feos_pets::python::PyPetsParameters;
+// use feos_pets::{PetsFunctional, PetsOptions};
 use ndarray::{Array1, Array2};
 use numpy::convert::ToPyArray;
 use numpy::{PyArray1, PyArray2, PyArray4};
-use petgraph::graph::{Graph, UnGraph};
-use pyo3::exceptions::PyValueError;
+// use petgraph::graph::{Graph, UnGraph};
+use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
+#[cfg(feature = "fit")]
 use pyo3::wrap_pymodule;
 use quantity::python::*;
 use quantity::si::*;
@@ -25,29 +32,32 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 pub enum FunctionalVariant {
+    #[cfg(feature = "pcsaft")]
     PcSaft(PcSaftFunctional),
-    GcPcSaft(GcPcSaftFunctional),
-    Pets(PetsFunctional),
+    // GcPcSaft(GcPcSaftFunctional),
+    // FcSaft(FcSaftFunctional),
+    // Pets(PetsFunctional),
     Fmt(FMTFunctional),
 }
 
+#[cfg(feature = "pcsaft")]
 impl From<PcSaftFunctional> for FunctionalVariant {
     fn from(f: PcSaftFunctional) -> Self {
         Self::PcSaft(f)
     }
 }
 
-impl From<GcPcSaftFunctional> for FunctionalVariant {
-    fn from(f: GcPcSaftFunctional) -> Self {
-        Self::GcPcSaft(f)
-    }
-}
+// impl From<GcPcSaftFunctional> for FunctionalVariant {
+//     fn from(f: GcPcSaftFunctional) -> Self {
+//         Self::GcPcSaft(f)
+//     }
+// }
 
-impl From<PetsFunctional> for FunctionalVariant {
-    fn from(f: PetsFunctional) -> Self {
-        Self::Pets(f)
-    }
-}
+// impl From<PetsFunctional> for FunctionalVariant {
+//     fn from(f: PetsFunctional) -> Self {
+//         Self::Pets(f)
+//     }
+// }
 
 impl From<FMTFunctional> for FunctionalVariant {
     fn from(f: FMTFunctional) -> Self {
@@ -58,63 +68,76 @@ impl From<FMTFunctional> for FunctionalVariant {
 impl HelmholtzEnergyFunctional for FunctionalVariant {
     fn subset(&self, component_list: &[usize]) -> DFT<Self> {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.subset(component_list).into(),
-            FunctionalVariant::GcPcSaft(functional) => functional.subset(component_list).into(),
-            FunctionalVariant::Pets(functional) => functional.subset(component_list).into(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.subset(component_list).into(),
+            // FunctionalVariant::FcSaft(functional) => functional.subset(component_list).into(),
+            // FunctionalVariant::Pets(functional) => functional.subset(component_list).into(),
             FunctionalVariant::Fmt(functional) => functional.subset(component_list).into(),
         }
     }
 
     fn molecule_shape(&self) -> MoleculeShape {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.molecule_shape(),
-            FunctionalVariant::GcPcSaft(functional) => functional.molecule_shape(),
-            FunctionalVariant::Pets(functional) => functional.molecule_shape(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.molecule_shape(),
+            // FunctionalVariant::FcSaft(functional) => functional.molecule_shape(),
+            // FunctionalVariant::Pets(functional) => functional.molecule_shape(),
             FunctionalVariant::Fmt(functional) => functional.molecule_shape(),
         }
     }
 
     fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.compute_max_density(moles),
-            FunctionalVariant::GcPcSaft(functional) => functional.compute_max_density(moles),
-            FunctionalVariant::Pets(functional) => functional.compute_max_density(moles),
+            // FunctionalVariant::GcPcSaft(functional) => functional.compute_max_density(moles),
+            // FunctionalVariant::FcSaft(functional) => functional.compute_max_density(moles),
+            // FunctionalVariant::Pets(functional) => functional.compute_max_density(moles),
             FunctionalVariant::Fmt(functional) => functional.compute_max_density(moles),
         }
     }
 
     fn contributions(&self) -> &[Box<dyn FunctionalContribution>] {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.contributions(),
-            FunctionalVariant::GcPcSaft(functional) => functional.contributions(),
-            FunctionalVariant::Pets(functional) => functional.contributions(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.contributions(),
+            // FunctionalVariant::FcSaft(functional) => functional.contributions(),
+            // FunctionalVariant::Pets(functional) => functional.contributions(),
             FunctionalVariant::Fmt(functional) => functional.contributions(),
         }
     }
 
     fn ideal_gas(&self) -> &dyn IdealGasContribution {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.ideal_gas(),
-            FunctionalVariant::GcPcSaft(functional) => functional.ideal_gas(),
-            FunctionalVariant::Pets(functional) => functional.ideal_gas(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.ideal_gas(),
+            // FunctionalVariant::FcSaft(functional) => functional.ideal_gas(),
+            // FunctionalVariant::Pets(functional) => functional.ideal_gas(),
             FunctionalVariant::Fmt(functional) => functional.ideal_gas(),
         }
     }
 
-    fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
-        match self {
-            FunctionalVariant::GcPcSaft(functional) => functional.bond_lengths(temperature),
-            _ => Graph::with_capacity(0, 0),
-        }
-    }
+    // fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
+    //     match self {
+    //         // FunctionalVariant::GcPcSaft(functional) => functional.bond_lengths(temperature),
+    //         // FunctionalVariant::FcSaft(functional) => functional.bond_lengths(temperature),
+    //         _ => Graph::with_capacity(0, 0),
+    //     }
+    // }
 }
 
 impl MolarWeight<SIUnit> for FunctionalVariant {
     fn molar_weight(&self) -> SIArray1 {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.molar_weight(),
-            FunctionalVariant::GcPcSaft(functional) => functional.molar_weight(),
-            FunctionalVariant::Pets(functional) => functional.molar_weight(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.molar_weight(),
+            // FunctionalVariant::FcSaft(functional) => functional.molar_weight(),
+            // FunctionalVariant::Pets(functional) => functional.molar_weight(),
             _ => unimplemented!(),
         }
     }
@@ -123,30 +146,34 @@ impl MolarWeight<SIUnit> for FunctionalVariant {
 impl FluidParameters for FunctionalVariant {
     fn epsilon_k_ff(&self) -> Array1<f64> {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.epsilon_k_ff(),
-            FunctionalVariant::GcPcSaft(functional) => functional.epsilon_k_ff(),
-            FunctionalVariant::Pets(functional) => functional.epsilon_k_ff(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.epsilon_k_ff(),
+            // FunctionalVariant::FcSaft(functional) => functional.epsilon_k_ff(),
+            // FunctionalVariant::Pets(functional) => functional.epsilon_k_ff(),
             FunctionalVariant::Fmt(functional) => functional.epsilon_k_ff(),
         }
     }
 
     fn sigma_ff(&self) -> &Array1<f64> {
         match self {
+            #[cfg(feature = "pcsaft")]
             FunctionalVariant::PcSaft(functional) => functional.sigma_ff(),
-            FunctionalVariant::GcPcSaft(functional) => functional.sigma_ff(),
-            FunctionalVariant::Pets(functional) => functional.sigma_ff(),
+            // FunctionalVariant::GcPcSaft(functional) => functional.sigma_ff(),
+            // FunctionalVariant::FcSaft(functional) => functional.sigma_ff(),
+            // FunctionalVariant::Pets(functional) => functional.sigma_ff(),
             FunctionalVariant::Fmt(functional) => functional.sigma_ff(),
         }
     }
 }
 
 impl PairPotential for FunctionalVariant {
-    fn pair_potential(&self, r: &Array1<f64>) -> Array2<f64> {
+    fn pair_potential(&self, i: usize, r: &Array1<f64>, temperature: f64) -> Array2<f64> {
         match self {
-            FunctionalVariant::PcSaft(functional) => functional.pair_potential(r),
-            FunctionalVariant::Pets(functional) => functional.pair_potential(r),
-            FunctionalVariant::Fmt(functional) => functional.pair_potential(r),
-            _ => unimplemented!(),
+            #[cfg(feature = "pcsaft")]
+            FunctionalVariant::PcSaft(functional) => functional.pair_potential(i, r, temperature),
+            // FunctionalVariant::Pets(functional) => functional.pair_potential(i, r, temperature),
+            FunctionalVariant::Fmt(functional) => functional.pair_potential(i, r, temperature),
         }
     }
 }
@@ -177,6 +204,7 @@ impl PyFunctionalVariant {
     /// Returns
     /// -------
     /// Functional
+    #[cfg(feature = "pcsaft")]
     #[args(
         fmt_version = "FMTVersion::WhiteBear",
         max_eta = "0.5",
@@ -207,75 +235,75 @@ impl PyFunctionalVariant {
         ))
     }
 
-    /// (heterosegmented) group contribution PC-SAFT Helmholtz energy functional.
-    ///
-    /// Parameters
-    /// ----------
-    /// parameters: GcPcSaftFunctionalParameters
-    ///     The set of PC-SAFT parameters.
-    /// fmt_version: FMTVersion, optional
-    ///     The specific variant of the FMT term. Defaults to FMTVersion.WhiteBear
-    /// max_eta : float, optional
-    ///     Maximum packing fraction. Defaults to 0.5.
-    /// max_iter_cross_assoc : unsigned integer, optional
-    ///     Maximum number of iterations for cross association. Defaults to 50.
-    /// tol_cross_assoc : float
-    ///     Tolerance for convergence of cross association. Defaults to 1e-10.
-    ///
-    /// Returns
-    /// -------
-    /// Functional
-    #[args(
-        fmt_version = "FMTVersion::WhiteBear",
-        max_eta = "0.5",
-        max_iter_cross_assoc = "50",
-        tol_cross_assoc = "1e-10"
-    )]
-    #[staticmethod]
-    #[pyo3(
-        text_signature = "(parameters, fmt_version, max_eta, max_iter_cross_assoc, tol_cross_assoc)"
-    )]
-    fn gc_pcsaft(
-        parameters: PyGcPcSaftFunctionalParameters,
-        fmt_version: FMTVersion,
-        max_eta: f64,
-        max_iter_cross_assoc: usize,
-        tol_cross_assoc: f64,
-    ) -> Self {
-        let options = GcPcSaftOptions {
-            max_eta,
-            max_iter_cross_assoc,
-            tol_cross_assoc,
-        };
-        Self(Rc::new(
-            GcPcSaftFunctional::with_options(parameters.0, fmt_version, options).into(),
-        ))
-    }
+    // /// (heterosegmented) group contribution PC-SAFT Helmholtz energy functional.
+    // ///
+    // /// Parameters
+    // /// ----------
+    // /// parameters: GcPcSaftFunctionalParameters
+    // ///     The set of PC-SAFT parameters.
+    // /// fmt_version: FMTVersion, optional
+    // ///     The specific variant of the FMT term. Defaults to FMTVersion.WhiteBear
+    // /// max_eta : float, optional
+    // ///     Maximum packing fraction. Defaults to 0.5.
+    // /// max_iter_cross_assoc : unsigned integer, optional
+    // ///     Maximum number of iterations for cross association. Defaults to 50.
+    // /// tol_cross_assoc : float
+    // ///     Tolerance for convergence of cross association. Defaults to 1e-10.
+    // ///
+    // /// Returns
+    // /// -------
+    // /// Functional
+    // #[args(
+    //     fmt_version = "FMTVersion::WhiteBear",
+    //     max_eta = "0.5",
+    //     max_iter_cross_assoc = "50",
+    //     tol_cross_assoc = "1e-10"
+    // )]
+    // #[staticmethod]
+    // #[pyo3(
+    //     text_signature = "(parameters, fmt_version, max_eta, max_iter_cross_assoc, tol_cross_assoc)"
+    // )]
+    // fn gc_pcsaft(
+    //     parameters: PyGcPcSaftFunctionalParameters,
+    //     fmt_version: FMTVersion,
+    //     max_eta: f64,
+    //     max_iter_cross_assoc: usize,
+    //     tol_cross_assoc: f64,
+    // ) -> Self {
+    //     let options = GcPcSaftOptions {
+    //         max_eta,
+    //         max_iter_cross_assoc,
+    //         tol_cross_assoc,
+    //     };
+    //     Self(Rc::new(
+    //         GcPcSaftFunctional::with_options(parameters.0, fmt_version, options).into(),
+    //     ))
+    // }
 
-    /// PeTS Helmholtz energy functional without simplifications
-    /// for pure components.
-    ///
-    /// Parameters
-    /// ----------
-    /// parameters: PetsParameters
-    ///     The set of PeTS parameters.
-    /// fmt_version: FMTVersion, optional
-    ///     The specific variant of the FMT term. Defaults to FMTVersion.WhiteBear
-    /// max_eta : float, optional
-    ///     Maximum packing fraction. Defaults to 0.5.
-    ///
-    /// Returns
-    /// -------
-    /// Functional
-    #[args(fmt_version = "FMTVersion::WhiteBear", max_eta = "0.5")]
-    #[staticmethod]
-    #[pyo3(text_signature = "(parameters, fmt_version, max_eta)")]
-    fn pets(parameters: PyPetsParameters, fmt_version: FMTVersion, max_eta: f64) -> Self {
-        let options = PetsOptions { max_eta };
-        Self(Rc::new(
-            PetsFunctional::with_options(parameters.0, fmt_version, options).into(),
-        ))
-    }
+    // /// PeTS Helmholtz energy functional without simplifications
+    // /// for pure components.
+    // ///
+    // /// Parameters
+    // /// ----------
+    // /// parameters: PetsParameters
+    // ///     The set of PeTS parameters.
+    // /// fmt_version: FMTVersion, optional
+    // ///     The specific variant of the FMT term. Defaults to FMTVersion.WhiteBear
+    // /// max_eta : float, optional
+    // ///     Maximum packing fraction. Defaults to 0.5.
+    // ///
+    // /// Returns
+    // /// -------
+    // /// Functional
+    // #[args(fmt_version = "FMTVersion::WhiteBear", max_eta = "0.5")]
+    // #[staticmethod]
+    // #[pyo3(text_signature = "(parameters, fmt_version, max_eta)")]
+    // fn pets(parameters: PyPetsParameters, fmt_version: FMTVersion, max_eta: f64) -> Self {
+    //     let options = PetsOptions { max_eta };
+    //     Self(Rc::new(
+    //         PetsFunctional::with_options(parameters.0, fmt_version, options).into(),
+    //     ))
+    // }
 
     /// Helmholtz energy functional for hard sphere systems.
     ///
@@ -313,6 +341,7 @@ impl_adsorption!(FunctionalVariant, PyFunctionalVariant);
 impl_pair_correlation!(FunctionalVariant);
 impl_solvation_profile!(FunctionalVariant);
 
+#[cfg(feature = "fit")]
 impl_estimator!(DFT<FunctionalVariant>, PyFunctionalVariant);
 
 #[pymodule]
@@ -338,9 +367,13 @@ pub fn dft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyDFTSolver>()?;
     m.add_class::<PySolvationProfile>()?;
 
-    m.add_wrapped(wrap_pymodule!(estimator_dft))
+    #[cfg(feature = "fit")]
+    m.add_wrapped(wrap_pymodule!(estimator_dft))?;
+
+    Ok(())
 }
 
+#[cfg(feature = "fit")]
 #[pymodule]
 pub fn estimator_dft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyDataSet>()?;

--- a/src/python/eos.rs
+++ b/src/python/eos.rs
@@ -1,23 +1,31 @@
+#[cfg(feature = "fit")]
+use crate::fit::*;
+#[cfg(feature = "fit")]
+use crate::impl_estimator;
+#[cfg(all(feature = "fit", feature = "pcsaft"))]
+use crate::impl_estimator_entropy_scaling;
 use feos_core::cubic::PengRobinson;
 use feos_core::python::cubic::PyPengRobinsonParameters;
 use feos_core::python::user_defined::PyEoSObj;
 use feos_core::*;
-use feos_estimator::*;
-use feos_fcsaft::python::PyFcSaftParameters;
-use feos_fcsaft::{FcSaft, FcSaftOptions};
-use feos_gc_pcsaft::python::PyGcPcSaftEosParameters;
-use feos_gc_pcsaft::{GcPcSaft, GcPcSaftOptions};
-use feos_pcsaft::python::PyPcSaftParameters;
-use feos_pcsaft::{PcSaft, PcSaftOptions};
-use feos_pets::python::PyPetsParameters;
-use feos_pets::{Pets, PetsOptions};
-use feos_uvtheory::python::PyUVParameters;
-use feos_uvtheory::{Perturbation, UVTheory, UVTheoryOptions};
+// use feos_fcsaft::python::PyFcSaftParameters;
+// use feos_fcsaft::{FcSaft, FcSaftOptions};
+// use feos_gc_pcsaft::python::PyGcPcSaftEosParameters;
+// use feos_gc_pcsaft::{GcPcSaft, GcPcSaftOptions};
+#[cfg(feature = "pcsaft")]
+use crate::pcsaft::python::PyPcSaftParameters;
+#[cfg(feature = "pcsaft")]
+use crate::pcsaft::{PcSaft, PcSaftOptions};
+// use feos_pets::python::PyPetsParameters;
+// use feos_pets::{Pets, PetsOptions};
+// use feos_uvtheory::python::PyUVParameters;
+// use feos_uvtheory::{Perturbation, UVTheory, UVTheoryOptions};
 use ndarray::Array1;
 use numpy::convert::ToPyArray;
 use numpy::{PyArray1, PyArray2};
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
+#[cfg(feature = "fit")]
 use pyo3::wrap_pymodule;
 use quantity::python::*;
 use quantity::si::*;
@@ -25,72 +33,79 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 pub enum EosVariant {
+    #[cfg(feature = "pcsaft")]
     PcSaft(PcSaft),
-    GcPcSaft(GcPcSaft),
-    FcSaft(FcSaft),
+    // GcPcSaft(GcPcSaft),
+    // FcSaft(FcSaft),
     PengRobinson(PengRobinson),
     Python(PyEoSObj),
-    Pets(Pets),
-    UVTheory(UVTheory),
+    // Pets(Pets),
+    // UVTheory(UVTheory),
 }
 
 impl EquationOfState for EosVariant {
     fn components(&self) -> usize {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.components(),
-            EosVariant::GcPcSaft(eos) => eos.components(),
-            EosVariant::FcSaft(eos) => eos.components(),
+            // EosVariant::GcPcSaft(eos) => eos.components(),
+            // EosVariant::FcSaft(eos) => eos.components(),
             EosVariant::PengRobinson(eos) => eos.components(),
             EosVariant::Python(eos) => eos.components(),
-            EosVariant::Pets(eos) => eos.components(),
-            EosVariant::UVTheory(eos) => eos.components(),
+            // EosVariant::Pets(eos) => eos.components(),
+            // EosVariant::UVTheory(eos) => eos.components(),
         }
     }
 
     fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.compute_max_density(moles),
-            EosVariant::GcPcSaft(eos) => eos.compute_max_density(moles),
-            EosVariant::FcSaft(eos) => eos.compute_max_density(moles),
+            // EosVariant::GcPcSaft(eos) => eos.compute_max_density(moles),
+            // EosVariant::FcSaft(eos) => eos.compute_max_density(moles),
             EosVariant::PengRobinson(eos) => eos.compute_max_density(moles),
             EosVariant::Python(eos) => eos.compute_max_density(moles),
-            EosVariant::Pets(eos) => eos.compute_max_density(moles),
-            EosVariant::UVTheory(eos) => eos.compute_max_density(moles),
+            // EosVariant::Pets(eos) => eos.compute_max_density(moles),
+            // EosVariant::UVTheory(eos) => eos.compute_max_density(moles),
         }
     }
 
     fn subset(&self, component_list: &[usize]) -> Self {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => Self::PcSaft(eos.subset(component_list)),
-            EosVariant::GcPcSaft(eos) => Self::GcPcSaft(eos.subset(component_list)),
-            EosVariant::FcSaft(eos) => Self::FcSaft(eos.subset(component_list)),
+            // EosVariant::GcPcSaft(eos) => Self::GcPcSaft(eos.subset(component_list)),
+            // EosVariant::FcSaft(eos) => Self::FcSaft(eos.subset(component_list)),
             EosVariant::PengRobinson(eos) => Self::PengRobinson(eos.subset(component_list)),
             EosVariant::Python(eos) => Self::Python(eos.subset(component_list)),
-            EosVariant::Pets(eos) => Self::Pets(eos.subset(component_list)),
-            EosVariant::UVTheory(eos) => Self::UVTheory(eos.subset(component_list)),
+            // EosVariant::Pets(eos) => Self::Pets(eos.subset(component_list)),
+            // EosVariant::UVTheory(eos) => Self::UVTheory(eos.subset(component_list)),
         }
     }
 
     fn residual(&self) -> &[Box<dyn HelmholtzEnergy>] {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.residual(),
-            EosVariant::GcPcSaft(eos) => eos.residual(),
-            EosVariant::FcSaft(eos) => eos.residual(),
+            //     EosVariant::GcPcSaft(eos) => eos.residual(),
+            //     EosVariant::FcSaft(eos) => eos.residual(),
             EosVariant::PengRobinson(eos) => eos.residual(),
             EosVariant::Python(eos) => eos.residual(),
-            EosVariant::Pets(eos) => eos.residual(),
-            EosVariant::UVTheory(eos) => eos.residual(),
+            //     EosVariant::Pets(eos) => eos.residual(),
+            //     EosVariant::UVTheory(eos) => eos.residual(),
         }
     }
 
     fn ideal_gas(&self) -> &dyn IdealGasContribution {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.ideal_gas(),
-            EosVariant::GcPcSaft(eos) => eos.ideal_gas(),
+            // EosVariant::GcPcSaft(eos) => eos.ideal_gas(),
+            // EosVariant::FcSaft(eos) => eos.ideal_gas(),
             EosVariant::PengRobinson(eos) => eos.ideal_gas(),
             EosVariant::Python(eos) => eos.ideal_gas(),
-            EosVariant::Pets(eos) => eos.ideal_gas(),
-            EosVariant::UVTheory(eos) => eos.ideal_gas(),
+            // EosVariant::Pets(eos) => eos.ideal_gas(),
+            // EosVariant::UVTheory(eos) => eos.ideal_gas(),
         }
     }
 }
@@ -98,17 +113,18 @@ impl EquationOfState for EosVariant {
 impl MolarWeight<SIUnit> for EosVariant {
     fn molar_weight(&self) -> SIArray1 {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.molar_weight(),
-            EosVariant::GcPcSaft(eos) => eos.molar_weight(),
-            EosVariant::FcSaft(eos) => eos.molar_weight(),
+            // EosVariant::GcPcSaft(eos) => eos.molar_weight(),
+            // EosVariant::FcSaft(eos) => eos.molar_weight(),
             EosVariant::PengRobinson(eos) => eos.molar_weight(),
             EosVariant::Python(eos) => eos.molar_weight(),
-            EosVariant::Pets(eos) => eos.molar_weight(),
-            _ => unimplemented!(),
+            // EosVariant::Pets(eos) => eos.molar_weight(),
         }
     }
 }
 
+#[cfg(feature = "pcsaft")]
 impl EntropyScaling<SIUnit> for EosVariant {
     fn viscosity_reference(
         &self,
@@ -117,6 +133,7 @@ impl EntropyScaling<SIUnit> for EosVariant {
         moles: &SIArray1,
     ) -> EosResult<SINumber> {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.viscosity_reference(temperature, volume, moles),
             _ => unimplemented!(),
         }
@@ -124,6 +141,7 @@ impl EntropyScaling<SIUnit> for EosVariant {
 
     fn viscosity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64> {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.viscosity_correlation(s_res, x),
             _ => unimplemented!(),
         }
@@ -136,6 +154,7 @@ impl EntropyScaling<SIUnit> for EosVariant {
         moles: &SIArray1,
     ) -> EosResult<SINumber> {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.diffusion_reference(temperature, volume, moles),
             _ => unimplemented!(),
         }
@@ -143,6 +162,7 @@ impl EntropyScaling<SIUnit> for EosVariant {
 
     fn diffusion_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64> {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.diffusion_correlation(s_res, x),
             _ => unimplemented!(),
         }
@@ -155,6 +175,7 @@ impl EntropyScaling<SIUnit> for EosVariant {
         moles: &SIArray1,
     ) -> EosResult<SINumber> {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => {
                 eos.thermal_conductivity_reference(temperature, volume, moles)
             }
@@ -164,6 +185,7 @@ impl EntropyScaling<SIUnit> for EosVariant {
 
     fn thermal_conductivity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64> {
         match self {
+            #[cfg(feature = "pcsaft")]
             EosVariant::PcSaft(eos) => eos.thermal_conductivity_correlation(s_res, x),
             _ => unimplemented!(),
         }
@@ -196,6 +218,7 @@ impl PyEosVariant {
     /// EquationOfState
     ///     The PC-SAFT equation of state that can be used to compute thermodynamic
     ///     states.
+    #[cfg(feature = "pcsaft")]
     #[args(
         max_eta = "0.5",
         max_iter_cross_assoc = "50",
@@ -225,75 +248,75 @@ impl PyEosVariant {
         ))))
     }
 
-    /// Initialize the (heterosegmented) group contribution PC-SAFT equation of state.
-    ///
-    /// Parameters
-    /// ----------
-    /// parameters : GcPcSaftEosParameters
-    ///     The parameters of the PC-Saft equation of state to use.
-    /// max_eta : float, optional
-    ///     Maximum packing fraction. Defaults to 0.5.
-    /// max_iter_cross_assoc : unsigned integer, optional
-    ///     Maximum number of iterations for cross association. Defaults to 50.
-    /// tol_cross_assoc : float
-    ///     Tolerance for convergence of cross association. Defaults to 1e-10.
-    ///
-    /// Returns
-    /// -------
-    /// EquationOfState
-    ///     The gc-PC-SAFT equation of state that can be used to compute thermodynamic
-    ///     states.
-    #[args(
-        max_eta = "0.5",
-        max_iter_cross_assoc = "50",
-        tol_cross_assoc = "1e-10"
-    )]
-    #[staticmethod]
-    #[pyo3(text_signature = "(parameters, max_eta, max_iter_cross_assoc, tol_cross_assoc)")]
-    pub fn gc_pcsaft(
-        parameters: PyGcPcSaftEosParameters,
-        max_eta: f64,
-        max_iter_cross_assoc: usize,
-        tol_cross_assoc: f64,
-    ) -> Self {
-        let options = GcPcSaftOptions {
-            max_eta,
-            max_iter_cross_assoc,
-            tol_cross_assoc,
-        };
-        Self(Rc::new(EosVariant::GcPcSaft(GcPcSaft::with_options(
-            parameters.0,
-            options,
-        ))))
-    }
+    // /// Initialize the (heterosegmented) group contribution PC-SAFT equation of state.
+    // ///
+    // /// Parameters
+    // /// ----------
+    // /// parameters : GcPcSaftEosParameters
+    // ///     The parameters of the PC-Saft equation of state to use.
+    // /// max_eta : float, optional
+    // ///     Maximum packing fraction. Defaults to 0.5.
+    // /// max_iter_cross_assoc : unsigned integer, optional
+    // ///     Maximum number of iterations for cross association. Defaults to 50.
+    // /// tol_cross_assoc : float
+    // ///     Tolerance for convergence of cross association. Defaults to 1e-10.
+    // ///
+    // /// Returns
+    // /// -------
+    // /// EquationOfState
+    // ///     The gc-PC-SAFT equation of state that can be used to compute thermodynamic
+    // ///     states.
+    // #[args(
+    //     max_eta = "0.5",
+    //     max_iter_cross_assoc = "50",
+    //     tol_cross_assoc = "1e-10"
+    // )]
+    // #[staticmethod]
+    // #[pyo3(text_signature = "(parameters, max_eta, max_iter_cross_assoc, tol_cross_assoc)")]
+    // pub fn gc_pcsaft(
+    //     parameters: PyGcPcSaftEosParameters,
+    //     max_eta: f64,
+    //     max_iter_cross_assoc: usize,
+    //     tol_cross_assoc: f64,
+    // ) -> Self {
+    //     let options = GcPcSaftOptions {
+    //         max_eta,
+    //         max_iter_cross_assoc,
+    //         tol_cross_assoc,
+    //     };
+    //     Self(Rc::new(EosVariant::GcPcSaft(GcPcSaft::with_options(
+    //         parameters.0,
+    //         options,
+    //     ))))
+    // }
 
-    #[args(
-        max_eta = "0.5",
-        max_iter_cross_assoc = "50",
-        tol_cross_assoc = "1e-10"
-    )]
-    #[staticmethod]
-    #[pyo3(
-        text_signature = "(parameters, max_eta, max_iter_cross_assoc, tol_cross_assoc, model_params=None)"
-    )]
-    fn fcsaft(
-        parameters: PyFcSaftParameters,
-        max_eta: f64,
-        max_iter_cross_assoc: usize,
-        tol_cross_assoc: f64,
-        model_params: Option<[[f64; 7]; 4]>,
-    ) -> Self {
-        let options = FcSaftOptions {
-            max_eta,
-            max_iter_cross_assoc,
-            tol_cross_assoc,
-        };
-        Self(Rc::new(EosVariant::FcSaft(FcSaft::with_options(
-            parameters.0,
-            options,
-            model_params,
-        ))))
-    }
+    // #[args(
+    //     max_eta = "0.5",
+    //     max_iter_cross_assoc = "50",
+    //     tol_cross_assoc = "1e-10"
+    // )]
+    // #[staticmethod]
+    // #[pyo3(
+    //     text_signature = "(parameters, max_eta, max_iter_cross_assoc, tol_cross_assoc, model_params=None)"
+    // )]
+    // fn fcsaft(
+    //     parameters: PyFcSaftParameters,
+    //     max_eta: f64,
+    //     max_iter_cross_assoc: usize,
+    //     tol_cross_assoc: f64,
+    //     model_params: Option<[[f64; 7]; 4]>,
+    // ) -> Self {
+    //     let options = FcSaftOptions {
+    //         max_eta,
+    //         max_iter_cross_assoc,
+    //         tol_cross_assoc,
+    //     };
+    //     Self(Rc::new(EosVariant::FcSaft(FcSaft::with_options(
+    //         parameters.0,
+    //         options,
+    //         model_params,
+    //     ))))
+    // }
 
     /// Peng-Robinson equation of state.
     ///
@@ -332,69 +355,72 @@ impl PyEosVariant {
         Ok(Self(Rc::new(EosVariant::Python(PyEoSObj::new(obj)?))))
     }
 
-    /// PeTS equation of state.
-    ///
-    /// Parameters
-    /// ----------
-    /// parameters : PetsParameters
-    ///     The parameters of the PeTS equation of state to use.
-    /// max_eta : float, optional
-    ///     Maximum packing fraction. Defaults to 0.5.
-    ///
-    /// Returns
-    /// -------
-    /// EquationOfState
-    ///     The PeTS equation of state that can be used to compute thermodynamic
-    ///     states.
-    #[args(max_eta = "0.5")]
-    #[staticmethod]
-    #[pyo3(text_signature = "(parameters, max_eta)")]
-    fn pets(parameters: PyPetsParameters, max_eta: f64) -> Self {
-        let options = PetsOptions { max_eta };
-        Self(Rc::new(EosVariant::Pets(Pets::with_options(
-            parameters.0,
-            options,
-        ))))
-    }
+    // /// PeTS equation of state.
+    // ///
+    // /// Parameters
+    // /// ----------
+    // /// parameters : PetsParameters
+    // ///     The parameters of the PeTS equation of state to use.
+    // /// max_eta : float, optional
+    // ///     Maximum packing fraction. Defaults to 0.5.
+    // ///
+    // /// Returns
+    // /// -------
+    // /// EquationOfState
+    // ///     The PeTS equation of state that can be used to compute thermodynamic
+    // ///     states.
+    // #[args(max_eta = "0.5")]
+    // #[staticmethod]
+    // #[pyo3(text_signature = "(parameters, max_eta)")]
+    // fn pets(parameters: PyPetsParameters, max_eta: f64) -> Self {
+    //     let options = PetsOptions { max_eta };
+    //     Self(Rc::new(EosVariant::Pets(Pets::with_options(
+    //         parameters.0,
+    //         options,
+    //     ))))
+    // }
 
-    /// UV-Theory equation of state.
-    ///
-    /// Parameters
-    /// ----------
-    /// parameters : PetsParameters
-    ///     The parameters of the PeTS equation of state to use.
-    /// max_eta : float, optional
-    ///     Maximum packing fraction. Defaults to 0.5.
-    /// perturbation : Perturbation, optional
-    ///
-    /// Returns
-    /// -------
-    /// EquationOfState
-    ///     The UV-Theory equation of state that can be used to compute thermodynamic
-    ///     states.
-    #[args(max_eta = "0.5", perturbation = "Perturbation::WeeksChandlerAndersen")]
-    #[staticmethod]
-    #[pyo3(text_signature = "(parameters, max_eta, perturbation)")]
-    fn uvtheory(parameters: PyUVParameters, max_eta: f64, perturbation: Perturbation) -> Self {
-        let options = UVTheoryOptions {
-            max_eta,
-            perturbation,
-        };
-        Self(Rc::new(EosVariant::UVTheory(UVTheory::with_options(
-            parameters.0,
-            options,
-        ))))
-    }
+    // /// UV-Theory equation of state.
+    // ///
+    // /// Parameters
+    // /// ----------
+    // /// parameters : PetsParameters
+    // ///     The parameters of the PeTS equation of state to use.
+    // /// max_eta : float, optional
+    // ///     Maximum packing fraction. Defaults to 0.5.
+    // /// perturbation : Perturbation, optional
+    // ///
+    // /// Returns
+    // /// -------
+    // /// EquationOfState
+    // ///     The UV-Theory equation of state that can be used to compute thermodynamic
+    // ///     states.
+    // #[args(max_eta = "0.5", perturbation = "Perturbation::WeeksChandlerAndersen")]
+    // #[staticmethod]
+    // #[pyo3(text_signature = "(parameters, max_eta, perturbation)")]
+    // fn uvtheory(parameters: PyUVParameters, max_eta: f64, perturbation: Perturbation) -> Self {
+    //     let options = UVTheoryOptions {
+    //         max_eta,
+    //         perturbation,
+    //     };
+    //     Self(Rc::new(EosVariant::UVTheory(UVTheory::with_options(
+    //         parameters.0,
+    //         options,
+    //     ))))
+    // }
 }
 
 impl_equation_of_state!(PyEosVariant);
 impl_virial_coefficients!(PyEosVariant);
 impl_state!(EosVariant, PyEosVariant);
 impl_state_molarweight!(EosVariant, PyEosVariant);
+#[cfg(feature = "pcsaft")]
 impl_state_entropy_scaling!(EosVariant, PyEosVariant);
 impl_phase_equilibrium!(EosVariant, PyEosVariant);
 
+#[cfg(feature = "fit")]
 impl_estimator!(EosVariant, PyEosVariant);
+#[cfg(all(feature = "fit", feature = "pcsaft"))]
 impl_estimator_entropy_scaling!(EosVariant, PyEosVariant);
 
 #[pymodule]
@@ -407,9 +433,13 @@ pub fn eos(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyPhaseDiagram>()?;
     m.add_class::<PyPhaseEquilibrium>()?;
 
-    m.add_wrapped(wrap_pymodule!(estimator_eos))
+    #[cfg(feature = "fit")]
+    m.add_wrapped(wrap_pymodule!(estimator_eos))?;
+
+    Ok(())
 }
 
+#[cfg(feature = "fit")]
 #[pymodule]
 pub fn estimator_eos(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyDataSet>()?;

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,0 +1,73 @@
+use crate::pcsaft::python::__PYO3_PYMODULE_DEF_PCSAFT;
+use pyo3::prelude::*;
+use pyo3::wrap_pymodule;
+use quantity::python::__PYO3_PYMODULE_DEF_QUANTITY;
+
+mod cubic;
+mod eos;
+use cubic::__PYO3_PYMODULE_DEF_CUBIC;
+use eos::__PYO3_PYMODULE_DEF_EOS;
+
+#[cfg(feature = "dft")]
+mod dft;
+#[cfg(feature = "dft")]
+use dft::__PYO3_PYMODULE_DEF_DFT;
+
+#[pymodule]
+pub fn feos(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_wrapped(wrap_pymodule!(quantity))?;
+    m.add_wrapped(wrap_pymodule!(eos))?;
+    #[cfg(feature = "dft")]
+    m.add_wrapped(wrap_pymodule!(dft))?;
+    m.add_wrapped(wrap_pymodule!(cubic))?;
+    #[cfg(feature = "pcsaft")]
+    m.add_wrapped(wrap_pymodule!(pcsaft))?;
+    // m.add_wrapped(wrap_pymodule!(gc_pcsaft))?;
+    // m.add_wrapped(wrap_pymodule!(fcsaft))?;
+    // m.add_wrapped(wrap_pymodule!(pets))?;
+    // m.add_wrapped(wrap_pymodule!(uvtheory))?;
+
+    set_path(py, m, "feos.si", "quantity")?;
+    set_path(py, m, "feos.eos", "eos")?;
+    #[cfg(feature = "fit")]
+    set_path(py, m, "feos.eos.estimator", "eos.estimator_eos")?;
+    #[cfg(feature = "dft")]
+    set_path(py, m, "feos.dft", "dft")?;
+    #[cfg(all(feature = "dft", feature = "fit"))]
+    set_path(py, m, "feos.dft.estimator", "dft.estimator_dft")?;
+    set_path(py, m, "feos.cubic", "cubic")?;
+    #[cfg(feature = "pcsaft")]
+    set_path(py, m, "feos.pcsaft", "pcsaft")?;
+    // set_path(py, m, "feos.gc_pcsaft", "gc_pcsaft")?;
+    // set_path(py, m, "feos.fcsaft", "fcsaft")?;
+    // set_path(py, m, "feos.pets", "pets")?;
+    // set_path(py, m, "feos.uvtheory", "uvtheory")?;
+
+    py.run(
+        "\
+import sys
+quantity.SINumber.__module__ = 'feos.si'
+quantity.SIArray1.__module__ = 'feos.si'
+quantity.SIArray2.__module__ = 'feos.si'
+quantity.SIArray3.__module__ = 'feos.si'
+quantity.SIArray4.__module__ = 'feos.si'
+    ",
+        None,
+        Some(m.dict()),
+    )?;
+    Ok(())
+}
+
+fn set_path(py: Python<'_>, m: &PyModule, path: &str, module: &str) -> PyResult<()> {
+    py.run(
+        &format!(
+            "\
+import sys
+sys.modules['{path}'] = {module}
+    "
+        ),
+        None,
+        Some(m.dict()),
+    )
+}


### PR DESCRIPTION
This PR thoroughly restructures the entire FeOs project.

`feos-core` and `feos-dft` are included as workspace members in `feos`. That means

- They keep their own version numbers/changelogs/documentations etc.
- They can (and will) still be published individually on crates.io.
- Development is facilitated significantly with them as workspace members without a reduction in compilation times.

Individual models (and also other tools like `feos-estimator`) are included as modules in `feos`

- Major releases for model crates are usually only required to fix breaking changes in `feos-core` and `feos-dft`. Therefore there is hardly any benefit to maintaining individual version numbers/changelogs.
- To keep compile times short during development, every model is hidden behind a feature.

Having all components in a single repository also results in a better overview over open issues and pull requests.