### PR TITLE
Use single function evaluation in the calculation of critical points

### DIFF
--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `PartialDerivative::Second` to enable non-mixed second order partial derivatives. [#94](https://github.com/feos-org/feos/pull/94)
 - Changed `dp_dv_` and `ds_dt_` to use `Dual2_64` instead of `HyperDual64`. [#94](https://github.com/feos-org/feos/pull/94)
 - Added `get_or_insert_with_d2_64` to `Cache`. [#94](https://github.com/feos-org/feos/pull/94)
-- The critical point algorithm now uses vector dual numbers to reduce the number of model evaluations and reduce computation times. [#96](https://github.com/feos-org/feos/pull/96)
+- The critical point algorithm now uses vector dual numbers to reduce the number of model evaluations and computation times. [#96](https://github.com/feos-org/feos/pull/96)
 
 ## [0.3.1] - 2022-08-25
 ### Added

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `PartialDerivative::Second` to enable non-mixed second order partial derivatives. [#94](https://github.com/feos-org/feos/pull/94)
 - Changed `dp_dv_` and `ds_dt_` to use `Dual2_64` instead of `HyperDual64`. [#94](https://github.com/feos-org/feos/pull/94)
 - Added `get_or_insert_with_d2_64` to `Cache`. [#94](https://github.com/feos-org/feos/pull/94)
+- The critical point algorithm now uses vector dual numbers to reduce the number of model evaluations and reduce computation times. [#96](https://github.com/feos-org/feos/pull/96)
 
 ## [0.3.1] - 2022-08-25
 ### Added

--- a/feos-core/src/equation_of_state.rs
+++ b/feos-core/src/equation_of_state.rs
@@ -2,7 +2,9 @@ use crate::errors::{EosError, EosResult};
 use crate::state::StateHD;
 use crate::EosUnit;
 use ndarray::prelude::*;
-use num_dual::{Dual, Dual3, Dual3_64, Dual64, DualNum, DualVec64, HyperDual, HyperDual64, Dual2_64};
+use num_dual::{
+    Dual, Dual2_64, Dual3, Dual3_64, Dual64, DualNum, DualVec64, HyperDual, HyperDual64,
+};
 use num_traits::{One, Zero};
 use quantity::{QuantityArray1, QuantityScalar};
 use std::fmt;

--- a/feos-core/src/phase_equilibria/bubble_dew.rs
+++ b/feos-core/src/phase_equilibria/bubble_dew.rs
@@ -488,11 +488,7 @@ where
             let mut lnpstep = -f / df;
 
             // catch too big p-steps
-            if lnpstep < -MAX_LNPSTEP {
-                lnpstep = -MAX_LNPSTEP;
-            } else if lnpstep > MAX_LNPSTEP {
-                lnpstep = MAX_LNPSTEP;
-            }
+            lnpstep = lnpstep.clamp(-MAX_LNPSTEP, MAX_LNPSTEP);
 
             // Update p
             *p = *p * lnpstep.exp();

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -78,34 +78,34 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
                     let new_state = self.derive0();
                     let computation =
                         || self.eos.evaluate_residual(&new_state) * new_state.temperature;
-                    cache.get_or_insert_with_f64(&computation) * U::reference_energy()
+                    cache.get_or_insert_with_f64(computation) * U::reference_energy()
                 }
                 PartialDerivative::First(v) => {
                     let new_state = self.derive1(v);
                     let computation =
                         || self.eos.evaluate_residual(&new_state) * new_state.temperature;
-                    cache.get_or_insert_with_d64(v, &computation) * U::reference_energy()
+                    cache.get_or_insert_with_d64(v, computation) * U::reference_energy()
                         / v.reference()
                 }
                 PartialDerivative::Second(v) => {
                     let new_state = self.derive2(v);
                     let computation =
                         || self.eos.evaluate_residual(&new_state) * new_state.temperature;
-                    cache.get_or_insert_with_d2_64(v, &computation) * U::reference_energy()
+                    cache.get_or_insert_with_d2_64(v, computation) * U::reference_energy()
                         / (v.reference() * v.reference())
                 }
                 PartialDerivative::SecondMixed(v1, v2) => {
                     let new_state = self.derive2_mixed(v1, v2);
                     let computation =
                         || self.eos.evaluate_residual(&new_state) * new_state.temperature;
-                    cache.get_or_insert_with_hd64(v1, v2, &computation) * U::reference_energy()
+                    cache.get_or_insert_with_hd64(v1, v2, computation) * U::reference_energy()
                         / (v1.reference() * v2.reference())
                 }
                 PartialDerivative::Third(v) => {
                     let new_state = self.derive3(v);
                     let computation =
                         || self.eos.evaluate_residual(&new_state) * new_state.temperature;
-                    cache.get_or_insert_with_hd364(v, &computation) * U::reference_energy()
+                    cache.get_or_insert_with_hd364(v, computation) * U::reference_energy()
                         / (v.reference() * v.reference() * v.reference())
                 }
             }),


### PR DESCRIPTION
The new automatic differentiation scheme halves the number of model evaluations which leads to a ~20-25% decrease in computation time.