### PR TITLE
Add `critical_temperature` argument to `VaporPressure` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added SAFT-VRQ Mie equation of state and Helmholtz energy functional for first order Feynman-Hibbs corrected Mie fluids. [#79](https://github.com/feos-org/feos/pull/79)
+Added `estimator` module to documentation. [#86](https://github.com/feos-org/feos/pull/86)
 
 ### Changed
 - Export `EosVariant` and `FunctionalVariant` directly in the crate root instead of their own modules. [#62](https://github.com/feos-org/feos/pull/62)
+- Changed constructors `VaporPressure::new` and `DataSet.vapor_pressure` (Python) to take a new optional argument `critical_temperature`. [#86](https://github.com/feos-org/feos/pull/86)
 
 ## [0.3.0] - 2022-09-14
 - Major restructuring of the entire `feos` project. All individual models are reunited in the `feos` crate. `feos-core` and `feos-dft` still live as individual crates within the `feos` workspace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added SAFT-VRQ Mie equation of state and Helmholtz energy functional for first order Feynman-Hibbs corrected Mie fluids. [#79](https://github.com/feos-org/feos/pull/79)
-Added `estimator` module to documentation. [#86](https://github.com/feos-org/feos/pull/86)
+- Added `estimator` module to documentation. [#86](https://github.com/feos-org/feos/pull/86)
 
 ### Changed
 - Export `EosVariant` and `FunctionalVariant` directly in the crate root instead of their own modules. [#62](https://github.com/feos-org/feos/pull/62)

--- a/docs/api/eos.md
+++ b/docs/api/eos.md
@@ -35,3 +35,17 @@ The `State` and `PhaseEquilibrium` objects are used to define thermodynamic cond
     PhaseEquilibrium
     PhaseDiagram
 ```
+
+## Estimator
+
+```{eval-rst}
+.. currentmodule:: feos.eos.estimator
+
+.. autosummary::
+    :toctree: generated/
+
+    DataSet
+    Loss
+    Estimator
+    Phase
+```

--- a/docs/api/eos.md
+++ b/docs/api/eos.md
@@ -3,6 +3,8 @@
 The `eos` module contains the `EquationOfState` object that contains all implemented equations of state.
 The `State` and `PhaseEquilibrium` objects are used to define thermodynamic conditions and -- once created -- can be used to compute properties.
 
+If you want to adjust parameters of a model to experimental data you can use classes and utilities from the `estimator` module.
+
 ## `EquationOfState`
 
 ```{eval-rst}
@@ -36,7 +38,13 @@ The `State` and `PhaseEquilibrium` objects are used to define thermodynamic cond
     PhaseDiagram
 ```
 
-## Estimator
+## The `estimator` module
+
+### Import 
+
+```python
+from feos.eos.estimator import Estimator, DataSet, Loss, Phase
+```
 
 ```{eval-rst}
 .. currentmodule:: feos.eos.estimator
@@ -44,8 +52,8 @@ The `State` and `PhaseEquilibrium` objects are used to define thermodynamic cond
 .. autosummary::
     :toctree: generated/
 
+    Estimator
     DataSet
     Loss
-    Estimator
     Phase
 ```

--- a/src/estimator/python.rs
+++ b/src/estimator/python.rs
@@ -11,7 +11,8 @@ impl From<EstimatorError> for PyErr {
 #[macro_export]
 macro_rules! impl_estimator {
     ($eos:ty, $py_eos:ty) => {
-        /// Loss function that is applied to the residuum to calculate costs.
+        /// Loss function that is applied to the residuals to 
+        /// weight to in- and outliers.
         #[pyclass(name = "Loss")]
         #[derive(Clone)]
         pub struct PyLoss(Loss);
@@ -122,20 +123,26 @@ macro_rules! impl_estimator {
         impl PyDataSet {
             /// Compute the cost function for each input value.
             ///
-            /// The cost function that is used depends on the
-            /// property. See the class constructors to learn
-            /// about the cost functions of the properties.
-            ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
+            /// loss : Loss
+            ///     The loss function that is applied to residuals
+            ///     to distinguish between in- and outliers.
             ///
             /// Returns
             /// -------
             /// numpy.ndarray[Float]
             ///     The cost function evaluated for each experimental data point.
-            #[pyo3(text_signature = "($self, eos)")]
+            /// 
+            /// Note
+            /// ----
+            /// The cost function that is used depends on the
+            /// property. For most properties it is the absolute relative difference.
+            /// See the constructors of the respective properties
+            /// to learn about the cost functions that are used.
+            #[pyo3(text_signature = "($self, eos, loss)")]
             fn cost<'py>(
                 &self,
                 eos: &$py_eos,
@@ -150,18 +157,12 @@ macro_rules! impl_estimator {
             ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns
             /// -------
             /// SIArray1
-            ///
-            /// See also
-            /// --------
-            /// eos_python.saft.estimator.DataSet.vapor_pressure : ``DataSet`` for vapor pressure.
-            /// eos_python.saft.estimator.DataSet.liquid_density : ``DataSet`` for liquid density.
-            /// eos_python.saft.estimator.DataSet.equilibrium_liquid_density : ``DataSet`` for liquid density at vapor liquid equilibrium.
             #[pyo3(text_signature = "($self, eos)")]
             fn predict(&self, eos: &$py_eos) -> PyResult<PySIArray1> {
                 Ok(self.0.predict(&eos.0)?.into())
@@ -176,7 +177,7 @@ macro_rules! impl_estimator {
             ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns
@@ -199,7 +200,7 @@ macro_rules! impl_estimator {
             ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns
@@ -496,15 +497,9 @@ macro_rules! impl_estimator {
 
             /// Compute the cost function for each ``DataSet``.
             ///
-            /// The cost function is:
-            /// - The relative difference between prediction and target value,
-            /// - to which a loss function is applied,
-            /// - and which is weighted according to the number of datapoints,
-            /// - and the relative weights as defined in the Estimator object.
-            ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns
@@ -512,6 +507,15 @@ macro_rules! impl_estimator {
             /// numpy.ndarray[Float]
             ///     The cost function evaluated for each experimental data point
             ///     of each ``DataSet``.
+            /// 
+            /// Note
+            /// ----
+            /// The cost function is:
+            /// 
+            /// - The relative difference between prediction and target value,
+            /// - to which a loss function is applied,
+            /// - and which is weighted according to the number of datapoints,
+            /// - and the relative weights as defined in the Estimator object.
             #[pyo3(text_signature = "($self, eos)")]
             fn cost<'py>(&self, eos: &$py_eos, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
                 Ok(self.0.cost(&eos.0)?.view().to_pyarray(py))
@@ -522,7 +526,7 @@ macro_rules! impl_estimator {
             ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns
@@ -547,7 +551,7 @@ macro_rules! impl_estimator {
             ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns
@@ -575,7 +579,7 @@ macro_rules! impl_estimator {
             ///
             /// Parameters
             /// ----------
-            /// eos : PyEos
+            /// eos : EquationOfState
             ///     The equation of state that is used.
             ///
             /// Returns

--- a/src/estimator/python.rs
+++ b/src/estimator/python.rs
@@ -11,8 +11,8 @@ impl From<EstimatorError> for PyErr {
 #[macro_export]
 macro_rules! impl_estimator {
     ($eos:ty, $py_eos:ty) => {
-        /// Loss function that is applied to the residuals to 
-        /// weight to in- and outliers.
+        /// Collection of loss functions that can be applied to residuals
+        /// to handle outliers.
         #[pyclass(name = "Loss")]
         #[derive(Clone)]
         pub struct PyLoss(Loss);
@@ -129,7 +129,7 @@ macro_rules! impl_estimator {
             ///     The equation of state that is used.
             /// loss : Loss
             ///     The loss function that is applied to residuals
-            ///     to distinguish between in- and outliers.
+            ///     to handle outliers.
             ///
             /// Returns
             /// -------


### PR DESCRIPTION
This PR adds a new optional argument to the constructors of `VaporPressure` and `DataSet.vapor_pressure`, i.e. the critical temperature.

- If provided, it is used as initial temperature when calculating the critical point in the `predict` method.
- If not provided, the maximum temperature of the input temperatures is used.
- If the calculation of the critical point within `predict` fails (using either the provided or maximum temperature), another call to the method using the default temperatures is used.

- Did some cleanup of the documentation and added `eos.estimator` to the documentation.