### PR TITLE
Make `binary_parameters` in `from_records` optional and replace unwrap with panic with message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Made binary parameters in `from_records` Python routine an `Option`. [#35](https://github.com/feos-org/feos/pull/35)
-- Added panic with message when parsing missing Identifiers variants. [#35](https://github.com/feos-org/feos/pull/35)
 
 ## [0.2.1] - 2022-05-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Made binary parameters in `from_records` Python routine an `Option`. [#35](https://github.com/feos-org/feos/pull/35)
+- Added panic with message when parsing missing Identifiers variants. [#35](https://github.com/feos-org/feos/pull/35)
 
 ## [0.2.1] - 2022-05-13
 ### Fixed

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Made binary parameters in `from_records` Python routine an `Option`. [#35](https://github.com/feos-org/feos/pull/35)
+- Added panic with message when parsing missing Identifiers variants. [#35](https://github.com/feos-org/feos/pull/35)
+
 ### Fixed
 - Avoid panicking when calculating `ResidualNpt` properties of states with negative pressures. [#42](https://github.com/feos-org/feos/pull/42)
 

--- a/feos-core/src/parameter/mod.rs
+++ b/feos-core/src/parameter/mod.rs
@@ -92,8 +92,20 @@ where
         };
         let n = pure_records.len();
         Array2::from_shape_fn([n, n], |(i, j)| {
-            let id1 = pure_records[i].identifier.as_string(search_option).unwrap();
-            let id2 = pure_records[j].identifier.as_string(search_option).unwrap();
+            let id1 = pure_records[i]
+                .identifier
+                .as_string(search_option)
+                .expect(&format!(
+                    "No identifier for given search_option for pure record {}.",
+                    i
+                ));
+            let id2 = pure_records[j]
+                .identifier
+                .as_string(search_option)
+                .expect(&format!(
+                    "No identifier for given search_option for pure record {}.",
+                    j
+                ));
             binary_map
                 .get(&(id1.clone(), id2.clone()))
                 .or_else(|| binary_map.get(&(id2, id1)))

--- a/feos-core/src/python/cubic.rs
+++ b/feos-core/src/python/cubic.rs
@@ -6,6 +6,7 @@ use crate::parameter::{
 use crate::python::joback::PyJobackRecord;
 use crate::python::parameter::PyIdentifier;
 use crate::*;
+use ndarray::Array2;
 use numpy::PyReadonlyArray2;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;

--- a/src/gc_pcsaft/dft/parameter.rs
+++ b/src/gc_pcsaft/dft/parameter.rs
@@ -8,7 +8,6 @@ use indexmap::IndexMap;
 use ndarray::{Array1, Array2};
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{Graph, UnGraph};
-use std::fmt::Write;
 
 /// psi Parameter for heterosegmented DFT (Mairhofer2018)
 const PSI_GC_DFT: f64 = 1.5357;

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -8,6 +8,7 @@ use feos_core::parameter::{
 use feos_core::python::joback::PyJobackRecord;
 use feos_core::python::parameter::*;
 use feos_core::*;
+use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;


### PR DESCRIPTION
Fixes #28 

- Made binary parameters in `from_records` python routine an `Option`. 
- added panic with message when parsing missing `Identifiers` variants.