### PR TITLE
Speed up DFT calculations with vector dual numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ inherits = "release"
 lto = true
 
 [features]
-default = ["pcsaft", "dft"]
+default = []
 dft = ["feos-dft", "petgraph"]
 estimator = []
 association = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ inherits = "release"
 lto = true
 
 [features]
-default = []
+default = ["pcsaft", "dft"]
 dft = ["feos-dft", "petgraph"]
 estimator = []
 association = []

--- a/feos-derive/src/functional_contribution.rs
+++ b/feos-derive/src/functional_contribution.rs
@@ -6,7 +6,7 @@ pub(crate) fn expand_functional_contribution(input: DeriveInput) -> proc_macro2:
         .attrs
         .iter()
         .find(|a| a.path.segments.len() == 1 && a.path.segments[0].ident == "max_size")
-        .expect("max_size attribute required for deriving MyTrait!");
+        .expect("max_size attribute required for deriving FunctionalContribution!");
     let max_size: proc_macro2::Literal = max_size
         .parse_args()
         .expect("max_size has to be an integer literal!");
@@ -14,12 +14,7 @@ pub(crate) fn expand_functional_contribution(input: DeriveInput) -> proc_macro2:
         .to_string()
         .parse()
         .expect("max_size has to be an integer literal!");
-    let functional_derivative = impl_functional_derivative(&input, max_size);
-    let functional_derivative_helpers = impl_functional_derivative_helpers(&input);
-    quote! {
-        #functional_derivative
-        #functional_derivative_helpers
-    }
+    impl_functional_derivative(&input, max_size)
 }
 
 fn impl_functional_derivative(input: &DeriveInput, max_size: usize) -> proc_macro2::TokenStream {
@@ -37,7 +32,8 @@ fn impl_functional_derivative(input: &DeriveInput, max_size: usize) -> proc_macr
                 first_partial_derivative: ArrayViewMut2<f64>,
             ) -> EosResult<()> {
                 match weighted_densities.shape()[0] {
-                    #(#components => self.first_partial_derivatives_n::<#components>(
+                    #(#components => <Self as PartialDerivativesDual<#components>>::first_partial_derivatives_n(
+                        &self,
                         temperature,
                         weighted_densities,
                         helmholtz_energy_density,
@@ -61,7 +57,8 @@ fn impl_functional_derivative(input: &DeriveInput, max_size: usize) -> proc_macr
                 second_partial_derivative: ArrayViewMut3<f64>,
             ) -> EosResult<()> {
                 match weighted_densities.shape()[0] {
-                    #(#components => self.second_partial_derivatives_n::<#components>(
+                    #(#components => <Self as PartialDerivativesDual<#components>>::second_partial_derivatives_n(
+                        &self,
                         temperature,
                         weighted_densities,
                         helmholtz_energy_density,
@@ -76,137 +73,6 @@ fn impl_functional_derivative(input: &DeriveInput, max_size: usize) -> proc_macr
                         second_partial_derivative,
                     ),
                 }
-            }
-        }
-    }
-}
-
-fn impl_functional_derivative_helpers(input: &DeriveInput) -> proc_macro2::TokenStream {
-    let name = &input.ident;
-    let generics = &input.generics;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    quote! {
-        impl #impl_generics #name #ty_generics #where_clause {
-            fn first_partial_derivatives_n<const N: usize>(
-                &self,
-                temperature: f64,
-                weighted_densities: Array2<f64>,
-                mut helmholtz_energy_density: ArrayViewMut1<f64>,
-                mut first_partial_derivative: ArrayViewMut2<f64>,
-            ) -> EosResult<()> {
-                let t = DualVec64::<N>::from(temperature);
-                let mut wd = weighted_densities.mapv(DualVec64::<N>::from);
-                for i in 0..N {
-                    wd.index_axis_mut(Axis(0), i)
-                        .map_inplace(|x| x.eps[i] = 1.0);
-                }
-                let phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
-                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
-                for i in 0..N {
-                    first_partial_derivative
-                        .index_axis_mut(Axis(0), i)
-                        .assign(&phi.mapv(|p| p.eps[i]));
-                }
-
-                Ok(())
-            }
-
-            fn second_partial_derivatives_n<const N: usize>(
-                &self,
-                temperature: f64,
-                weighted_densities: Array2<f64>,
-                mut helmholtz_energy_density: ArrayViewMut1<f64>,
-                mut first_partial_derivative: ArrayViewMut2<f64>,
-                mut second_partial_derivative: ArrayViewMut3<f64>,
-            ) -> EosResult<()> {
-                let t = Dual2Vec64::<N>::from(temperature);
-                let mut wd = weighted_densities.mapv(Dual2Vec64::<N>::from);
-                for i in 0..N {
-                    wd.index_axis_mut(Axis(0), i).map_inplace(|x| x.v1[i] = 1.0);
-                }
-                let phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
-                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
-                for i in 0..N {
-                    first_partial_derivative
-                        .index_axis_mut(Axis(0), i)
-                        .assign(&phi.mapv(|p| p.v1[i]));
-                    for j in 0..N {
-                        second_partial_derivative
-                            .index_axis_mut(Axis(0), i)
-                            .index_axis_mut(Axis(0), j)
-                            .assign(&phi.mapv(|p| p.v2[(i, j)]));
-                    }
-                }
-
-                Ok(())
-            }
-
-            fn first_partial_derivatives_dyn(
-                &self,
-                temperature: f64,
-                weighted_densities: Array2<f64>,
-                mut helmholtz_energy_density: ArrayViewMut1<f64>,
-                mut first_partial_derivative: ArrayViewMut2<f64>,
-            ) -> EosResult<()> {
-                let mut wd = weighted_densities.mapv(Dual64::from);
-                let t = Dual64::from(temperature);
-                let mut phi = Array::zeros(weighted_densities.raw_dim().remove_axis(Axis(0)));
-
-                for i in 0..wd.shape()[0] {
-                    wd.index_axis_mut(Axis(0), i)
-                        .map_inplace(|x| x.eps[0] = 1.0);
-                    phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
-                    first_partial_derivative
-                        .index_axis_mut(Axis(0), i)
-                        .assign(&phi.mapv(|p| p.eps[0]));
-                    wd.index_axis_mut(Axis(0), i)
-                        .map_inplace(|x| x.eps[0] = 0.0);
-                }
-                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
-                Ok(())
-            }
-
-            fn second_partial_derivatives_dyn(
-                &self,
-                temperature: f64,
-                weighted_densities: Array2<f64>,
-                mut helmholtz_energy_density: ArrayViewMut1<f64>,
-                mut first_partial_derivative: ArrayViewMut2<f64>,
-                mut second_partial_derivative: ArrayViewMut3<f64>,
-            ) -> EosResult<()> {
-                let mut wd = weighted_densities.mapv(HyperDual64::from);
-                let t = HyperDual64::from(temperature);
-                let mut phi = Array::zeros(weighted_densities.raw_dim().remove_axis(Axis(0)));
-
-                for i in 0..wd.shape()[0] {
-                    wd.index_axis_mut(Axis(0), i)
-                        .map_inplace(|x| x.eps1[0] = 1.0);
-                    for j in 0..=i {
-                        wd.index_axis_mut(Axis(0), j)
-                            .map_inplace(|x| x.eps2[0] = 1.0);
-                        phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
-                        let p = phi.mapv(|p| p.eps1eps2[(0, 0)]);
-                        second_partial_derivative
-                            .index_axis_mut(Axis(0), i)
-                            .index_axis_mut(Axis(0), j)
-                            .assign(&p);
-                        if i != j {
-                            second_partial_derivative
-                                .index_axis_mut(Axis(0), j)
-                                .index_axis_mut(Axis(0), i)
-                                .assign(&p);
-                        }
-                        wd.index_axis_mut(Axis(0), j)
-                            .map_inplace(|x| x.eps2[0] = 0.0);
-                    }
-                    first_partial_derivative
-                        .index_axis_mut(Axis(0), i)
-                        .assign(&phi.mapv(|p| p.eps1[0]));
-                    wd.index_axis_mut(Axis(0), i)
-                        .map_inplace(|x| x.eps1[0] = 0.0);
-                }
-                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
-                Ok(())
             }
         }
     }

