### PR TITLE
Rename `molar_volume` and `ln_phi_pure`

### DIFF
--- a/benches/state_properties.rs
+++ b/benches/state_properties.rs
@@ -63,8 +63,17 @@ fn properties_pcsaft(c: &mut Criterion) {
     group.bench_function("c_v", |b| {
         b.iter(|| property((&eos, S::c_v, t, v, &m, Contributions::ResidualNvt)))
     });
-    group.bench_function("molar_volume", |b| {
-        b.iter(|| property((&eos, S::molar_volume, t, v, &m, Contributions::ResidualNvt)))
+    group.bench_function("partial_molar_volume", |b| {
+        b.iter(|| {
+            property((
+                &eos,
+                S::partial_molar_volume,
+                t,
+                v,
+                &m,
+                Contributions::ResidualNvt,
+            ))
+        })
     });
 }
 

--- a/docs/theory/eos/properties.md
+++ b/docs/theory/eos/properties.md
@@ -90,8 +90,8 @@ The table below lists all properties that are available in $\text{FeO}_\text{s}$
 | Partial molar entropy $s_i$ | $\left(\frac{\partial S}{\partial n_i}\right)_{T,p,n_j}$ | yes |
 | Partial molar enthalpy $h_i$ | $\left(\frac{\partial H}{\partial n_i}\right)_{T,p,n_j}$ | yes |
 | Joule Thomson coefficient $\mu_\mathrm{JT}$ | $\left(\frac{\partial T}{\partial p}\right)_{H,n_i}$ | no |
-| Isentropic copmressibility $\kappa_s$ | $-\frac{1}{V}\left(\frac{\partial V}{\partial p}\right)_{S,n_i}$ | no |
-| Isothermal copmressibility $\kappa_T$ | $-\frac{1}{V}\left(\frac{\partial V}{\partial p}\right)_{T,n_i}$ | no |
+| Isentropic compressibility $\kappa_s$ | $-\frac{1}{V}\left(\frac{\partial V}{\partial p}\right)_{S,n_i}$ | no |
+| Isothermal compressibility $\kappa_T$ | $-\frac{1}{V}\left(\frac{\partial V}{\partial p}\right)_{T,n_i}$ | no |
 | (Static) structure factor $S(0)$ | $RT\left(\frac{\partial\rho}{\partial p}\right)_{T,n_i}$ | no |
 
 ## Additional properties for fluids with known molar weights

--- a/docs/tutorials/eos/pcsaft/pcsaft_state.ipynb
+++ b/docs/tutorials/eos/pcsaft/pcsaft_state.ipynb
@@ -748,7 +748,7 @@
     "- `isothermal_compressibility`,\n",
     "- `joule_thomson`,\n",
     "- `ln_phi`,\n",
-    "- `ln_phi_pure`,\n",
+    "- `ln_phi_pure_liquid`,\n",
     "- `ln_symmetric_activity_coefficient`,\n",
     "- `molar_enthalpy`,\n",
     "- `molar_entropy`,\n",
@@ -808,7 +808,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -822,7 +822,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.6.9 (default, Nov 25 2022, 14:10:45) \n[GCC 8.4.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/eos/pcsaft/pcsaft_state.ipynb
+++ b/docs/tutorials/eos/pcsaft/pcsaft_state.ipynb
@@ -688,6 +688,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -754,7 +755,7 @@
     "- `molar_gibbs_energy`,\n",
     "- `molar_helmholtz_energy`,\n",
     "- `molar_internal_energy`,\n",
-    "- `molar_volume`,\n",
+    "- `partial_molar_volume`,\n",
     "- `partial_molar_enthalpy`,\n",
     "- `partial_molar_entropy`,\n",
     "- `pressure`,\n",

--- a/examples/pcsaft_state.ipynb
+++ b/examples/pcsaft_state.ipynb
@@ -748,7 +748,7 @@
     "- `isothermal_compressibility`,\n",
     "- `joule_thomson`,\n",
     "- `ln_phi`,\n",
-    "- `ln_phi_pure`,\n",
+    "- `ln_phi_pure_liquid`,\n",
     "- `ln_symmetric_activity_coefficient`,\n",
     "- `molar_enthalpy`,\n",
     "- `molar_entropy`,\n",
@@ -808,7 +808,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -822,7 +822,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.6.9 (default, Nov 25 2022, 14:10:45) \n[GCC 8.4.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/pcsaft_state.ipynb
+++ b/examples/pcsaft_state.ipynb
@@ -688,6 +688,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -754,7 +755,7 @@
     "- `molar_gibbs_energy`,\n",
     "- `molar_helmholtz_energy`,\n",
     "- `molar_internal_energy`,\n",
-    "- `molar_volume`,\n",
+    "- `partial_molar_volume`,\n",
     "- `partial_molar_enthalpy`,\n",
     "- `partial_molar_entropy`,\n",
     "- `pressure`,\n",

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `dp_dv_` and `ds_dt_` to use `Dual2_64` instead of `HyperDual64`. [#94](https://github.com/feos-org/feos/pull/94)
 - Added `get_or_insert_with_d2_64` to `Cache`. [#94](https://github.com/feos-org/feos/pull/94)
 - The critical point algorithm now uses vector dual numbers to reduce the number of model evaluations and computation times. [#96](https://github.com/feos-org/feos/pull/96)
+- Renamed `State::molar_volume` to `State::partial_molar_volume` and `State::ln_phi_pure` to `State::ln_phi_pure_liquid`. [#107](https://github.com/feos-org/feos/pull/107)
 
 ## [0.3.1] - 2022-08-25
 ### Added

--- a/feos-core/src/phase_equilibria/bubble_dew.rs
+++ b/feos-core/src/phase_equilibria/bubble_dew.rs
@@ -227,7 +227,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
         let m = liquid_molefracs * U::reference_moles();
         let density = 0.75 * eos.max_density(Some(&m))?;
         let liquid = State::new_nvt(eos, temperature, m.sum() / density, &m)?;
-        let v_l = liquid.molar_volume(Contributions::Total);
+        let v_l = liquid.partial_molar_volume(Contributions::Total);
         let p_l = liquid.pressure(Contributions::Total);
         let mu_l = liquid.chemical_potential(Contributions::ResidualNvt);
         let p_i = (temperature * density * U::gas_constant() * liquid_molefracs)
@@ -253,7 +253,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
             let m = x * U::reference_moles();
             let density = 0.75 * eos.max_density(Some(&m))?;
             let liquid = State::new_nvt(eos, temperature, m.sum() / density, &m)?;
-            let v_l = liquid.molar_volume(Contributions::Total);
+            let v_l = liquid.partial_molar_volume(Contributions::Total);
             let p_l = liquid.pressure(Contributions::Total);
             let mu_l = liquid.chemical_potential(Contributions::ResidualNvt);
             let k = vapor_molefracs

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -467,7 +467,7 @@ macro_rules! impl_state {
                 PySINumber::from(self.0.d2p_drho2(contributions))
             }
 
-            /// Return molar volume of each component.
+            /// Return partial molar volume of each component.
             ///
             /// Parameters
             /// ----------
@@ -480,8 +480,8 @@ macro_rules! impl_state {
             /// SIArray1
             #[args(contributions = "Contributions::Total")]
             #[pyo3(text_signature = "($self, contributions)")]
-            fn molar_volume(&self, contributions: Contributions) -> PySIArray1 {
-                PySIArray1::from(self.0.molar_volume(contributions))
+            fn partial_molar_volume(&self, contributions: Contributions) -> PySIArray1 {
+                PySIArray1::from(self.0.partial_molar_volume(contributions))
             }
 
             /// Return chemical potential of each component.

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -565,7 +565,7 @@ macro_rules! impl_state {
                 self.0.ln_phi().view().to_pyarray(py)
             }
 
-            /// Return logarithmic pure substance fugacity coefficient.
+            /// Return logarithmic fugacity coefficient of a pure liquid reference state.
             ///
             /// For each component, the hypothetical liquid fugacity coefficient
             /// at mixture temperature and pressure is computed.
@@ -574,8 +574,8 @@ macro_rules! impl_state {
             /// -------
             /// numpy.ndarray
             #[pyo3(text_signature = "($self)")]
-            fn ln_phi_pure<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
-                Ok(self.0.ln_phi_pure()?.view().to_pyarray(py))
+            fn ln_phi_pure_liquid<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
+                Ok(self.0.ln_phi_pure_liquid()?.view().to_pyarray(py))
             }
 
             /// Return logarithmic symmetric activity coefficient.

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -565,10 +565,8 @@ macro_rules! impl_state {
                 self.0.ln_phi().view().to_pyarray(py)
             }
 
-            /// Return logarithmic fugacity coefficient of a pure liquid reference state.
-            ///
-            /// For each component, the hypothetical liquid fugacity coefficient
-            /// at mixture temperature and pressure is computed.
+            /// Return logarithmic fugacity coefficient of all components treated as
+            /// pure substance at mixture temperature and pressure.
             ///
             /// Returns
             /// -------

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -290,7 +290,7 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
     }
 
     /// Partial molar volume: $v_i=\left(\frac{\partial V}{\partial N_i}\right)_{T,p,N_j}$
-    pub fn molar_volume(&self, contributions: Contributions) -> QuantityArray1<U> {
+    pub fn partial_molar_volume(&self, contributions: Contributions) -> QuantityArray1<U> {
         let func = |s: &Self, evaluate: Evaluate| -s.dp_dni_(evaluate) / s.dp_dv_(evaluate);
         self.evaluate_property(func, contributions, false)
     }
@@ -356,7 +356,8 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
 
     /// Partial derivative of the logarithm of the fugacity coefficient w.r.t. pressure: $\left(\frac{\partial\ln\varphi_i}{\partial p}\right)_{T,N_i}$
     pub fn dln_phi_dp(&self) -> QuantityArray1<U> {
-        self.molar_volume(Contributions::ResidualNpt) / (U::gas_constant() * self.temperature)
+        self.partial_molar_volume(Contributions::ResidualNpt)
+            / (U::gas_constant() * self.temperature)
     }
 
     /// Partial derivative of the logarithm of the fugacity coefficient w.r.t. moles: $\left(\frac{\partial\ln\varphi_i}{\partial N_j}\right)_{T,p,N_k}$

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -319,7 +319,7 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
     }
 
     /// Logarithm of the fugacity coefficient of all components treated as pure substance at mixture temperature and pressure.
-    pub fn ln_phi_pure(&self) -> EosResult<Array1<f64>> {
+    pub fn ln_phi_pure_liquid(&self) -> EosResult<Array1<f64>> {
         let pressure = self.pressure(Contributions::Total);
         (0..self.eos.components())
             .map(|i| {
@@ -340,7 +340,7 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
     pub fn ln_symmetric_activity_coefficient(&self) -> EosResult<Array1<f64>> {
         match self.eos.components() {
             1 => Ok(arr1(&[0.0])),
-            _ => Ok(self.ln_phi() - &self.ln_phi_pure()?),
+            _ => Ok(self.ln_phi() - &self.ln_phi_pure_liquid()?),
         }
     }
 

--- a/feos-dft/src/adsorption/mod.rs
+++ b/feos-dft/src/adsorption/mod.rs
@@ -288,10 +288,19 @@ where
 
         // calculate initial value for the molar gibbs energy
         let nv = vapor.profile.bulk.density
-            * (vapor.profile.moles() * vapor.profile.bulk.molar_volume(Contributions::Total)).sum();
+            * (vapor.profile.moles()
+                * vapor
+                    .profile
+                    .bulk
+                    .partial_molar_volume(Contributions::Total))
+            .sum();
         let nl = liquid.profile.bulk.density
-            * (liquid.profile.moles() * liquid.profile.bulk.molar_volume(Contributions::Total))
-                .sum();
+            * (liquid.profile.moles()
+                * liquid
+                    .profile
+                    .bulk
+                    .partial_molar_volume(Contributions::Total))
+            .sum();
         let f = |s: &PoreProfile<U, D, F>, n: QuantityScalar<U>| -> EosResult<_> {
             Ok(s.grand_potential.unwrap()
                 + s.profile.bulk.molar_gibbs_energy(Contributions::Total) * n)
@@ -323,11 +332,19 @@ where
 
             // calculate moles
             let nv = vapor.profile.bulk.density
-                * (vapor.profile.moles() * vapor.profile.bulk.molar_volume(Contributions::Total))
-                    .sum();
+                * (vapor.profile.moles()
+                    * vapor
+                        .profile
+                        .bulk
+                        .partial_molar_volume(Contributions::Total))
+                .sum();
             let nl = liquid.profile.bulk.density
-                * (liquid.profile.moles() * liquid.profile.bulk.molar_volume(Contributions::Total))
-                    .sum();
+                * (liquid.profile.moles()
+                    * liquid
+                        .profile
+                        .bulk
+                        .partial_molar_volume(Contributions::Total))
+                .sum();
 
             // check for a trivial solution
             if nl.to_reduced(nv)? - 1.0 < 1e-5 {


### PR DESCRIPTION
`molar_volume` should be called `partial_molar_volume` to not be confused with `V/N`.

Also #105 revealed confusion around the `ln_phi_pure` function which should be more accurately called `ln_phi_pure_liquid`