### PR TITLE
Add custom PhaseDiagram constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added SAFT-VRQ Mie equation of state and Helmholtz energy functional for first order Feynman-Hibbs corrected Mie fluids. [#79](https://github.com/feos-org/feos/pull/79)
 - Added `estimator` module to documentation. [#86](https://github.com/feos-org/feos/pull/86)
 - Added benchmarks for the evaluation of the Helmholtz energy and some properties of the `State` object for PC-SAFT. [#89](https://github.com/feos-org/feos/pull/89)
+- The Python class `StateVec` is exposed in both the `feos.eos` and `feos.dft` module. [#113](https://github.com/feos-org/feos/pull/113)
 
 ### Changed
 - Export `EosVariant` and `FunctionalVariant` directly in the crate root instead of their own modules. [#62](https://github.com/feos-org/feos/pull/62)

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Added `PhaseDiagram::par_pure` that uses rayon to calculate phase diagrams in parallel. [#57](https://github.com/feos-org/feos/pull/57)
+- Added `StateVec::moles` getter. [#113](https://github.com/feos-org/feos/pull/113)
+- Added public constructors `PhaseDiagram::new` and `StateVec::new` that allow the creation of the respective structs from a list of `PhaseEquilibrium`s or `State`s in Rust and Python. [#113](https://github.com/feos-org/feos/pull/113)
 
 ### Changed
 - Added `Sync` and `Send` as supertraits to `EquationOfState`. [#57](https://github.com/feos-org/feos/pull/57)
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `get_or_insert_with_d2_64` to `Cache`. [#94](https://github.com/feos-org/feos/pull/94)
 - The critical point algorithm now uses vector dual numbers to reduce the number of model evaluations and computation times. [#96](https://github.com/feos-org/feos/pull/96)
 - Renamed `State::molar_volume` to `State::partial_molar_volume` and `State::ln_phi_pure` to `State::ln_phi_pure_liquid`. [#107](https://github.com/feos-org/feos/pull/107)
+- Added a const generic parameter to `PhaseDiagram` that accounts for the number of phases analogously to `PhaseEquilibrium`. [#113](https://github.com/feos-org/feos/pull/113)
 
 ## [0.3.1] - 2022-08-25
 ### Added

--- a/feos-core/src/phase_equilibria/phase_diagram_binary.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_binary.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 const DEFAULT_POINTS: usize = 51;
 
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     /// Create a new binary phase diagram exhibiting a
     /// vapor/liquid equilibrium.
     ///
@@ -254,12 +254,12 @@ impl<U: EosUnit, E: EquationOfState> State<U, E> {
 
 /// Phase diagram (Txy or pxy) for a system with heteroazeotropic phase behavior.
 pub struct PhaseDiagramHetero<U, E> {
-    pub vle1: PhaseDiagram<U, E>,
-    pub vle2: PhaseDiagram<U, E>,
-    pub lle: Option<PhaseDiagram<U, E>>,
+    pub vle1: PhaseDiagram<U, E, 2>,
+    pub vle2: PhaseDiagram<U, E, 2>,
+    pub lle: Option<PhaseDiagram<U, E, 2>>,
 }
 
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     /// Create a new binary phase diagram exhibiting a
     /// vapor/liquid/liquid equilibrium.
     ///
@@ -337,24 +337,23 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
             .transpose()?;
 
         Ok(PhaseDiagramHetero {
-            vle1: PhaseDiagram { states: dia1 },
-            vle2: PhaseDiagram { states: dia2 },
+            vle1: PhaseDiagram::new(dia1),
+            vle2: PhaseDiagram::new(dia2),
             lle,
         })
     }
 }
 
 impl<U: Clone, E> PhaseDiagramHetero<U, E> {
-    pub fn vle(&self) -> PhaseDiagram<U, E> {
-        PhaseDiagram {
-            states: self
-                .vle1
+    pub fn vle(&self) -> PhaseDiagram<U, E, 2> {
+        PhaseDiagram::new(
+            self.vle1
                 .states
                 .iter()
                 .chain(self.vle2.states.iter().rev())
                 .cloned()
                 .collect(),
-        }
+        )
     }
 }
 

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -11,11 +11,11 @@ use rayon::{prelude::*, ThreadPool};
 use std::sync::Arc;
 
 /// Pure component and binary mixture phase diagrams.
-pub struct PhaseDiagram<U, E> {
-    pub states: Vec<PhaseEquilibrium<U, E, 2>>,
+pub struct PhaseDiagram<U, E, const N: usize> {
+    pub states: Vec<PhaseEquilibrium<U, E, N>>,
 }
 
-impl<U: Clone, E> Clone for PhaseDiagram<U, E> {
+impl<U: Clone, E, const N: usize> Clone for PhaseDiagram<U, E, N> {
     fn clone(&self) -> Self {
         Self {
             states: self.states.clone(),
@@ -23,7 +23,13 @@ impl<U: Clone, E> Clone for PhaseDiagram<U, E> {
     }
 }
 
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+impl<U, E, const N: usize> PhaseDiagram<U, E, N> {
+    pub fn new(states: Vec<PhaseEquilibrium<U, E, N>>) -> Self {
+        Self { states }
+    }
+}
+
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     /// Calculate a phase diagram for a pure component.
     pub fn pure(
         eos: &Arc<E>,
@@ -52,7 +58,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
         }
         states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
 
-        Ok(PhaseDiagram { states })
+        Ok(PhaseDiagram::new(states))
     }
 
     /// Return the vapor states of the diagram.
@@ -67,7 +73,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
 }
 
 #[cfg(feature = "rayon")]
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     fn solve_temperatures(
         eos: &Arc<E>,
         temperatures: ArrayView1<f64>,
@@ -125,6 +131,6 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
         });
 
         states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
-        Ok(PhaseDiagram { states })
+        Ok(PhaseDiagram::new(states))
     }
 }

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -24,6 +24,7 @@ impl<U: Clone, E, const N: usize> Clone for PhaseDiagram<U, E, N> {
 }
 
 impl<U, E, const N: usize> PhaseDiagram<U, E, N> {
+    /// Create a phase diagram from a list of phase equilibria.
     pub fn new(states: Vec<PhaseEquilibrium<U, E, N>>) -> Self {
         Self { states }
     }

--- a/feos-core/src/phase_equilibria/phase_envelope.rs
+++ b/feos-core/src/phase_equilibria/phase_envelope.rs
@@ -6,7 +6,7 @@ use crate::{Contributions, EosUnit};
 use quantity::{QuantityArray1, QuantityScalar};
 use std::sync::Arc;
 
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
+impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     /// Calculate the bubble point line of a mixture with given composition.
     pub fn bubble_point_line(
         eos: &Arc<E>,
@@ -56,7 +56,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
         }
         states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
 
-        Ok(PhaseDiagram { states })
+        Ok(PhaseDiagram::new(states))
     }
 
     /// Calculate the dew point line of a mixture with given composition.
@@ -102,7 +102,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
 
         let n_p = npoints - n_t;
         if vle.is_none() {
-            return Ok(PhaseDiagram { states });
+            return Ok(PhaseDiagram::new(states));
         }
 
         let min_pressure = vle.as_ref().unwrap().vapor().pressure(Contributions::Total);
@@ -124,7 +124,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
 
         states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
 
-        Ok(PhaseDiagram { states })
+        Ok(PhaseDiagram::new(states))
     }
 
     /// Calculate the spinodal lines for a mixture with fixed composition.
@@ -160,6 +160,6 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E> {
         }
         states.push(PhaseEquilibrium::from_states(sc.clone(), sc));
 
-        Ok(PhaseDiagram { states })
+        Ok(PhaseDiagram::new(states))
     }
 }

--- a/feos-core/src/python/phase_equilibria.rs
+++ b/feos-core/src/python/phase_equilibria.rs
@@ -464,10 +464,15 @@ macro_rules! impl_phase_equilibrium {
 
         /// Phase diagram for a pure component or a binary mixture.
         #[pyclass(name = "PhaseDiagram")]
-        pub struct PyPhaseDiagram(PhaseDiagram<SIUnit, $eos>);
+        pub struct PyPhaseDiagram(PhaseDiagram<SIUnit, $eos, 2>);
 
         #[pymethods]
         impl PyPhaseDiagram {
+            #[new]
+            fn new(phase_equilibria: Vec<PyPhaseEquilibrium>) -> Self {
+                Self(PhaseDiagram::new(phase_equilibria.into_iter().map(|p| p.0).collect()))
+            }
+
             /// Calculate a pure component phase diagram.
             ///
             /// Parameters

--- a/feos-core/src/python/phase_equilibria.rs
+++ b/feos-core/src/python/phase_equilibria.rs
@@ -463,6 +463,15 @@ macro_rules! impl_phase_equilibrium {
         }
 
         /// Phase diagram for a pure component or a binary mixture.
+        ///
+        /// Parameters
+        /// ----------
+        /// phase_equilibria : [PhaseEquilibrium]
+        ///     A list of individual phase equilibria.
+        ///
+        /// Returns
+        /// -------
+        /// PhaseDiagram : the resulting phase diagram
         #[pyclass(name = "PhaseDiagram")]
         pub struct PyPhaseDiagram(PhaseDiagram<SIUnit, $eos, 2>);
 

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -1010,6 +1010,17 @@ macro_rules! impl_state {
         }
 
 
+        /// A list of states that provides convenient getters
+        /// for properties of all the individual states.
+        ///
+        /// Parameters
+        /// ----------
+        /// states : [State]
+        ///     A list of individual states.
+        ///
+        /// Returns
+        /// -------
+        /// StateVec
         #[pyclass(name = "StateVec")]
         pub struct PyStateVec(Vec<State<SIUnit, $eos>>);
 
@@ -1028,8 +1039,8 @@ macro_rules! impl_state {
         #[pymethods]
         impl PyStateVec {
             #[new]
-            fn new(vec: Vec<PyState>) -> Self {
-                Self(vec.into_iter().map(|s| s.0).collect())
+            fn new(states: Vec<PyState>) -> Self {
+                Self(states.into_iter().map(|s| s.0).collect())
             }
 
             fn __len__(&self) -> PyResult<usize> {

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -1027,6 +1027,11 @@ macro_rules! impl_state {
 
         #[pymethods]
         impl PyStateVec {
+            #[new]
+            fn new(vec: Vec<PyState>) -> Self {
+                Self(vec.into_iter().map(|s| s.0).collect())
+            }
+
             fn __len__(&self) -> PyResult<usize> {
                 Ok(self.0.len())
             }
@@ -1043,10 +1048,7 @@ macro_rules! impl_state {
                     Err(PyIndexError::new_err(format!("StateVec index out of range")))
                 }
             }
-        }
 
-        #[pymethods]
-        impl PyStateVec {
             #[getter]
             fn get_temperature(&self) -> PySIArray1{
                 StateVec::from(self).temperature().into()
@@ -1065,6 +1067,11 @@ macro_rules! impl_state {
             #[getter]
             fn get_density(&self) -> PySIArray1 {
                 StateVec::from(self).density().into()
+            }
+
+            #[getter]
+            fn get_moles<'py>(&self, py: Python<'py>) -> PySIArray2 {
+                StateVec::from(self).moles().into()
             }
 
             #[getter]

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -799,6 +799,12 @@ impl<'a, U: EosUnit, E: EquationOfState> StateVec<'a, U, E> {
         QuantityArray1::from_shape_fn(self.0.len(), |i| self.0[i].density)
     }
 
+    pub fn moles(&self) -> QuantityArray2<U> {
+        QuantityArray2::from_shape_fn((self.0.len(), self.0[0].eos.components()), |(i, j)| {
+            self.0[i].moles.get(j)
+        })
+    }
+
     pub fn molefracs(&self) -> Array2<f64> {
         Array2::from_shape_fn((self.0.len(), self.0[0].eos.components()), |(i, j)| {
             self.0[i].molefracs[j]

--- a/parameters/pcsaft/README.md
+++ b/parameters/pcsaft/README.md
@@ -35,5 +35,5 @@ The files named according to the pattern `NameYear.json` correspond to published
 [`sauer2014_homo_joback.json`](sauer2014_homo.json) | GC segment parameters for homosegmented PC-SAFT including ideal gas parameters | [&#128279;](https://doi.org/10.1021/ie502203w) [&#128279;](https://doi.org/10.1080/00986448708960487)|
 [`sauer2014_hetero.json`](sauer2014_hetero.json) | GC segment parameters for heterosegmented PC-SAFT | [&#128279;](https://doi.org/10.1021/ie502203w)
 [`sauer2014_hetero_joback.json`](sauer2014_hetero.json) | GC segment parameters for heterosegmented PC-SAFT including ideal gas parameters | [&#128279;](https://doi.org/10.1021/ie502203w) [&#128279;](https://doi.org/10.1080/00986448708960487)
-[`loetgeringlin2015_homo.json`](loetgeringlin2018.json) | GC segment parameters including for homosegmented PC-SAFT including viscosity parameter | [&#128279;](https://doi.org/10.1021/acs.iecr.5b01698)
+[`loetgeringlin2015_homo.json`](loetgeringlin2018.json) | GC segment parameters for homosegmented PC-SAFT including viscosity parameter | [&#128279;](https://doi.org/10.1021/acs.iecr.5b01698)
 

--- a/src/python/dft.rs
+++ b/src/python/dft.rs
@@ -258,6 +258,7 @@ pub fn dft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 
     m.add_class::<PyFunctionalVariant>()?;
     m.add_class::<PyState>()?;
+    m.add_class::<PyStateVec>()?;
     m.add_class::<PyPhaseDiagram>()?;
     m.add_class::<PyPhaseEquilibrium>()?;
     m.add_class::<FMTVersion>()?;

--- a/src/python/eos.rs
+++ b/src/python/eos.rs
@@ -299,6 +299,7 @@ pub fn eos(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 
     m.add_class::<PyEosVariant>()?;
     m.add_class::<PyState>()?;
+    m.add_class::<PyStateVec>()?;
     m.add_class::<PyPhaseDiagram>()?;
     m.add_class::<PyPhaseEquilibrium>()?;
 


### PR DESCRIPTION
This allows code like

```python
PhaseDiagram(
    [
        State(eos, temperature, pressure=p, moles=feed).tp_flash()
        for p in pressure
        if not State(eos, temperature, pressure=p, moles=feed).is_stable()
    ]
)
```
From the resulting `PhaseDiagram` object, the properties can then be obtained without having to write loops.

Similar to that `StateVec` is exposed in Python and gets a corresponding constructor, that can be used like this:
```python
StateVec([State(eos, temperature, pressure=p, moles=feed) for p in pressure])
```

Other smaller changes:
- `PhaseDiagram` "inherits" the const generic that indicates the number of phases from `PhaseEquilibrium`. It was a somewhat unnecessary limitation, that could make future additions breaking changes. In Python `PhaseDiagram` is still fixed to 2 phases and there is currently no analog to `ThreePhaseEquilibrium` as it isn't needed.
- `StateVec::moles` is added as an additional getter. A small inconvenience: At this point it is not possible to index `SIArray2`s in Python.