--- a/feos-derive/src/functional_contribution.rs
+++ b/feos-derive/src/functional_contribution.rs
@@ -1,0 +1,213 @@
+use quote::quote;
+use syn::DeriveInput;
+
+pub(crate) fn expand_functional_contribution(input: DeriveInput) -> proc_macro2::TokenStream {
+    let max_size = input
+        .attrs
+        .iter()
+        .find(|a| a.path.segments.len() == 1 && a.path.segments[0].ident == "max_size")
+        .expect("max_size attribute required for deriving MyTrait!");
+    let max_size: proc_macro2::Literal = max_size
+        .parse_args()
+        .expect("max_size has to be an integer literal!");
+    let max_size = max_size
+        .to_string()
+        .parse()
+        .expect("max_size has to be an integer literal!");
+    let functional_derivative = impl_functional_derivative(&input, max_size);
+    let functional_derivative_helpers = impl_functional_derivative_helpers(&input);
+    quote! {
+        #functional_derivative
+        #functional_derivative_helpers
+    }
+}
+
+fn impl_functional_derivative(input: &DeriveInput, max_size: usize) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let components: Vec<_> = (1..=max_size).collect();
+    quote! {
+        impl #impl_generics FunctionalContribution for #name #ty_generics #where_clause {
+            fn first_partial_derivatives(
+                &self,
+                temperature: f64,
+                weighted_densities: Array2<f64>,
+                helmholtz_energy_density: ArrayViewMut1<f64>,
+                first_partial_derivative: ArrayViewMut2<f64>,
+            ) -> EosResult<()> {
+                match weighted_densities.shape()[0] {
+                    #(#components => self.first_partial_derivatives_n::<#components>(
+                        temperature,
+                        weighted_densities,
+                        helmholtz_energy_density,
+                        first_partial_derivative,
+                    ),)*
+                    n => self.first_partial_derivatives_dyn(
+                        temperature,
+                        weighted_densities,
+                        helmholtz_energy_density,
+                        first_partial_derivative,
+                    ),
+                }
+            }
+
+            fn second_partial_derivatives(
+                &self,
+                temperature: f64,
+                weighted_densities: Array2<f64>,
+                helmholtz_energy_density: ArrayViewMut1<f64>,
+                first_partial_derivative: ArrayViewMut2<f64>,
+                second_partial_derivative: ArrayViewMut3<f64>,
+            ) -> EosResult<()> {
+                match weighted_densities.shape()[0] {
+                    #(#components => self.second_partial_derivatives_n::<#components>(
+                        temperature,
+                        weighted_densities,
+                        helmholtz_energy_density,
+                        first_partial_derivative,
+                        second_partial_derivative,
+                    ),)*
+                    n => self.second_partial_derivatives_dyn(
+                        temperature,
+                        weighted_densities,
+                        helmholtz_energy_density,
+                        first_partial_derivative,
+                        second_partial_derivative,
+                    ),
+                }
+            }
+        }
+    }
+}
+
+fn impl_functional_derivative_helpers(input: &DeriveInput) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            fn first_partial_derivatives_n<const N: usize>(
+                &self,
+                temperature: f64,
+                weighted_densities: Array2<f64>,
+                mut helmholtz_energy_density: ArrayViewMut1<f64>,
+                mut first_partial_derivative: ArrayViewMut2<f64>,
+            ) -> EosResult<()> {
+                let t = DualVec64::<N>::from(temperature);
+                let mut wd = weighted_densities.mapv(DualVec64::<N>::from);
+                for i in 0..N {
+                    wd.index_axis_mut(Axis(0), i)
+                        .map_inplace(|x| x.eps[i] = 1.0);
+                }
+                let phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
+                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
+                for i in 0..N {
+                    first_partial_derivative
+                        .index_axis_mut(Axis(0), i)
+                        .assign(&phi.mapv(|p| p.eps[i]));
+                }
+
+                Ok(())
+            }
+
+            fn second_partial_derivatives_n<const N: usize>(
+                &self,
+                temperature: f64,
+                weighted_densities: Array2<f64>,
+                mut helmholtz_energy_density: ArrayViewMut1<f64>,
+                mut first_partial_derivative: ArrayViewMut2<f64>,
+                mut second_partial_derivative: ArrayViewMut3<f64>,
+            ) -> EosResult<()> {
+                let t = Dual2Vec64::<N>::from(temperature);
+                let mut wd = weighted_densities.mapv(Dual2Vec64::<N>::from);
+                for i in 0..N {
+                    wd.index_axis_mut(Axis(0), i).map_inplace(|x| x.v1[i] = 1.0);
+                }
+                let phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
+                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
+                for i in 0..N {
+                    first_partial_derivative
+                        .index_axis_mut(Axis(0), i)
+                        .assign(&phi.mapv(|p| p.v1[i]));
+                    for j in 0..N {
+                        second_partial_derivative
+                            .index_axis_mut(Axis(0), i)
+                            .index_axis_mut(Axis(0), j)
+                            .assign(&phi.mapv(|p| p.v2[(i, j)]));
+                    }
+                }
+
+                Ok(())
+            }
+
+            fn first_partial_derivatives_dyn(
+                &self,
+                temperature: f64,
+                weighted_densities: Array2<f64>,
+                mut helmholtz_energy_density: ArrayViewMut1<f64>,
+                mut first_partial_derivative: ArrayViewMut2<f64>,
+            ) -> EosResult<()> {
+                let mut wd = weighted_densities.mapv(Dual64::from);
+                let t = Dual64::from(temperature);
+                let mut phi = Array::zeros(weighted_densities.raw_dim().remove_axis(Axis(0)));
+
+                for i in 0..wd.shape()[0] {
+                    wd.index_axis_mut(Axis(0), i)
+                        .map_inplace(|x| x.eps[0] = 1.0);
+                    phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
+                    first_partial_derivative
+                        .index_axis_mut(Axis(0), i)
+                        .assign(&phi.mapv(|p| p.eps[0]));
+                    wd.index_axis_mut(Axis(0), i)
+                        .map_inplace(|x| x.eps[0] = 0.0);
+                }
+                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
+                Ok(())
+            }
+
+            fn second_partial_derivatives_dyn(
+                &self,
+                temperature: f64,
+                weighted_densities: Array2<f64>,
+                mut helmholtz_energy_density: ArrayViewMut1<f64>,
+                mut first_partial_derivative: ArrayViewMut2<f64>,
+                mut second_partial_derivative: ArrayViewMut3<f64>,
+            ) -> EosResult<()> {
+                let mut wd = weighted_densities.mapv(HyperDual64::from);
+                let t = HyperDual64::from(temperature);
+                let mut phi = Array::zeros(weighted_densities.raw_dim().remove_axis(Axis(0)));
+
+                for i in 0..wd.shape()[0] {
+                    wd.index_axis_mut(Axis(0), i)
+                        .map_inplace(|x| x.eps1[0] = 1.0);
+                    for j in 0..=i {
+                        wd.index_axis_mut(Axis(0), j)
+                            .map_inplace(|x| x.eps2[0] = 1.0);
+                        phi = self.calculate_helmholtz_energy_density(t, wd.view())?;
+                        let p = phi.mapv(|p| p.eps1eps2[(0, 0)]);
+                        second_partial_derivative
+                            .index_axis_mut(Axis(0), i)
+                            .index_axis_mut(Axis(0), j)
+                            .assign(&p);
+                        if i != j {
+                            second_partial_derivative
+                                .index_axis_mut(Axis(0), j)
+                                .index_axis_mut(Axis(0), i)
+                                .assign(&p);
+                        }
+                        wd.index_axis_mut(Axis(0), j)
+                            .map_inplace(|x| x.eps2[0] = 0.0);
+                    }
+                    first_partial_derivative
+                        .index_axis_mut(Axis(0), i)
+                        .assign(&phi.mapv(|p| p.eps1[0]));
+                    wd.index_axis_mut(Axis(0), i)
+                        .map_inplace(|x| x.eps1[0] = 0.0);
+                }
+                helmholtz_energy_density.assign(&phi.mapv(|p| p.re));
+                Ok(())
+            }
+        }
+    }
+}

