### PR TITLE
Group contribution method for binary interaction parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `num-dual` dependency to 0.6. [#119](https://github.com/feos-org/feos/pull/119)
 
 
+### Fixed
+- Fixed incorrect indexing that lead to panics in the polar contribution of gc-PC-SAFT. [#104](https://github.com/feos-org/feos/pull/104)
+
 ## [0.3.0] - 2022-09-14
 - Major restructuring of the entire `feos` project. All individual models are reunited in the `feos` crate. `feos-core` and `feos-dft` still live as individual crates within the `feos` workspace.
 

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `StateVec::moles` getter. [#113](https://github.com/feos-org/feos/pull/113)
 - Added public constructors `PhaseDiagram::new` and `StateVec::new` that allow the creation of the respective structs from a list of `PhaseEquilibrium`s or `State`s in Rust and Python. [#113](https://github.com/feos-org/feos/pull/113)
 - Added new variant `EosError::Error` which allows dispatching generic errors that are not covered by the existing variants. [#98](https://github.com/feos-org/feos/pull/98)
-- Removed generics for units in all structs and traits in favor of static SI units. [#115](https://github.com/feos-org/feos/pull/115)
+- Added `binary_records` getter for parameter classes in Python. [#104](https://github.com/feos-org/feos/pull/104)
+- Added `BinaryRecord::from_json` and `BinarySegmentRecord::from_json` that read a list of records from a file. [#104](https://github.com/feos-org/feos/pull/104)
 
 ### Changed
 - Added `Sync` and `Send` as supertraits to `EquationOfState`. [#57](https://github.com/feos-org/feos/pull/57)
@@ -22,11 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The critical point algorithm now uses vector dual numbers to reduce the number of model evaluations and computation times. [#96](https://github.com/feos-org/feos/pull/96)
 - Renamed `State::molar_volume` to `State::partial_molar_volume` and `State::ln_phi_pure` to `State::ln_phi_pure_liquid`. [#107](https://github.com/feos-org/feos/pull/107)
 - Added a const generic parameter to `PhaseDiagram` that accounts for the number of phases analogously to `PhaseEquilibrium`. [#113](https://github.com/feos-org/feos/pull/113)
+- Removed generics for units in all structs and traits in favor of static SI units. [#115](https://github.com/feos-org/feos/pull/115)
 
 ### Packaging
 - Updated `pyo3` and `numpy` dependencies to 0.18. [#119](https://github.com/feos-org/feos/pull/119)
 - Updated `quantity` dependency to 0.6. [#119](https://github.com/feos-org/feos/pull/119)
 - Updated `num-dual` dependency to 0.6. [#119](https://github.com/feos-org/feos/pull/119)
+
+### Fixed
+- `Parameter::from_segments` only calculates binary interaction parameters for unlike molecules. [#104](https://github.com/feos-org/feos/pull/104)
 
 ## [0.3.1] - 2022-08-25
 ### Added

--- a/feos-core/src/parameter/mod.rs
+++ b/feos-core/src/parameter/mod.rs
@@ -241,7 +241,7 @@ where
         let n = pure_records.len();
         let mut binary_records = Array2::default([n, n]);
         for i in 0..n {
-            for j in 0..n {
+            for j in i + 1..n {
                 let mut vec = Vec::new();
                 for (id1, &n1) in segment_counts[i].iter() {
                     for (id2, &n2) in segment_counts[j].iter() {
@@ -253,7 +253,9 @@ where
                         vec.push((binary, n1, n2));
                     }
                 }
-                binary_records[(i, j)] = Self::Binary::from_segments_binary(&vec)?
+                let kij = Self::Binary::from_segments_binary(&vec)?;
+                binary_records[(i, j)] = kij.clone();
+                binary_records[(j, i)] = kij;
             }
         }
 

--- a/feos-core/src/parameter/model_record.rs
+++ b/feos-core/src/parameter/model_record.rs
@@ -2,7 +2,8 @@ use super::identifier::Identifier;
 use super::segment::SegmentRecord;
 use super::ParameterError;
 use conv::ValueInto;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{fs::File, io::BufReader, path::Path};
 
 /// A collection of parameters of a pure substance.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -120,6 +121,15 @@ impl<I, B> BinaryRecord<I, B> {
             id2,
             model_record,
         }
+    }
+
+    /// Read a list of `BinaryRecord`s from a JSON file.
+    pub fn from_json<P: AsRef<Path>>(file: P) -> Result<Vec<Self>, ParameterError>
+    where
+        I: DeserializeOwned,
+        B: DeserializeOwned,
+    {
+        Ok(serde_json::from_reader(BufReader::new(File::open(file)?))?)
     }
 }
 

--- a/feos-core/src/parameter/model_record.rs
+++ b/feos-core/src/parameter/model_record.rs
@@ -2,8 +2,11 @@ use super::identifier::Identifier;
 use super::segment::SegmentRecord;
 use super::ParameterError;
 use conv::ValueInto;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{fs::File, io::BufReader, path::Path};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
 
 /// A collection of parameters of a pure substance.
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/feos-core/src/python/cubic.rs
+++ b/feos-core/src/python/cubic.rs
@@ -7,7 +7,7 @@ use crate::python::joback::PyJobackRecord;
 use crate::python::parameter::PyIdentifier;
 use crate::*;
 use ndarray::Array2;
-use numpy::PyReadonlyArray2;
+use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use std::convert::{TryFrom, TryInto};

--- a/feos-core/src/python/parameter.rs
+++ b/feos-core/src/python/parameter.rs
@@ -216,6 +216,25 @@ macro_rules! impl_binary_record {
                 }
             }
 
+            /// Read a list of `BinaryRecord`s from a JSON file.
+            ///
+            /// Parameters
+            /// ----------
+            /// path : str
+            ///     Path to file containing the binary records.
+            ///
+            /// Returns
+            /// -------
+            /// [BinaryRecord]
+            #[staticmethod]
+            #[pyo3(text_signature = "(path)")]
+            fn from_json(path: &str) -> Result<Vec<Self>, ParameterError> {
+                Ok(BinaryRecord::from_json(path)?
+                    .into_iter()
+                    .map(Self)
+                    .collect())
+            }
+
             #[getter]
             fn get_id1(&self) -> PyIdentifier {
                 PyIdentifier(self.0.id1.clone())
@@ -291,6 +310,25 @@ impl PyBinarySegmentRecord {
     #[new]
     fn new(id1: String, id2: String, model_record: f64) -> PyResult<Self> {
         Ok(Self(BinaryRecord::new(id1, id2, model_record)))
+    }
+
+    /// Read a list of `BinarySegmentRecord`s from a JSON file.
+    ///
+    /// Parameters
+    /// ----------
+    /// path : str
+    ///     Path to file containing the binary records.
+    ///
+    /// Returns
+    /// -------
+    /// [BinarySegmentRecord]
+    #[staticmethod]
+    #[pyo3(text_signature = "(path)")]
+    fn from_json(path: &str) -> Result<Vec<Self>, ParameterError> {
+        Ok(BinaryRecord::from_json(path)?
+            .into_iter()
+            .map(Self)
+            .collect())
     }
 
     #[getter]
@@ -470,12 +508,12 @@ macro_rules! impl_segment_record {
             ///
             /// Returns
             /// -------
-            /// SegmentRecord
+            /// [SegmentRecord]
             #[staticmethod]
             fn from_json(path: &str) -> Result<Vec<Self>, ParameterError> {
                 Ok(SegmentRecord::from_json(path)?
                     .into_iter()
-                    .map(|s| Self(s))
+                    .map(Self)
                     .collect())
             }
 
@@ -693,6 +731,11 @@ macro_rules! impl_parameter {
                     .iter()
                     .map(|r| PyPureRecord(r.clone()))
                     .collect()
+            }
+
+            #[getter]
+            fn get_binary_records<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
+                self.0.records().1.mapv(f64::from).view().to_pyarray(py)
             }
         }
     };

--- a/feos-core/src/python/parameter.rs
+++ b/feos-core/src/python/parameter.rs
@@ -735,7 +735,12 @@ macro_rules! impl_parameter {
 
             #[getter]
             fn get_binary_records<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
-                self.0.records().1.mapv(f64::from).view().to_pyarray(py)
+                self.0
+                    .records()
+                    .1
+                    .mapv(|r| f64::try_from(r).unwrap())
+                    .view()
+                    .to_pyarray(py)
             }
         }
     };

--- a/src/uvtheory/python.rs
+++ b/src/uvtheory/python.rs
@@ -6,7 +6,7 @@ use feos_core::parameter::{
 use feos_core::python::parameter::*;
 use feos_core::*;
 use ndarray::Array2;
-use numpy::PyReadonlyArray2;
+use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use std::convert::{TryFrom, TryInto};


### PR DESCRIPTION
While the core functionality, like the inclusion of binary segment records, were already part of FeOs, this PR fixes issues to make the feature actually usable.