### PR TITLE
Add non-mixed second order derivatives to `State` property evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ name = "state_properties"
 harness = false
 
 [[bench]]
+name = "state_creation"
+harness = false
+
+[[bench]]
 name = "dual_numbers"
 harness = false
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -14,3 +14,4 @@ cargo bench --profile=release-lto --features=pcsaft --bench=dual_numbers
 |--|--|--|
 |`dual_numbers`|Helmholtz energy function evaluated using `StateHD` with different dual number types.|`pcsaft`|
 |`state_properties`|Properties of `State`. Including state creation using the natural variables of the Helmholtz energy (no density iteration).|`pcsaft`|
+|`state_creation`|Different constructors of `State` and `PhaseEquilibrium` including critical point calculations. For pure substances and mixtures.|`pcsaft`|

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -49,7 +49,7 @@ fn bench_dual_numbers<E: EquationOfState>(
         b.iter(|| a_res((&state.eos, &state.derive1(Derivative::DV))))
     });
     group.bench_function("a_hyperdual", |b| {
-        b.iter(|| a_res((&state.eos, &state.derive2partial(Derivative::DV, Derivative::DV))))
+        b.iter(|| a_res((&state.eos, &state.derive2_mixed(Derivative::DV, Derivative::DV))))
     });
     group.bench_function("a_dual3", |b| {
         b.iter(|| a_res((&state.eos, &state.derive3(Derivative::DV))))

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -48,6 +48,9 @@ fn bench_dual_numbers<E: EquationOfState>(
     group.bench_function("a_dual", |b| {
         b.iter(|| a_res((&state.eos, &state.derive1(Derivative::DV))))
     });
+    group.bench_function("a_dual2", |b| {
+        b.iter(|| a_res((&state.eos, &state.derive2(Derivative::DV))))
+    });
     group.bench_function("a_hyperdual", |b| {
         b.iter(|| a_res((&state.eos, &state.derive2_mixed(Derivative::DV, Derivative::DV))))
     });
@@ -66,7 +69,7 @@ fn pcsaft(c: &mut Criterion) {
         IdentifierOption::Name,
     )
     .unwrap();
-    bench_dual_numbers(c, "methane", state_pcsaft(parameters));
+    bench_dual_numbers(c, "dual_numbers_pcsaft_methane", state_pcsaft(parameters));
 
     // water (4C, polar)
     let parameters = PcSaftParameters::from_json(
@@ -76,7 +79,7 @@ fn pcsaft(c: &mut Criterion) {
         IdentifierOption::Name,
     )
     .unwrap();
-    bench_dual_numbers(c, "water_4c_polar", state_pcsaft(parameters));
+    bench_dual_numbers(c, "dual_numbers_pcsaft_water_4c_polar", state_pcsaft(parameters));
 
     // methane, ethane, propane
     let parameters = PcSaftParameters::from_json(
@@ -86,7 +89,7 @@ fn pcsaft(c: &mut Criterion) {
         IdentifierOption::Name,
     )
     .unwrap();
-    bench_dual_numbers(c, "methane_ethane_propane", state_pcsaft(parameters));
+    bench_dual_numbers(c, "dual_numbers_pcsaft_methane_ethane_propane", state_pcsaft(parameters));
 }
 
 /// Benchmark for the PC-SAFT equation of state.
@@ -116,7 +119,7 @@ fn methane_co2_pcsaft(c: &mut Criterion) {
     let x = arr1(&[0.15, 0.85]);
     let moles = &x * 10.0 * MOL;
     let state = State::new_nvt(&eos, temperature, volume, &moles).unwrap();
-    bench_dual_numbers(c, "methane_co2", state);
+    bench_dual_numbers(c, "dual_numbers_pcsaft_methane_co2", state);
 }
 
 criterion_group!(bench, pcsaft, methane_co2_pcsaft);

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -49,7 +49,7 @@ fn bench_dual_numbers<E: EquationOfState>(
         b.iter(|| a_res((&state.eos, &state.derive1(Derivative::DV))))
     });
     group.bench_function("a_hyperdual", |b| {
-        b.iter(|| a_res((&state.eos, &state.derive2(Derivative::DV, Derivative::DV))))
+        b.iter(|| a_res((&state.eos, &state.derive2partial(Derivative::DV, Derivative::DV))))
     });
     group.bench_function("a_dual3", |b| {
         b.iter(|| a_res((&state.eos, &state.derive3(Derivative::DV))))

--- a/benches/state_creation.rs
+++ b/benches/state_creation.rs
@@ -26,6 +26,7 @@ fn critical_point((eos, n): (&Arc<PcSaft>, Option<&SIArray1>)) {
     State::critical_point(eos, n, None, Default::default()).unwrap();
 }
 
+/// Evaluate temperature, pressure flash.
 fn tp_flash((eos, t, p, feed): (&Arc<PcSaft>, SINumber, SINumber, &SIArray1)) {
     PhaseEquilibrium::tp_flash(eos, t, p, feed, None, Default::default(), None).unwrap();
 }

--- a/benches/state_creation.rs
+++ b/benches/state_creation.rs
@@ -1,0 +1,58 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use feos::pcsaft::{PcSaft, PcSaftParameters};
+use feos_core::{
+    parameter::{IdentifierOption, Parameter},
+    DensityInitialization, PhaseEquilibrium, State,
+};
+use ndarray::arr1;
+use quantity::si::*;
+use std::sync::Arc;
+
+/// Evaluate NPT constructor
+fn npt(
+    (eos, t, p, n, rho0): (
+        &Arc<PcSaft>,
+        SINumber,
+        SINumber,
+        &SIArray1,
+        DensityInitialization<SIUnit>,
+    ),
+) {
+    State::new_npt(eos, t, p, n, rho0).unwrap();
+}
+
+/// Evaluate critical point constructor
+fn critical_point((eos, n): (&Arc<PcSaft>, Option<&SIArray1>)) {
+    State::critical_point(eos, n, None, Default::default()).unwrap();
+}
+
+fn tp_flash((eos, t, p, feed): (&Arc<PcSaft>, SINumber, SINumber, &SIArray1)) {
+    PhaseEquilibrium::tp_flash(eos, t, p, feed, None, Default::default(), None).unwrap();
+}
+
+fn states_pcsaft(c: &mut Criterion) {
+    let parameters = PcSaftParameters::from_json(
+        vec!["methane", "ethane", "propane"],
+        "./parameters/pcsaft/gross2001.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap();
+    let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
+    let t = 300.0 * KELVIN;
+    let x = arr1(&[1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]);
+    let n = &x * 100.0 * MOL;
+    let p = BAR;
+
+    let mut group = c.benchmark_group("methane_ethane_propane");
+    group.bench_function("NPT", |b| {
+        b.iter(|| npt((&eos, t, p, &n, DensityInitialization::None)))
+    });
+    group.bench_function("critical_point", |b| {
+        b.iter(|| critical_point((&eos, Some(&n))))
+    });
+    group.bench_function("tp_flash", |b| b.iter(|| tp_flash((&eos, 315.0 * KELVIN, 72.0 * BAR, &n))));
+}
+
+criterion_group!(bench, states_pcsaft);
+criterion_main!(bench);

--- a/benches/state_creation.rs
+++ b/benches/state_creation.rs
@@ -2,16 +2,16 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use feos::pcsaft::{PcSaft, PcSaftParameters};
 use feos_core::{
     parameter::{IdentifierOption, Parameter},
-    DensityInitialization, PhaseEquilibrium, State,
+    Contributions, DensityInitialization, EquationOfState, PhaseEquilibrium, State,
 };
-use ndarray::arr1;
+use ndarray::{Array, Array1};
 use quantity::si::*;
 use std::sync::Arc;
 
 /// Evaluate NPT constructor
-fn npt(
+fn npt<E: EquationOfState>(
     (eos, t, p, n, rho0): (
-        &Arc<PcSaft>,
+        &Arc<E>,
         SINumber,
         SINumber,
         &SIArray1,
@@ -22,16 +22,118 @@ fn npt(
 }
 
 /// Evaluate critical point constructor
-fn critical_point((eos, n): (&Arc<PcSaft>, Option<&SIArray1>)) {
+fn critical_point<E: EquationOfState>((eos, n): (&Arc<E>, Option<&SIArray1>)) {
     State::critical_point(eos, n, None, Default::default()).unwrap();
 }
 
 /// Evaluate temperature, pressure flash.
-fn tp_flash((eos, t, p, feed): (&Arc<PcSaft>, SINumber, SINumber, &SIArray1)) {
+fn tp_flash<E: EquationOfState>((eos, t, p, feed): (&Arc<E>, SINumber, SINumber, &SIArray1)) {
     PhaseEquilibrium::tp_flash(eos, t, p, feed, None, Default::default(), None).unwrap();
 }
 
-fn states_pcsaft(c: &mut Criterion) {
+fn bubble_point<E: EquationOfState>((eos, t, x): (&Arc<E>, SINumber, &Array1<f64>)) {
+    PhaseEquilibrium::bubble_point(
+        eos,
+        t,
+        x,
+        None,
+        None,
+        (Default::default(), Default::default()),
+    )
+    .unwrap();
+}
+
+fn dew_point<E: EquationOfState>((eos, t, y): (&Arc<E>, SINumber, &Array1<f64>)) {
+    PhaseEquilibrium::dew_point(
+        eos,
+        t,
+        y,
+        None,
+        None,
+        (Default::default(), Default::default()),
+    )
+    .unwrap();
+}
+
+fn bench_states<E: EquationOfState>(c: &mut Criterion, group_name: &str, eos: &Arc<E>) {
+    let ncomponents = eos.components();
+    let x = Array::from_elem(ncomponents, 1.0 / ncomponents as f64);
+    let n = &x * 100.0 * MOL;
+    let crit = State::critical_point(&eos, Some(&n), None, Default::default()).unwrap();
+    let vle = if ncomponents == 1 {
+        PhaseEquilibrium::pure(&eos, crit.temperature * 0.95, None, Default::default()).unwrap()
+    } else {
+        PhaseEquilibrium::tp_flash(
+            &eos,
+            crit.temperature,
+            crit.pressure(Contributions::Total) * 0.95,
+            &crit.moles,
+            None,
+            Default::default(),
+            None,
+        )
+        .unwrap()
+    };
+
+    let mut group = c.benchmark_group(group_name);
+    group.bench_function("new_npt_liquid", |b| {
+        b.iter(|| {
+            npt((
+                &eos,
+                vle.liquid().temperature,
+                vle.liquid().pressure(Contributions::Total) * 1.01,
+                &n,
+                DensityInitialization::Liquid,
+            ))
+        })
+    });
+    group.bench_function("new_npt_vapor", |b| {
+        b.iter(|| {
+            npt((
+                &eos,
+                vle.vapor().temperature,
+                vle.vapor().pressure(Contributions::Total) * 0.99,
+                &n,
+                DensityInitialization::Vapor,
+            ))
+        })
+    });
+    group.bench_function("critical_point", |b| {
+        b.iter(|| critical_point((&eos, Some(&n))))
+    });
+    if ncomponents != 1 {
+        group.bench_function("tp_flash", |b| {
+            b.iter(|| {
+                tp_flash((
+                    &eos,
+                    crit.temperature,
+                    crit.pressure(Contributions::Total) * 0.99,
+                    &n,
+                ))
+            })
+        });
+
+        group.bench_function("bubble_point", |b| {
+            b.iter(|| bubble_point((&eos, vle.liquid().temperature, &vle.liquid().molefracs)))
+        });
+
+        group.bench_function("dew_point", |b| {
+            b.iter(|| dew_point((&eos, vle.vapor().temperature, &vle.vapor().molefracs)))
+        });
+    }
+}
+
+fn pcsaft(c: &mut Criterion) {
+    let parameters = PcSaftParameters::from_json(
+        vec!["methane"],
+        "./parameters/pcsaft/gross2001.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap();
+    let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
+    bench_states(c, "state_creation_pcsaft_methane", &eos);
+
     let parameters = PcSaftParameters::from_json(
         vec!["methane", "ethane", "propane"],
         "./parameters/pcsaft/gross2001.json",
@@ -40,20 +142,18 @@ fn states_pcsaft(c: &mut Criterion) {
     )
     .unwrap();
     let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
-    let t = 300.0 * KELVIN;
-    let x = arr1(&[1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]);
-    let n = &x * 100.0 * MOL;
-    let p = BAR;
+    bench_states(c, "state_creation_pcsaft_methane_ethane", &eos);
 
-    let mut group = c.benchmark_group("methane_ethane_propane");
-    group.bench_function("NPT", |b| {
-        b.iter(|| npt((&eos, t, p, &n, DensityInitialization::None)))
-    });
-    group.bench_function("critical_point", |b| {
-        b.iter(|| critical_point((&eos, Some(&n))))
-    });
-    group.bench_function("tp_flash", |b| b.iter(|| tp_flash((&eos, 315.0 * KELVIN, 72.0 * BAR, &n))));
+    let parameters = PcSaftParameters::from_json(
+        vec!["methane", "ethane", "propane"],
+        "./parameters/pcsaft/gross2001.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap();
+    let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
+    bench_states(c, "state_creation_pcsaft_methane_ethane_propane", &eos);
 }
 
-criterion_group!(bench, states_pcsaft);
+criterion_group!(bench, pcsaft);
 criterion_main!(bench);

--- a/benches/state_creation.rs
+++ b/benches/state_creation.rs
@@ -26,6 +26,11 @@ fn critical_point<E: EquationOfState>((eos, n): (&Arc<E>, Option<&SIArray1>)) {
     State::critical_point(eos, n, None, Default::default()).unwrap();
 }
 
+/// VLE for pure substance for given temperature or pressure
+fn pure<E: EquationOfState>((eos, t_or_p): (&Arc<E>, SINumber)) {
+    PhaseEquilibrium::pure(eos, t_or_p, None, Default::default()).unwrap();
+}
+
 /// Evaluate temperature, pressure flash.
 fn tp_flash<E: EquationOfState>((eos, t, p, feed): (&Arc<E>, SINumber, SINumber, &SIArray1)) {
     PhaseEquilibrium::tp_flash(eos, t, p, feed, None, Default::default(), None).unwrap();
@@ -119,6 +124,13 @@ fn bench_states<E: EquationOfState>(c: &mut Criterion, group_name: &str, eos: &A
 
         group.bench_function("dew_point", |b| {
             b.iter(|| dew_point((&eos, vle.vapor().temperature, &vle.vapor().molefracs)))
+        });
+    } else {
+        group.bench_function("pure_t", |b| {
+            b.iter(|| pure((&eos, vle.vapor().temperature)))
+        });
+        group.bench_function("pure_p", |b| {
+            b.iter(|| pure((&eos, vle.vapor().pressure(Contributions::Total))))
         });
     }
 }

--- a/benches/state_properties.rs
+++ b/benches/state_properties.rs
@@ -50,7 +50,7 @@ fn properties_pcsaft(c: &mut Criterion) {
     let x = arr1(&[1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]);
     let m = &x * 100.0 * MOL;
 
-    let mut group = c.benchmark_group("methane_ethane_propane");
+    let mut group = c.benchmark_group("state_properties_pcsaft_methane_ethane_propane");
     group.bench_function("a", |b| {
         b.iter(|| property((&eos, S::helmholtz_energy, t, v, &m, Contributions::Total)))
     });

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added `Sync` and `Send` as supertraits to `EquationOfState`. [#57](https://github.com/feos-org/feos/pull/57)
+- Added `Dual2_64` dual number to `HelmholtzEnergy` trait to facilitate efficient non-mixed second order derivatives. [#94](https://github.com/feos-org/feos/pull/94)
+- Renamed `PartialDerivative::Second` to `PartialDerivative::SecondMixed`. [#94](https://github.com/feos-org/feos/pull/94)
+- Added `PartialDerivative::Second` to enable non-mixed second order partial derivatives. [#94](https://github.com/feos-org/feos/pull/94)
+- Changed `dp_dv_` and `ds_dt_` to use `Dual2_64` instead of `HyperDual64`. [#94](https://github.com/feos-org/feos/pull/94)
+- Added `get_or_insert_with_d2_64` to `Cache`. [#94](https://github.com/feos-org/feos/pull/94)
 
 ## [0.3.1] - 2022-08-25
 ### Added

--- a/feos-core/src/equation_of_state.rs
+++ b/feos-core/src/equation_of_state.rs
@@ -2,7 +2,7 @@ use crate::errors::{EosError, EosResult};
 use crate::state::StateHD;
 use crate::EosUnit;
 use ndarray::prelude::*;
-use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualNum, DualVec64, HyperDual, HyperDual64};
+use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualNum, DualVec64, HyperDual, HyperDual64, Dual2_64};
 use num_traits::{One, Zero};
 use quantity::{QuantityArray1, QuantityScalar};
 use std::fmt;
@@ -28,6 +28,7 @@ pub trait HelmholtzEnergy:
     + HelmholtzEnergyDual<Dual64>
     + HelmholtzEnergyDual<Dual<DualVec64<3>, f64>>
     + HelmholtzEnergyDual<HyperDual64>
+    + HelmholtzEnergyDual<Dual2_64>
     + HelmholtzEnergyDual<Dual3_64>
     + HelmholtzEnergyDual<HyperDual<Dual64, f64>>
     + HelmholtzEnergyDual<HyperDual<DualVec64<2>, f64>>
@@ -46,6 +47,7 @@ impl<T> HelmholtzEnergy for T where
         + HelmholtzEnergyDual<Dual64>
         + HelmholtzEnergyDual<Dual<DualVec64<3>, f64>>
         + HelmholtzEnergyDual<HyperDual64>
+        + HelmholtzEnergyDual<Dual2_64>
         + HelmholtzEnergyDual<Dual3_64>
         + HelmholtzEnergyDual<HyperDual<Dual64, f64>>
         + HelmholtzEnergyDual<HyperDual<DualVec64<2>, f64>>
@@ -99,6 +101,7 @@ pub trait IdealGasContribution:
     + IdealGasContributionDual<Dual64>
     + IdealGasContributionDual<Dual<DualVec64<3>, f64>>
     + IdealGasContributionDual<HyperDual64>
+    + IdealGasContributionDual<Dual2_64>
     + IdealGasContributionDual<Dual3_64>
     + IdealGasContributionDual<HyperDual<Dual64, f64>>
     + IdealGasContributionDual<HyperDual<DualVec64<2>, f64>>
@@ -115,6 +118,7 @@ impl<T> IdealGasContribution for T where
         + IdealGasContributionDual<Dual64>
         + IdealGasContributionDual<Dual<DualVec64<3>, f64>>
         + IdealGasContributionDual<HyperDual64>
+        + IdealGasContributionDual<Dual2_64>
         + IdealGasContributionDual<Dual3_64>
         + IdealGasContributionDual<HyperDual<Dual64, f64>>
         + IdealGasContributionDual<HyperDual<DualVec64<2>, f64>>

--- a/feos-core/src/python/statehd.rs
+++ b/feos-core/src/python/statehd.rs
@@ -1,7 +1,9 @@
 use crate::StateHD;
 use ndarray::Array1;
-use num_dual::python::{PyDual3Dual64, PyDual3_64, PyDual64, PyHyperDual64, PyHyperDualDual64};
-use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualVec64, HyperDual, HyperDual64};
+use num_dual::python::{
+    PyDual2_64, PyDual3Dual64, PyDual3_64, PyDual64, PyHyperDual64, PyHyperDualDual64,
+};
+use num_dual::{Dual, Dual2_64, Dual3, Dual3_64, Dual64, DualVec64, HyperDual, HyperDual64};
 use pyo3::prelude::*;
 use std::convert::From;
 
@@ -71,6 +73,16 @@ pub struct PyStateDDV3(StateHD<Dual<DualVec64<3>, f64>>);
 
 impl From<StateHD<Dual<DualVec64<3>, f64>>> for PyStateDDV3 {
     fn from(s: StateHD<Dual<DualVec64<3>, f64>>) -> Self {
+        Self(s)
+    }
+}
+
+#[pyclass(name = "StateD2")]
+#[derive(Clone)]
+pub struct PyStateD2(StateHD<Dual2_64>);
+
+impl From<StateHD<Dual2_64>> for PyStateD2 {
+    fn from(s: StateHD<Dual2_64>) -> Self {
         Self(s)
     }
 }

--- a/feos-core/src/python/statehd.rs
+++ b/feos-core/src/python/statehd.rs
@@ -179,6 +179,7 @@ impl_state_hd!(
     HyperDual<Dual64, f64>
 );
 impl_state_hd!(PyStateD, PyDual64, StateHD<Dual64>, Dual64);
+impl_state_hd!(PyStateD2, PyDual2_64, StateHD<Dual2_64>, Dual2_64);
 impl_state_hd!(PyStateD3, PyDual3_64, StateHD<Dual3_64>, Dual3_64);
 impl_state_hd!(
     PyStateD3D,

--- a/feos-core/src/python/user_defined.rs
+++ b/feos-core/src/python/user_defined.rs
@@ -1,8 +1,10 @@
 use crate::python::statehd::*;
 use crate::*;
 use ndarray::prelude::*;
-use num_dual::python::{PyDual3Dual64, PyDual3_64, PyDual64, PyHyperDual64, PyHyperDualDual64};
-use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualVec64, HyperDual, HyperDual64};
+use num_dual::python::{
+    PyDual2_64, PyDual3Dual64, PyDual3_64, PyDual64, PyHyperDual64, PyHyperDualDual64,
+};
+use num_dual::{Dual, Dual2_64, Dual3, Dual3_64, Dual64, DualVec64, HyperDual, HyperDual64};
 use numpy::convert::IntoPyArray;
 use pyo3::prelude::*;
 use quantity::python::PySIArray1;
@@ -215,6 +217,7 @@ impl_helmholtz_energy!(
     PyHyperDualDualVec64_3,
     HyperDual<DualVec64<3>, f64>
 );
+impl_helmholtz_energy!(PyStateD2, PyDual2_64, Dual2_64);
 impl_helmholtz_energy!(PyStateD3, PyDual3_64, Dual3_64);
 impl_helmholtz_energy!(PyStateD3D, PyDual3Dual64, Dual3<Dual64, f64>);
 impl_helmholtz_energy!(PyStateD3DV2, PyDual3DualVec64_2, Dual3<DualVec64<2>, f64>);

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -78,7 +78,7 @@ impl Cache {
     ) -> f64 {
         let d1 = min(derivative1, derivative2);
         let d2 = max(derivative1, derivative2);
-        if let Some(&value) = self.map.get(&PartialDerivative::SecondPartial(d1, d2)) {
+        if let Some(&value) = self.map.get(&PartialDerivative::SecondMixed(d1, d2)) {
             self.hit += 1;
             value
         } else {
@@ -90,7 +90,7 @@ impl Cache {
             self.map
                 .insert(PartialDerivative::First(derivative2), value.eps2[0]);
             self.map.insert(
-                PartialDerivative::SecondPartial(d1, d2),
+                PartialDerivative::SecondMixed(d1, d2),
                 value.eps1eps2[(0, 0)],
             );
             value.eps1eps2[(0, 0)]
@@ -114,7 +114,7 @@ impl Cache {
             self.map
                 .insert(PartialDerivative::Second(derivative), value.v2);
             self.map.insert(
-                PartialDerivative::SecondPartial(derivative, derivative),
+                PartialDerivative::SecondMixed(derivative, derivative),
                 value.v2,
             );
             self.map

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -111,8 +111,6 @@ impl Cache {
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
                 .insert(PartialDerivative::First(derivative), value.v1);
-            self.map
-                .insert(PartialDerivative::Second(derivative), value.v2);
             self.map.insert(
                 PartialDerivative::SecondMixed(derivative, derivative),
                 value.v2,

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -55,7 +55,7 @@ impl Cache {
         derivative: Derivative,
         f: F,
     ) -> f64 {
-        if let Some(&value) = self.map.get(&PartialDerivative::Second(derivative)) {
+        if let Some(&value) = self.map.get(&PartialDerivative::SecondMixed(derivative, derivative)) {
             self.hit += 1;
             value
         } else {
@@ -65,7 +65,7 @@ impl Cache {
             self.map
                 .insert(PartialDerivative::First(derivative), value.v1[0]);
             self.map
-                .insert(PartialDerivative::Second(derivative), value.v2[0]);
+                .insert(PartialDerivative::SecondMixed(derivative, derivative), value.v2[0]);
             value.v2[0]
         }
     }

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -686,9 +686,9 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
         let mut v = Dual64::from(self.reduced_volume);
         let mut n = self.reduced_moles.mapv(Dual64::from);
         match derivative {
-            Derivative::DT => t.eps[0] = 1.0,
-            Derivative::DV => v.eps[0] = 1.0,
-            Derivative::DN(i) => n[i].eps[0] = 1.0,
+            Derivative::DT => t = t.derive(),
+            Derivative::DV => v = v.derive(),
+            Derivative::DN(i) => n[i] = n[i].derive(),
         }
         StateHD::new(t, v, n)
     }
@@ -716,14 +716,14 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
         let mut v = HyperDual64::from(self.reduced_volume);
         let mut n = self.reduced_moles.mapv(HyperDual64::from);
         match derivative1 {
-            Derivative::DT => t.eps1[0] = 1.0,
-            Derivative::DV => v.eps1[0] = 1.0,
-            Derivative::DN(i) => n[i].eps1[0] = 1.0,
+            Derivative::DT => t = t.derive1(),
+            Derivative::DV => v = v.derive1(),
+            Derivative::DN(i) => n[i] = n[i].derive1(),
         }
         match derivative2 {
-            Derivative::DT => t.eps2[0] = 1.0,
-            Derivative::DV => v.eps2[0] = 1.0,
-            Derivative::DN(i) => n[i].eps2[0] = 1.0,
+            Derivative::DT => t = t.derive2(),
+            Derivative::DV => v = v.derive2(),
+            Derivative::DN(i) => n[i] = n[i].derive2(),
         }
         StateHD::new(t, v, n)
     }

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -212,7 +212,7 @@ pub(crate) enum PartialDerivative {
     Zeroth,
     First(Derivative),
     Second(Derivative),
-    SecondPartial(Derivative, Derivative),
+    SecondMixed(Derivative, Derivative),
     Third(Derivative),
 }
 
@@ -707,7 +707,7 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
     }
 
     /// Creates a [StateHD] taking the first and second (partial) derivatives.
-    pub fn derive2partial(
+    pub fn derive2_mixed(
         &self,
         derivative1: Derivative,
         derivative2: Derivative,

--- a/feos-dft/src/functional_contribution.rs
+++ b/feos-dft/src/functional_contribution.rs
@@ -36,6 +36,7 @@ impl_helmholtz_energy!(f64);
 impl_helmholtz_energy!(Dual64);
 impl_helmholtz_energy!(Dual<DualVec64<3>, f64>);
 impl_helmholtz_energy!(HyperDual64);
+impl_helmholtz_energy!(Dual2_64);
 impl_helmholtz_energy!(Dual3_64);
 impl_helmholtz_energy!(HyperDual<Dual64, f64>);
 impl_helmholtz_energy!(HyperDual<DualVec64<2>, f64>);
@@ -76,6 +77,7 @@ pub trait FunctionalContribution:
     + FunctionalContributionDual<Dual64>
     + FunctionalContributionDual<Dual<DualVec64<3>, f64>>
     + FunctionalContributionDual<HyperDual64>
+    + FunctionalContributionDual<Dual2_64>
     + FunctionalContributionDual<Dual3_64>
     + FunctionalContributionDual<HyperDual<Dual64, f64>>
     + FunctionalContributionDual<HyperDual<DualVec64<2>, f64>>
@@ -161,6 +163,7 @@ impl<T> FunctionalContribution for T where
         + FunctionalContributionDual<Dual64>
         + FunctionalContributionDual<Dual<DualVec64<3>, f64>>
         + FunctionalContributionDual<HyperDual64>
+        + FunctionalContributionDual<Dual2_64>
         + FunctionalContributionDual<Dual3_64>
         + FunctionalContributionDual<HyperDual<Dual64, f64>>
         + FunctionalContributionDual<HyperDual<DualVec64<2>, f64>>


### PR DESCRIPTION
This PR introduces the new variant `PartialDerivative::Second` and renames the existing variant to `PartialDerivative::SecondMixed`. `PartialDerivative::Second` can be used to calculate second order derivatives using `Dual2` instead of `HyperDual`, which is sufficient for non-mixed derivatives and computationally less expensive.

The new `PartialDerivative` looks like so
```rust
#[derive(Clone, Copy, Eq, Hash, PartialEq, Debug)]
pub(crate) enum PartialDerivative {
    Zeroth,
    First(Derivative),
    Second(Derivative),
    SecondMixed(Derivative, Derivative),
    Third(Derivative),
}
```

We can use this variant to calculate non-mixed second order derivatives like so:
```rust
fn dp_dv_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
    -self.get_or_compute_derivative(PartialDerivative::Second(DV), evaluate) // this PR
//  -self.get_or_compute_derivative(PartialDerivative::Second(DV, DV), evaluate) // current main
}

fn dp_dt_(&self, evaluate: Evaluate) -> QuantityScalar<U> {
    -self.get_or_compute_derivative(PartialDerivative::SecondMixed(DV, DT), evaluate) // this PR
//  -self.get_or_compute_derivative(PartialDerivative::Second(DV, DT), evaluate) // current main
}
```

The `Cache`, in which partial derivatives are stored, puts results into `PartialDerivative::SecondMixed` so that there are no cache misses when the derivatives are calculated with the (less efficient) variant that uses `HyperDual`s.

```rust
// state/cache.rs, method of Cache
pub fn get_or_insert_with_d2_64<F: FnOnce() -> Dual2_64>(
    &mut self,
    derivative: Derivative,
    f: F,
) -> f64 {
    if let Some(&value) = self.map.get(&PartialDerivative::SecondMixed(derivative, derivative)) {
        self.hit += 1;
        value
    } else {
        self.miss += 1;
        let value = f();
        self.map.insert(PartialDerivative::Zeroth, value.re);
        self.map
            .insert(PartialDerivative::First(derivative), value.v1[0]);
        self.map
            .insert(PartialDerivative::SecondMixed(derivative, derivative), value.v2[0]);
        value.v2[0]
    }
}
``` 

 This change benefits the `density_iteration` function in which we currently repeatedly call

```rust
// method of State
pub(crate) fn p_dpdrho(&self) -> (QuantityScalar<U>, QuantityScalar<U>) {
    let dp_dv = self.dp_dv(Contributions::Total); // <- currently uses HyperDual
    (
        self.pressure(Contributions::Total),
        (-self.volume * dp_dv / self.density),
    )
}
```

In the added benchmarks for different ways to create `State`s, this change shows an ~8-9% improvement (i.e. execution speed) for the `State::new_npt` and an ~2-4% improvement for `PhaseEquilibrium::tp_flash` although more systems should be added to get a proper idea of the impact.