--- a/feos-derive/src/functional_contribution.rs
+++ b/feos-derive/src/functional_contribution.rs
@@ -51,7 +51,7 @@ fn impl_functional_derivative(input: &DeriveInput, max_size: usize) -> proc_macr
             fn second_partial_derivatives(
                 &self,
                 temperature: f64,
-                weighted_densities: Array2<f64>,
+                weighted_densities: ArrayView2<f64>,
                 helmholtz_energy_density: ArrayViewMut1<f64>,
                 first_partial_derivative: ArrayViewMut2<f64>,
                 second_partial_derivative: ArrayViewMut3<f64>,

--- a/feos-derive/src/lib.rs
+++ b/feos-derive/src/lib.rs
@@ -3,11 +3,13 @@
 //! the boilerplate for the EquationOfState and HelmholtzEnergyFunctional traits.
 use dft::expand_helmholtz_energy_functional;
 use eos::expand_equation_of_state;
+use functional_contribution::expand_functional_contribution;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 mod dft;
 mod eos;
+mod functional_contribution;
 
 fn implement(name: &str, variant: &syn::Variant, opts: &[&'static str]) -> syn::Result<bool> {
     let syn::Variant { attrs, .. } = variant;
@@ -57,4 +59,10 @@ pub fn derive_helmholtz_energy_functional(input: TokenStream) -> TokenStream {
     expand_helmholtz_energy_functional(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
+}
+
+#[proc_macro_derive(FunctionalContribution, attributes(max_size))]
+pub fn derive_functional_contribution(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_functional_contribution(input).into()
 }

--- a/feos-dft/src/functional_contribution.rs
+++ b/feos-dft/src/functional_contribution.rs
@@ -98,7 +98,7 @@ pub trait FunctionalContribution:
     fn second_partial_derivatives(
         &self,
         temperature: f64,
-        weighted_densities: Array2<f64>,
+        weighted_densities: ArrayView2<f64>,
         helmholtz_energy_density: ArrayViewMut1<f64>,
         first_partial_derivative: ArrayViewMut2<f64>,
         second_partial_derivative: ArrayViewMut3<f64>,

--- a/feos-dft/src/functional_contribution.rs
+++ b/feos-dft/src/functional_contribution.rs
@@ -156,20 +156,20 @@ pub trait FunctionalContribution:
     }
 }
 
-impl<T> FunctionalContribution for T where
-    T: FunctionalContributionDual<f64>
-        + FunctionalContributionDual<Dual64>
-        + FunctionalContributionDual<Dual<DualVec64<3>, f64>>
-        + FunctionalContributionDual<HyperDual64>
-        + FunctionalContributionDual<Dual3_64>
-        + FunctionalContributionDual<HyperDual<Dual64, f64>>
-        + FunctionalContributionDual<HyperDual<DualVec64<2>, f64>>
-        + FunctionalContributionDual<HyperDual<DualVec64<3>, f64>>
-        + FunctionalContributionDual<Dual3<Dual64, f64>>
-        + FunctionalContributionDual<Dual3<DualVec64<2>, f64>>
-        + FunctionalContributionDual<Dual3<DualVec64<3>, f64>>
-        + Display
-        + Sync
-        + Send
-{
-}
+// impl<T> FunctionalContribution for T where
+//     T: FunctionalContributionDual<f64>
+//         + FunctionalContributionDual<Dual64>
+//         + FunctionalContributionDual<Dual<DualVec64<3>, f64>>
+//         + FunctionalContributionDual<HyperDual64>
+//         + FunctionalContributionDual<Dual3_64>
+//         + FunctionalContributionDual<HyperDual<Dual64, f64>>
+//         + FunctionalContributionDual<HyperDual<DualVec64<2>, f64>>
+//         + FunctionalContributionDual<HyperDual<DualVec64<3>, f64>>
+//         + FunctionalContributionDual<Dual3<Dual64, f64>>
+//         + FunctionalContributionDual<Dual3<DualVec64<2>, f64>>
+//         + FunctionalContributionDual<Dual3<DualVec64<3>, f64>>
+//         + Display
+//         + Sync
+//         + Send
+// {
+// }

--- a/feos-dft/src/functional_contribution.rs
+++ b/feos-dft/src/functional_contribution.rs
@@ -203,7 +203,7 @@ pub trait PartialDerivativesDual<const N: usize>:
     fn second_partial_derivatives_n(
         &self,
         temperature: f64,
-        weighted_densities: Array2<f64>,
+        weighted_densities: ArrayView2<f64>,
         mut helmholtz_energy_density: ArrayViewMut1<f64>,
         mut first_partial_derivative: ArrayViewMut2<f64>,
         mut second_partial_derivative: ArrayViewMut3<f64>,

--- a/feos-dft/src/lib.rs
+++ b/feos-dft/src/lib.rs
@@ -18,7 +18,9 @@ mod weight_functions;
 
 pub use convolver::{Convolver, ConvolverFFT};
 pub use functional::{HelmholtzEnergyFunctional, MoleculeShape, DFT};
-pub use functional_contribution::{FunctionalContribution, FunctionalContributionDual};
+pub use functional_contribution::{
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual,
+};
 pub use geometry::{Axis, Geometry, Grid};
 pub use profile::{DFTProfile, DFTSpecification, DFTSpecifications};
 pub use solver::{DFTSolver, DFTSolverLog};

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -118,7 +118,7 @@ impl AssociationParameters {
 /// Implementation of the SAFT association Helmholtz energy
 /// contribution and functional.
 #[cfg_attr(feature = "dft", derive(FunctionalContribution))]
-#[max_size(20)]
+#[cfg_attr(feature = "dft", max_size(20))]
 pub struct Association<P: HardSphereProperties> {
     parameters: Arc<P>,
     association_parameters: AssociationParameters,

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -5,7 +5,7 @@ use feos_core::{EosError, EosResult, HelmholtzEnergyDual, StateHD};
 #[cfg(feature = "dft")]
 use feos_derive::FunctionalContribution;
 #[cfg(feature = "dft")]
-use feos_dft::{FunctionalContribution, FunctionalContributionDual};
+use feos_dft::{FunctionalContribution, PartialDerivativesDual};
 use ndarray::*;
 use num_dual::linalg::{norm, LU};
 use num_dual::*;

--- a/src/gc_pcsaft/dft/dispersion.rs
+++ b/src/gc_pcsaft/dft/dispersion.rs
@@ -1,17 +1,20 @@
 use super::parameter::GcPcSaftFunctionalParameters;
 use crate::gc_pcsaft::eos::dispersion::{A0, A1, A2, B0, B1, B2};
 use crate::hard_sphere::HardSphereProperties;
-use feos_core::EosError;
+use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
-use num_dual::DualNum;
+use num_dual::*;
 use std::f64::consts::{FRAC_PI_6, PI};
 use std::fmt;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(10)]
 pub struct AttractiveFunctional {
     parameters: Arc<GcPcSaftFunctionalParameters>,
 }
@@ -39,7 +42,7 @@ impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for Attracti
         &self,
         temperature: N,
         density: ArrayView2<N>,
-    ) -> Result<Array1<N>, EosError> {
+    ) -> EosResult<Array1<N>> {
         // auxiliary variables
         let p = &self.parameters;
         let n = p.m.len();

--- a/src/gc_pcsaft/dft/dispersion.rs
+++ b/src/gc_pcsaft/dft/dispersion.rs
@@ -4,8 +4,8 @@ use crate::hard_sphere::HardSphereProperties;
 use feos_core::EosResult;
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/gc_pcsaft/dft/hard_chain.rs
+++ b/src/gc_pcsaft/dft/hard_chain.rs
@@ -3,8 +3,8 @@ use crate::hard_sphere::HardSphereProperties;
 use feos_core::EosResult;
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/gc_pcsaft/dft/hard_chain.rs
+++ b/src/gc_pcsaft/dft/hard_chain.rs
@@ -1,16 +1,19 @@
 use super::GcPcSaftFunctionalParameters;
 use crate::hard_sphere::HardSphereProperties;
-use feos_core::EosError;
+use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
-use num_dual::DualNum;
+use num_dual::*;
 use petgraph::visit::EdgeRef;
 use std::fmt;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(12)]
 pub struct ChainFunctional {
     parameters: Arc<GcPcSaftFunctionalParameters>,
 }
@@ -50,7 +53,7 @@ impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for ChainFun
         &self,
         temperature: N,
         weighted_densities: ArrayView2<N>,
-    ) -> Result<Array1<N>, EosError> {
+    ) -> EosResult<Array1<N>> {
         let p = &self.parameters;
         // number of segments
         let segments = weighted_densities.shape()[0] - 2;

--- a/src/hard_sphere/dft.rs
+++ b/src/hard_sphere/dft.rs
@@ -4,7 +4,7 @@ use feos_dft::adsorption::FluidParameters;
 use feos_dft::solvation::PairPotential;
 use feos_dft::{
     FunctionalContribution, FunctionalContributionDual, HelmholtzEnergyFunctional, MoleculeShape,
-    WeightFunction, WeightFunctionInfo, WeightFunctionShape, DFT,
+    PartialDerivativesDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape, DFT,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/hard_sphere/dft.rs
+++ b/src/hard_sphere/dft.rs
@@ -1,4 +1,5 @@
 use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::adsorption::FluidParameters;
 use feos_dft::solvation::PairPotential;
 use feos_dft::{
@@ -6,7 +7,7 @@ use feos_dft::{
     WeightFunction, WeightFunctionInfo, WeightFunctionShape, DFT,
 };
 use ndarray::*;
-use num_dual::DualNum;
+use num_dual::*;
 use std::f64::consts::PI;
 use std::fmt;
 use std::sync::Arc;
@@ -61,12 +62,14 @@ pub enum FMTVersion {
 /// |$\vec\omega_2^\alpha(\mathbf{r})$|$C_{3,\alpha}\frac{\mathbf{r}}{\|\mathbf{r}\|}\\,\delta\\!\left(\frac{d_\alpha}{2}-\|\mathbf{r}\|\right)$|-|
 ///
 /// The geometry coefficients $C_{k,\alpha}$ and the segment diameters $d_\alpha$ are specified via the [HardSphereProperties] trait.
-pub struct FMTContribution<P> {
+#[derive(FunctionalContribution)]
+#[max_size(10)]
+pub struct FMTContribution<P: HardSphereProperties> {
     pub properties: Arc<P>,
     version: FMTVersion,
 }
 
-impl<P> Clone for FMTContribution<P> {
+impl<P: HardSphereProperties> Clone for FMTContribution<P> {
     fn clone(&self) -> Self {
         Self {
             properties: self.properties.clone(),
@@ -75,7 +78,7 @@ impl<P> Clone for FMTContribution<P> {
     }
 }
 
-impl<P> FMTContribution<P> {
+impl<P: HardSphereProperties> FMTContribution<P> {
     pub fn new(properties: &Arc<P>, version: FMTVersion) -> Self {
         Self {
             properties: properties.clone(),

--- a/src/hard_sphere/mod.rs
+++ b/src/hard_sphere/mod.rs
@@ -26,7 +26,7 @@ pub enum MonomerShape<'a, D> {
 }
 
 /// Properties of (generalized) hard sphere systems.
-pub trait HardSphereProperties {
+pub trait HardSphereProperties: Send + Sync {
     /// The [MonomerShape] used in the model.
     fn monomer_shape<D: DualNum<f64>>(&self, temperature: D) -> MonomerShape<D>;
 

--- a/src/pcsaft/dft/dispersion.rs
+++ b/src/pcsaft/dft/dispersion.rs
@@ -5,8 +5,8 @@ use crate::pcsaft::eos::dispersion::{A0, A1, A2, B0, B1, B2};
 use feos_core::EosResult;
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/pcsaft/dft/dispersion.rs
+++ b/src/pcsaft/dft/dispersion.rs
@@ -2,12 +2,14 @@ use super::polar::calculate_helmholtz_energy_density_polar;
 use super::PcSaftParameters;
 use crate::hard_sphere::HardSphereProperties;
 use crate::pcsaft::eos::dispersion::{A0, A1, A2, B0, B1, B2};
-use feos_core::EosError;
+use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
-use num_dual::DualNum;
+use num_dual::*;
 use std::f64::consts::{FRAC_PI_3, PI};
 use std::fmt;
 use std::sync::Arc;
@@ -17,7 +19,8 @@ const PSI_DFT: f64 = 1.3862;
 /// psi Parameter for pDGT (Rehner2018)
 const PSI_PDGT: f64 = 1.3286;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(5)]
 pub struct AttractiveFunctional {
     parameters: Arc<PcSaftParameters>,
 }
@@ -53,7 +56,7 @@ impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for Attracti
         &self,
         temperature: N,
         density: ArrayView2<N>,
-    ) -> Result<Array1<N>, EosError> {
+    ) -> EosResult<Array1<N>> {
         // auxiliary variables
         let p = &self.parameters;
         let n = p.m.len();

--- a/src/pcsaft/dft/hard_chain.rs
+++ b/src/pcsaft/dft/hard_chain.rs
@@ -1,15 +1,18 @@
 use super::PcSaftParameters;
 use crate::hard_sphere::HardSphereProperties;
-use feos_core::EosError;
+use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
-use num_dual::DualNum;
+use num_dual::*;
 use std::fmt;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(12)]
 pub struct ChainFunctional {
     parameters: Arc<PcSaftParameters>,
 }
@@ -51,7 +54,7 @@ impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for ChainFun
         &self,
         temperature: N,
         weighted_densities: ArrayView2<N>,
-    ) -> Result<Array1<N>, EosError> {
+    ) -> EosResult<Array1<N>> {
         let p = &self.parameters;
         // number of segments
         let n = (weighted_densities.shape()[0] - 2) / 2;

--- a/src/pcsaft/dft/hard_chain.rs
+++ b/src/pcsaft/dft/hard_chain.rs
@@ -3,8 +3,8 @@ use crate::hard_sphere::HardSphereProperties;
 use feos_core::EosResult;
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/pcsaft/dft/pure_saft_functional.rs
+++ b/src/pcsaft/dft/pure_saft_functional.rs
@@ -5,8 +5,10 @@ use crate::hard_sphere::{FMTVersion, HardSphereProperties};
 use crate::pcsaft::eos::dispersion::{A0, A1, A2, B0, B1, B2};
 use crate::pcsaft::eos::polar::{AD, AQ, BD, BQ, CD, CQ, PI_SQ_43};
 use feos_core::{EosError, EosResult};
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;
@@ -18,7 +20,8 @@ const PI36M1: f64 = 1.0 / (36.0 * PI);
 const N3_CUTOFF: f64 = 1e-5;
 const N0_CUTOFF: f64 = 1e-9;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(5)]
 pub struct PureFMTAssocFunctional {
     parameters: Arc<PcSaftParameters>,
     version: FMTVersion,
@@ -152,7 +155,8 @@ impl fmt::Display for PureFMTAssocFunctional {
     }
 }
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(3)]
 pub struct PureChainFunctional {
     parameters: Arc<PcSaftParameters>,
 }
@@ -204,7 +208,8 @@ impl fmt::Display for PureChainFunctional {
     }
 }
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(1)]
 pub struct PureAttFunctional {
     parameters: Arc<PcSaftParameters>,
 }

--- a/src/pcsaft/dft/pure_saft_functional.rs
+++ b/src/pcsaft/dft/pure_saft_functional.rs
@@ -7,8 +7,8 @@ use crate::pcsaft::eos::polar::{AD, AQ, BD, BQ, CD, CQ, PI_SQ_43};
 use feos_core::{EosError, EosResult};
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/pets/dft/dispersion.rs
+++ b/src/pets/dft/dispersion.rs
@@ -4,8 +4,8 @@ use crate::pets::parameters::PetsParameters;
 use feos_core::EosResult;
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/pets/dft/dispersion.rs
+++ b/src/pets/dft/dispersion.rs
@@ -1,12 +1,14 @@
 use crate::hard_sphere::HardSphereProperties;
 use crate::pets::eos::dispersion::{A, B};
 use crate::pets::parameters::PetsParameters;
-use feos_core::EosError;
+use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
-use num_dual::DualNum;
+use num_dual::*;
 use std::f64::consts::{FRAC_PI_3, PI};
 use std::fmt;
 use std::sync::Arc;
@@ -16,7 +18,8 @@ const PSI_DFT: f64 = 1.21;
 /// psi Parameter for pDGT (not adjusted, yet)
 const PSI_PDGT: f64 = 1.21;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(3)]
 pub struct AttractiveFunctional {
     parameters: Arc<PetsParameters>,
 }
@@ -52,7 +55,7 @@ impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for Attracti
         &self,
         temperature: N,
         density: ArrayView2<N>,
-    ) -> Result<Array1<N>, EosError> {
+    ) -> EosResult<Array1<N>> {
         // auxiliary variables
         let p = &self.parameters;
         let n = p.sigma.len();

--- a/src/pets/dft/pure_pets_functional.rs
+++ b/src/pets/dft/pure_pets_functional.rs
@@ -2,8 +2,10 @@ use crate::hard_sphere::{FMTVersion, HardSphereProperties};
 use crate::pets::eos::dispersion::{A, B};
 use crate::pets::parameters::PetsParameters;
 use feos_core::{EosError, EosResult};
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
+    WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;
@@ -14,7 +16,8 @@ use std::sync::Arc;
 const PI36M1: f64 = 1.0 / (36.0 * PI);
 const N3_CUTOFF: f64 = 1e-5;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(5)]
 pub struct PureFMTFunctional {
     parameters: Arc<PetsParameters>,
     version: FMTVersion,
@@ -114,7 +117,8 @@ impl fmt::Display for PureFMTFunctional {
     }
 }
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(1)]
 pub struct PureAttFunctional {
     parameters: Arc<PetsParameters>,
 }

--- a/src/pets/dft/pure_pets_functional.rs
+++ b/src/pets/dft/pure_pets_functional.rs
@@ -4,8 +4,8 @@ use crate::pets::parameters::PetsParameters;
 use feos_core::{EosError, EosResult};
 use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContribution, FunctionalContributionDual, WeightFunction, WeightFunctionInfo,
-    WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::*;

--- a/src/saftvrqmie/dft/dispersion.rs
+++ b/src/saftvrqmie/dft/dispersion.rs
@@ -1,8 +1,10 @@
 use crate::saftvrqmie::eos::dispersion::{dispersion_energy_density, Alpha};
 use crate::saftvrqmie::parameters::SaftVRQMieParameters;
 use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::DualNum;
@@ -14,7 +16,8 @@ const PSI_DFT: f64 = 1.3862;
 /// psi Parameter for pDGT (Rehner2018)
 const PSI_PDGT: f64 = 1.3286;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(5)]
 pub struct AttractiveFunctional {
     parameters: Arc<SaftVRQMieParameters>,
     // Store stuff here

--- a/src/saftvrqmie/dft/non_additive_hs.rs
+++ b/src/saftvrqmie/dft/non_additive_hs.rs
@@ -1,7 +1,9 @@
 use crate::saftvrqmie::parameters::SaftVRQMieParameters;
 use feos_core::EosResult;
+use feos_derive::FunctionalContribution;
 use feos_dft::{
-    FunctionalContributionDual, WeightFunction, WeightFunctionInfo, WeightFunctionShape,
+    FunctionalContribution, FunctionalContributionDual, PartialDerivativesDual, WeightFunction,
+    WeightFunctionInfo, WeightFunctionShape,
 };
 use ndarray::*;
 use num_dual::DualNum;
@@ -11,7 +13,8 @@ use std::sync::Arc;
 
 pub const N0_CUTOFF: f64 = 1e-9;
 
-#[derive(Clone)]
+#[derive(FunctionalContribution)]
+#[max_size(10)]
 pub struct NonAddHardSphereFunctional {
     parameters: Arc<SaftVRQMieParameters>,
 }


### PR DESCRIPTION
## Implementation
This PR improves the speed of DFT calculations without affecting the convergence at all. Instead, vector dual numbers are used to calculate first and second partial derivatives of the Helmholtz energy. Having functions that are generic over the number of weighted densities in the `FunctionalContribution` trait makes it not object safe. Therefore, it is instead implemented via a derive macro.

## Execution times
This PR replaces one AD method with another one; both produce exact (up to machine precision) derivatives. Therefore, no difference in convergence is to be expected.

Some benchmarks:

|model|components/segments|time old|time new|
|-|-|-|-|
|FMT|1|55.3 ms|**37.1 ms**|
|PC-SAFT|1|74.7 ms|**54.6 ms**|
|PC-SAFT|2|208 ms|**124 ms**|
|gc-PC-SAFT|4|23.1 s|**7.95 s**|

## Compilation time
The new code generates a lot of additional code. While this is necessary to increase performance, it also slows down the compilation (and increases binary size). As compromise, the optimization is only applied for mixtures with up to 5 (PC-SAFT) or 3 (PeTS) components, and 10 (gc-PC-SAFT) segments.