### PR TITLE
Remove unit generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export `EosVariant` and `FunctionalVariant` directly in the crate root instead of their own modules. [#62](https://github.com/feos-org/feos/pull/62)
 - Changed constructors `VaporPressure::new` and `DataSet.vapor_pressure` (Python) to take a new optional argument `critical_temperature`. [#86](https://github.com/feos-org/feos/pull/86)
 - The limitations of the homo gc method for PC-SAFT are enforced more strictly. [#88](https://github.com/feos-org/feos/pull/88)
+- Removed generics for units in all structs and traits in favor of static SI units. [#115](https://github.com/feos-org/feos/pull/115)
 
 ## [0.3.0] - 2022-09-14
 - Major restructuring of the entire `feos` project. All individual models are reunited in the `feos` crate. `feos-core` and `feos-dft` still live as individual crates within the `feos` workspace.

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -36,11 +36,7 @@ where
 }
 
 /// Benchmark for evaluation of the Helmholtz energy for different dual number types.
-fn bench_dual_numbers<E: EquationOfState>(
-    c: &mut Criterion,
-    group_name: &str,
-    state: State<E>,
-) {
+fn bench_dual_numbers<E: EquationOfState>(c: &mut Criterion, group_name: &str, state: State<E>) {
     let mut group = c.benchmark_group(group_name);
     group.bench_function("a_f64", |b| {
         b.iter(|| a_res((&state.eos, &state.derive0())))

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// - temperature is 80% of critical temperature,
 /// - volume is critical volume,
 /// - molefracs (or moles) for equimolar mixture.
-fn state_pcsaft(parameters: PcSaftParameters) -> State<SIUnit, PcSaft> {
+fn state_pcsaft(parameters: PcSaftParameters) -> State<PcSaft> {
     let n = parameters.pure_records.len();
     let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
     let moles = Array::from_elem(n, 1.0 / n as f64) * 10.0 * MOL;
@@ -39,7 +39,7 @@ where
 fn bench_dual_numbers<E: EquationOfState>(
     c: &mut Criterion,
     group_name: &str,
-    state: State<SIUnit, E>,
+    state: State<E>,
 ) {
     let mut group = c.benchmark_group(group_name);
     group.bench_function("a_f64", |b| {

--- a/benches/state_creation.rs
+++ b/benches/state_creation.rs
@@ -15,7 +15,7 @@ fn npt<E: EquationOfState>(
         SINumber,
         SINumber,
         &SIArray1,
-        DensityInitialization<SIUnit>,
+        DensityInitialization,
     ),
 ) {
     State::new_npt(eos, t, p, n, rho0).unwrap();

--- a/benches/state_properties.rs
+++ b/benches/state_properties.rs
@@ -8,11 +8,11 @@ use ndarray::arr1;
 use quantity::si::*;
 use std::sync::Arc;
 
-type S = State<SIUnit, PcSaft>;
+type S = State<PcSaft>;
 
 /// Evaluate a property of a state given the EoS, the property to compute,
 /// temperature, volume, moles, and the contributions to consider.
-fn property<E: EquationOfState, T, F: Fn(&State<SIUnit, E>, Contributions) -> T>(
+fn property<E: EquationOfState, T, F: Fn(&State<E>, Contributions) -> T>(
     (eos, property, t, v, n, contributions): (
         &Arc<E>,
         F,
@@ -28,7 +28,7 @@ fn property<E: EquationOfState, T, F: Fn(&State<SIUnit, E>, Contributions) -> T>
 
 /// Evaluate a property with of a state given the EoS, the property to compute,
 /// temperature, volume, moles.
-fn property_no_contributions<E: EquationOfState, T, F: Fn(&State<SIUnit, E>) -> T>(
+fn property_no_contributions<E: EquationOfState, T, F: Fn(&State<E>) -> T>(
     (eos, property, t, v, n): (&Arc<E>, F, SINumber, SINumber, &SIArray1),
 ) -> T {
     let state = State::new_nvt(eos, t, v, n).unwrap();

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `StateVec::moles` getter. [#113](https://github.com/feos-org/feos/pull/113)
 - Added public constructors `PhaseDiagram::new` and `StateVec::new` that allow the creation of the respective structs from a list of `PhaseEquilibrium`s or `State`s in Rust and Python. [#113](https://github.com/feos-org/feos/pull/113)
 - Added new variant `EosError::Error` which allows dispatching generic errors that are not covered by the existing variants. [#98](https://github.com/feos-org/feos/pull/98)
+- Removed generics for units in all structs and traits in favor of static SI units. [#115](https://github.com/feos-org/feos/pull/115)
 
 ### Changed
 - Added `Sync` and `Send` as supertraits to `EquationOfState`. [#57](https://github.com/feos-org/feos/pull/57)

--- a/feos-core/src/cubic.rs
+++ b/feos-core/src/cubic.rs
@@ -14,7 +14,7 @@ use crate::state::StateHD;
 use crate::MolarWeight;
 use ndarray::{Array1, Array2};
 use num_dual::DualNum;
-use quantity::si::{SIArray1, SIUnit};
+use quantity::si::SIArray1;
 use serde::{Deserialize, Serialize};
 use std::f64::consts::SQRT_2;
 use std::fmt;
@@ -255,7 +255,7 @@ impl EquationOfState for PengRobinson {
     }
 }
 
-impl MolarWeight<SIUnit> for PengRobinson {
+impl MolarWeight for PengRobinson {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/feos-core/src/density_iteration.rs
+++ b/feos-core/src/density_iteration.rs
@@ -2,7 +2,7 @@ use crate::equation_of_state::EquationOfState;
 use crate::errors::{EosError, EosResult};
 use crate::state::State;
 use crate::EosUnit;
-use quantity::si::{SINumber, SIArray1, SIUnit};
+use quantity::si::{SIArray1, SINumber, SIUnit};
 use std::sync::Arc;
 
 pub fn density_iteration<E: EquationOfState>(
@@ -129,7 +129,10 @@ pub fn density_iteration<E: EquationOfState>(
         // Newton step
         rho += delta_rho;
         if error.to_reduced(SIUnit::reference_pressure())?.abs()
-            < f64::max(abstol, (rho * reltol).to_reduced(SIUnit::reference_density())?)
+            < f64::max(
+                abstol,
+                (rho * reltol).to_reduced(SIUnit::reference_density())?,
+            )
         {
             break 'iteration;
         }

--- a/feos-core/src/density_iteration.rs
+++ b/feos-core/src/density_iteration.rs
@@ -2,26 +2,26 @@ use crate::equation_of_state::EquationOfState;
 use crate::errors::{EosError, EosResult};
 use crate::state::State;
 use crate::EosUnit;
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SINumber, SIArray1, SIUnit};
 use std::sync::Arc;
 
-pub fn density_iteration<U: EosUnit, E: EquationOfState>(
+pub fn density_iteration<E: EquationOfState>(
     eos: &Arc<E>,
-    temperature: QuantityScalar<U>,
-    pressure: QuantityScalar<U>,
-    moles: &QuantityArray1<U>,
-    initial_density: QuantityScalar<U>,
-) -> EosResult<State<U, E>> {
+    temperature: SINumber,
+    pressure: SINumber,
+    moles: &SIArray1,
+    initial_density: SINumber,
+) -> EosResult<State<E>> {
     let maxdensity = eos.max_density(Some(moles))?;
     let (abstol, reltol) = (1e-12, 1e-14);
     let n = moles.sum();
 
     let mut rho = initial_density;
-    if rho <= 0.0 * U::reference_density() {
+    if rho <= 0.0 * SIUnit::reference_density() {
         return Err(EosError::InvalidState(
             String::from("density iteration"),
             String::from("density"),
-            rho.to_reduced(U::reference_density())?,
+            rho.to_reduced(SIUnit::reference_density())?,
         ));
     }
 
@@ -117,7 +117,7 @@ pub fn density_iteration<U: EosUnit, E: EquationOfState>(
             } else {
                 rho = (rho + initial_density) * 0.5;
                 if (rho - initial_density)
-                    .to_reduced(U::reference_density())?
+                    .to_reduced(SIUnit::reference_density())?
                     .abs()
                     < 1e-8
                 {
@@ -128,8 +128,8 @@ pub fn density_iteration<U: EosUnit, E: EquationOfState>(
         }
         // Newton step
         rho += delta_rho;
-        if error.to_reduced(U::reference_pressure())?.abs()
-            < f64::max(abstol, (rho * reltol).to_reduced(U::reference_density())?)
+        if error.to_reduced(SIUnit::reference_pressure())?.abs()
+            < f64::max(abstol, (rho * reltol).to_reduced(SIUnit::reference_density())?)
         {
             break 'iteration;
         }
@@ -141,12 +141,12 @@ pub fn density_iteration<U: EosUnit, E: EquationOfState>(
     }
 }
 
-fn pressure_spinodal<U: EosUnit, E: EquationOfState>(
+fn pressure_spinodal<E: EquationOfState>(
     eos: &Arc<E>,
-    temperature: QuantityScalar<U>,
-    rho_init: QuantityScalar<U>,
-    moles: &QuantityArray1<U>,
-) -> EosResult<[QuantityScalar<U>; 2]> {
+    temperature: SINumber,
+    rho_init: SINumber,
+    moles: &SIArray1,
+) -> EosResult<[SINumber; 2]> {
     let maxiter = 30;
     let abstol = 1e-8;
 
@@ -154,11 +154,11 @@ fn pressure_spinodal<U: EosUnit, E: EquationOfState>(
     let n = moles.sum();
     let mut rho = rho_init;
 
-    if rho <= 0.0 * U::reference_density() {
+    if rho <= 0.0 * SIUnit::reference_density() {
         return Err(EosError::InvalidState(
             String::from("pressure spinodal"),
             String::from("density"),
-            rho.to_reduced(U::reference_density())?,
+            rho.to_reduced(SIUnit::reference_density())?,
         ));
     }
 
@@ -174,7 +174,7 @@ fn pressure_spinodal<U: EosUnit, E: EquationOfState>(
         rho += delta_rho;
 
         if dpdrho
-            .to_reduced(U::reference_pressure() / U::reference_density())?
+            .to_reduced(SIUnit::reference_pressure() / SIUnit::reference_density())?
             .abs()
             < abstol
         {

--- a/feos-core/src/joback.rs
+++ b/feos-core/src/joback.rs
@@ -85,11 +85,7 @@ impl Joback {
     }
 
     /// Directly calculates the ideal gas heat capacity from the Joback model.
-    pub fn c_p(
-        &self,
-        temperature: SINumber,
-        molefracs: &Array1<f64>,
-    ) -> EosResult<SINumber> {
+    pub fn c_p(&self, temperature: SINumber, molefracs: &Array1<f64>) -> EosResult<SINumber> {
         let t = temperature.to_reduced(SIUnit::reference_temperature())?;
         let mut c_p = 0.0;
         for (j, &x) in self.records.iter().zip(molefracs.iter()) {

--- a/feos-core/src/joback.rs
+++ b/feos-core/src/joback.rs
@@ -9,7 +9,7 @@ use crate::{
 use conv::ValueInto;
 use ndarray::Array1;
 use num_dual::*;
-use quantity::QuantityScalar;
+use quantity::si::{SINumber, SIUnit};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -85,17 +85,17 @@ impl Joback {
     }
 
     /// Directly calculates the ideal gas heat capacity from the Joback model.
-    pub fn c_p<U: EosUnit>(
+    pub fn c_p(
         &self,
-        temperature: QuantityScalar<U>,
+        temperature: SINumber,
         molefracs: &Array1<f64>,
-    ) -> EosResult<QuantityScalar<U>> {
-        let t = temperature.to_reduced(U::reference_temperature())?;
+    ) -> EosResult<SINumber> {
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
         let mut c_p = 0.0;
         for (j, &x) in self.records.iter().zip(molefracs.iter()) {
             c_p += x * (j.a + j.b * t + j.c * t.powi(2) + j.d * t.powi(3) + j.e * t.powi(4));
         }
-        Ok(c_p / RGAS * U::gas_constant())
+        Ok(c_p / RGAS * SIUnit::gas_constant())
     }
 }
 

--- a/feos-core/src/lib.rs
+++ b/feos-core/src/lib.rs
@@ -42,7 +42,9 @@ pub use errors::{EosError, EosResult};
 pub use phase_equilibria::{
     PhaseDiagram, PhaseDiagramHetero, PhaseEquilibrium, SolverOptions, Verbosity,
 };
-pub use state::{Contributions, DensityInitialization, State, StateBuilder, StateHD, StateVec, Derivative};
+pub use state::{
+    Contributions, DensityInitialization, Derivative, State, StateBuilder, StateHD, StateVec,
+};
 
 #[cfg(feature = "python")]
 pub mod python;

--- a/feos-core/src/phase_equilibria/mod.rs
+++ b/feos-core/src/phase_equilibria/mod.rs
@@ -2,7 +2,7 @@ use crate::equation_of_state::EquationOfState;
 use crate::errors::{EosError, EosResult};
 use crate::state::{Contributions, DensityInitialization, State};
 use crate::EosUnit;
-use quantity::si::{SINumber, SIArray1, SIUnit};
+use quantity::si::{SIArray1, SINumber, SIUnit};
 use std::fmt;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -261,10 +261,7 @@ impl<E: EquationOfState, const N: usize> PhaseEquilibrium<E, N> {
         Ok(())
     }
 
-    pub fn update_chemical_potential(
-        &mut self,
-        chemical_potential: &SIArray1,
-    ) -> EosResult<()> {
+    pub fn update_chemical_potential(&mut self, chemical_potential: &SIArray1) -> EosResult<()> {
         for s in self.0.iter_mut() {
             s.update_chemical_potential(chemical_potential)?;
         }
@@ -272,9 +269,11 @@ impl<E: EquationOfState, const N: usize> PhaseEquilibrium<E, N> {
     }
 
     pub(super) fn total_gibbs_energy(&self) -> SINumber {
-        self.0.iter().fold(0.0 * SIUnit::reference_energy(), |acc, s| {
-            acc + s.gibbs_energy(Contributions::Total)
-        })
+        self.0
+            .iter()
+            .fold(0.0 * SIUnit::reference_energy(), |acc, s| {
+                acc + s.gibbs_energy(Contributions::Total)
+            })
     }
 }
 

--- a/feos-core/src/phase_equilibria/phase_diagram_binary.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_binary.rs
@@ -24,9 +24,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints: Option<usize>,
         x_lle: Option<(f64, f64)>,
         bubble_dew_options: (SolverOptions, SolverOptions),
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let npoints = npoints.unwrap_or(DEFAULT_POINTS);
         let tp = temperature_or_pressure.try_into()?;
 
@@ -104,9 +102,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         x_lle: (f64, f64),
         vle_sat: [Option<PhaseEquilibrium<E, 2>>; 2],
         bubble_dew_options: (SolverOptions, SolverOptions),
-    ) -> EosResult<(Vec<PhaseEquilibrium<E, 2>>, Vec<PhaseEquilibrium<E, 2>>)>
-    
-    {
+    ) -> EosResult<(Vec<PhaseEquilibrium<E, 2>>, Vec<PhaseEquilibrium<E, 2>>)> {
         match vle_sat {
             [Some(vle2), Some(vle1)] => {
                 let states1 = iterate_vle(
@@ -148,9 +144,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         min_tp: SINumber,
         max_tp: SINumber,
         npoints: Option<usize>,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let npoints = npoints.unwrap_or(DEFAULT_POINTS);
         let mut states = Vec::with_capacity(npoints);
         let tp: TPSpec = temperature_or_pressure.try_into()?;
@@ -268,9 +262,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints_vle: Option<usize>,
         npoints_lle: Option<usize>,
         bubble_dew_options: (SolverOptions, SolverOptions),
-    ) -> EosResult<PhaseDiagramHetero<E>>
-    
-    {
+    ) -> EosResult<PhaseDiagramHetero<E>> {
         let npoints_vle = npoints_vle.unwrap_or(DEFAULT_POINTS);
         let tp = temperature_or_pressure.try_into()?;
 

--- a/feos-core/src/phase_equilibria/phase_diagram_binary.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_binary.rs
@@ -25,8 +25,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         x_lle: Option<(f64, f64)>,
         bubble_dew_options: (SolverOptions, SolverOptions),
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let npoints = npoints.unwrap_or(DEFAULT_POINTS);
         let tp = temperature_or_pressure.try_into()?;
@@ -106,8 +105,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         vle_sat: [Option<PhaseEquilibrium<E, 2>>; 2],
         bubble_dew_options: (SolverOptions, SolverOptions),
     ) -> EosResult<(Vec<PhaseEquilibrium<E, 2>>, Vec<PhaseEquilibrium<E, 2>>)>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         match vle_sat {
             [Some(vle2), Some(vle1)] => {
@@ -151,8 +149,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         max_tp: SINumber,
         npoints: Option<usize>,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let npoints = npoints.unwrap_or(DEFAULT_POINTS);
         let mut states = Vec::with_capacity(npoints);
@@ -272,8 +269,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints_lle: Option<usize>,
         bubble_dew_options: (SolverOptions, SolverOptions),
     ) -> EosResult<PhaseDiagramHetero<E>>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let npoints_vle = npoints_vle.unwrap_or(DEFAULT_POINTS);
         let tp = temperature_or_pressure.try_into()?;

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -38,9 +38,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints: usize,
         critical_temperature: Option<SINumber>,
         options: SolverOptions,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let mut states = Vec::with_capacity(npoints);
 
         let sc = State::critical_point(eos, None, critical_temperature, SolverOptions::default())?;
@@ -78,9 +76,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         eos: &Arc<E>,
         temperatures: ArrayView1<f64>,
         options: SolverOptions,
-    ) -> EosResult<Vec<PhaseEquilibrium<E, 2>>>
-    
-    {
+    ) -> EosResult<Vec<PhaseEquilibrium<E, 2>>> {
         let mut states = Vec::with_capacity(temperatures.len());
         let mut vle = None;
         for ti in temperatures {
@@ -106,9 +102,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         thread_pool: ThreadPool,
         critical_temperature: Option<SINumber>,
         options: SolverOptions,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let sc = State::critical_point(eos, None, critical_temperature, SolverOptions::default())?;
 
         let max_temperature = min_temperature

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -2,9 +2,10 @@ use super::{PhaseEquilibrium, SolverOptions};
 use crate::equation_of_state::EquationOfState;
 use crate::errors::EosResult;
 use crate::state::{State, StateVec};
+use crate::EosUnit;
 #[cfg(feature = "rayon")]
 use ndarray::{Array1, ArrayView1, Axis};
-use quantity::si::{SINumber, SIArray1};
+use quantity::si::{SIArray1, SINumber, SIUnit};
 #[cfg(feature = "rayon")]
 use rayon::{prelude::*, ThreadPool};
 use std::sync::Arc;

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -2,20 +2,19 @@ use super::{PhaseEquilibrium, SolverOptions};
 use crate::equation_of_state::EquationOfState;
 use crate::errors::EosResult;
 use crate::state::{State, StateVec};
-use crate::EosUnit;
 #[cfg(feature = "rayon")]
 use ndarray::{Array1, ArrayView1, Axis};
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SINumber, SIArray1};
 #[cfg(feature = "rayon")]
 use rayon::{prelude::*, ThreadPool};
 use std::sync::Arc;
 
 /// Pure component and binary mixture phase diagrams.
-pub struct PhaseDiagram<U, E, const N: usize> {
-    pub states: Vec<PhaseEquilibrium<U, E, N>>,
+pub struct PhaseDiagram<E, const N: usize> {
+    pub states: Vec<PhaseEquilibrium<E, N>>,
 }
 
-impl<U: Clone, E, const N: usize> Clone for PhaseDiagram<U, E, N> {
+impl<E, const N: usize> Clone for PhaseDiagram<E, N> {
     fn clone(&self) -> Self {
         Self {
             states: self.states.clone(),
@@ -23,24 +22,24 @@ impl<U: Clone, E, const N: usize> Clone for PhaseDiagram<U, E, N> {
     }
 }
 
-impl<U, E, const N: usize> PhaseDiagram<U, E, N> {
+impl<E, const N: usize> PhaseDiagram<E, N> {
     /// Create a phase diagram from a list of phase equilibria.
-    pub fn new(states: Vec<PhaseEquilibrium<U, E, N>>) -> Self {
+    pub fn new(states: Vec<PhaseEquilibrium<E, N>>) -> Self {
         Self { states }
     }
 }
 
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
+impl<E: EquationOfState> PhaseDiagram<E, 2> {
     /// Calculate a phase diagram for a pure component.
     pub fn pure(
         eos: &Arc<E>,
-        min_temperature: QuantityScalar<U>,
+        min_temperature: SINumber,
         npoints: usize,
-        critical_temperature: Option<QuantityScalar<U>>,
+        critical_temperature: Option<SINumber>,
         options: SolverOptions,
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -48,7 +47,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
 
         let max_temperature = min_temperature
             + (sc.temperature - min_temperature) * ((npoints - 2) as f64 / (npoints - 1) as f64);
-        let temperatures = QuantityArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
+        let temperatures = SIArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
 
         let mut vle = None;
         for ti in &temperatures {
@@ -63,32 +62,32 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     }
 
     /// Return the vapor states of the diagram.
-    pub fn vapor(&self) -> StateVec<'_, U, E> {
+    pub fn vapor(&self) -> StateVec<'_, E> {
         self.states.iter().map(|s| s.vapor()).collect()
     }
 
     /// Return the liquid states of the diagram.
-    pub fn liquid(&self) -> StateVec<'_, U, E> {
+    pub fn liquid(&self) -> StateVec<'_, E> {
         self.states.iter().map(|s| s.liquid()).collect()
     }
 }
 
 #[cfg(feature = "rayon")]
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
+impl<E: EquationOfState> PhaseDiagram<E, 2> {
     fn solve_temperatures(
         eos: &Arc<E>,
         temperatures: ArrayView1<f64>,
         options: SolverOptions,
-    ) -> EosResult<Vec<PhaseEquilibrium<U, E, 2>>>
+    ) -> EosResult<Vec<PhaseEquilibrium<E, 2>>>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let mut states = Vec::with_capacity(temperatures.len());
         let mut vle = None;
         for ti in temperatures {
             vle = PhaseEquilibrium::pure(
                 eos,
-                *ti * U::reference_temperature(),
+                *ti * SIUnit::reference_temperature(),
                 vle.as_ref(),
                 options,
             )
@@ -102,27 +101,27 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
 
     pub fn par_pure(
         eos: &Arc<E>,
-        min_temperature: QuantityScalar<U>,
+        min_temperature: SINumber,
         npoints: usize,
         chunksize: usize,
         thread_pool: ThreadPool,
-        critical_temperature: Option<QuantityScalar<U>>,
+        critical_temperature: Option<SINumber>,
         options: SolverOptions,
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let sc = State::critical_point(eos, None, critical_temperature, SolverOptions::default())?;
 
         let max_temperature = min_temperature
             + (sc.temperature - min_temperature) * ((npoints - 2) as f64 / (npoints - 1) as f64);
         let temperatures = Array1::linspace(
-            min_temperature.to_reduced(U::reference_temperature())?,
-            max_temperature.to_reduced(U::reference_temperature())?,
+            min_temperature.to_reduced(SIUnit::reference_temperature())?,
+            max_temperature.to_reduced(SIUnit::reference_temperature())?,
             npoints - 1,
         );
 
-        let mut states: Vec<PhaseEquilibrium<U, E, 2>> = thread_pool.install(|| {
+        let mut states: Vec<PhaseEquilibrium<E, 2>> = thread_pool.install(|| {
             temperatures
                 .axis_chunks_iter(Axis(0), chunksize)
                 .into_par_iter()

--- a/feos-core/src/phase_equilibria/phase_diagram_pure.rs
+++ b/feos-core/src/phase_equilibria/phase_diagram_pure.rs
@@ -39,8 +39,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         critical_temperature: Option<SINumber>,
         options: SolverOptions,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -80,8 +79,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         temperatures: ArrayView1<f64>,
         options: SolverOptions,
     ) -> EosResult<Vec<PhaseEquilibrium<E, 2>>>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let mut states = Vec::with_capacity(temperatures.len());
         let mut vle = None;
@@ -109,8 +107,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         critical_temperature: Option<SINumber>,
         options: SolverOptions,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let sc = State::critical_point(eos, None, critical_temperature, SolverOptions::default())?;
 

--- a/feos-core/src/phase_equilibria/phase_envelope.rs
+++ b/feos-core/src/phase_equilibria/phase_envelope.rs
@@ -15,9 +15,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints: usize,
         critical_temperature: Option<SINumber>,
         options: (SolverOptions, SolverOptions),
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let mut states = Vec::with_capacity(npoints);
 
         let sc = State::critical_point(
@@ -66,9 +64,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints: usize,
         critical_temperature: Option<SINumber>,
         options: (SolverOptions, SolverOptions),
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let mut states = Vec::with_capacity(npoints);
 
         let sc = State::critical_point(
@@ -133,9 +129,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         npoints: usize,
         critical_temperature: Option<SINumber>,
         options: SolverOptions,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let mut states = Vec::with_capacity(npoints);
 
         let sc = State::critical_point(

--- a/feos-core/src/phase_equilibria/phase_envelope.rs
+++ b/feos-core/src/phase_equilibria/phase_envelope.rs
@@ -16,8 +16,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         critical_temperature: Option<SINumber>,
         options: (SolverOptions, SolverOptions),
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -68,8 +67,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         critical_temperature: Option<SINumber>,
         options: (SolverOptions, SolverOptions),
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -136,8 +134,7 @@ impl<E: EquationOfState> PhaseDiagram<E, 2> {
         critical_temperature: Option<SINumber>,
         options: SolverOptions,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let mut states = Vec::with_capacity(npoints);
 

--- a/feos-core/src/phase_equilibria/phase_envelope.rs
+++ b/feos-core/src/phase_equilibria/phase_envelope.rs
@@ -2,22 +2,22 @@ use super::{PhaseDiagram, PhaseEquilibrium, SolverOptions};
 use crate::equation_of_state::EquationOfState;
 use crate::errors::EosResult;
 use crate::state::State;
-use crate::{Contributions, EosUnit};
-use quantity::{QuantityArray1, QuantityScalar};
+use crate::Contributions;
+use quantity::si::{SIArray1, SINumber};
 use std::sync::Arc;
 
-impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
+impl<E: EquationOfState> PhaseDiagram<E, 2> {
     /// Calculate the bubble point line of a mixture with given composition.
     pub fn bubble_point_line(
         eos: &Arc<E>,
-        moles: &QuantityArray1<U>,
-        min_temperature: QuantityScalar<U>,
+        moles: &SIArray1,
+        min_temperature: SINumber,
         npoints: usize,
-        critical_temperature: Option<QuantityScalar<U>>,
+        critical_temperature: Option<SINumber>,
         options: (SolverOptions, SolverOptions),
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -30,10 +30,10 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
 
         let max_temperature = min_temperature
             + (sc.temperature - min_temperature) * ((npoints - 2) as f64 / (npoints - 1) as f64);
-        let temperatures = QuantityArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
+        let temperatures = SIArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
         let molefracs = moles.to_reduced(moles.sum())?;
 
-        let mut vle: Option<PhaseEquilibrium<U, E, 2>> = None;
+        let mut vle: Option<PhaseEquilibrium<E, 2>> = None;
         for ti in &temperatures {
             // calculate new liquid point
             let p_init = vle
@@ -62,14 +62,14 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     /// Calculate the dew point line of a mixture with given composition.
     pub fn dew_point_line(
         eos: &Arc<E>,
-        moles: &QuantityArray1<U>,
-        min_temperature: QuantityScalar<U>,
+        moles: &SIArray1,
+        min_temperature: SINumber,
         npoints: usize,
-        critical_temperature: Option<QuantityScalar<U>>,
+        critical_temperature: Option<SINumber>,
         options: (SolverOptions, SolverOptions),
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -83,10 +83,10 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
         let n_t = npoints / 2;
         let max_temperature = min_temperature
             + (sc.temperature - min_temperature) * ((n_t - 2) as f64 / (n_t - 1) as f64);
-        let temperatures = QuantityArray1::linspace(min_temperature, max_temperature, n_t - 1)?;
+        let temperatures = SIArray1::linspace(min_temperature, max_temperature, n_t - 1)?;
         let molefracs = moles.to_reduced(moles.sum())?;
 
-        let mut vle: Option<PhaseEquilibrium<U, E, 2>> = None;
+        let mut vle: Option<PhaseEquilibrium<E, 2>> = None;
         for ti in &temperatures {
             let p_init = vle
                 .as_ref()
@@ -109,7 +109,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
         let p_c = sc.pressure(Contributions::Total);
         let max_pressure =
             min_pressure + (p_c - min_pressure) * ((n_p - 2) as f64 / (n_p - 1) as f64);
-        let pressures = QuantityArray1::linspace(min_pressure, max_pressure, n_p)?;
+        let pressures = SIArray1::linspace(min_pressure, max_pressure, n_p)?;
 
         for pi in &pressures {
             let t_init = vle.as_ref().map(|vle| vle.vapor().temperature);
@@ -130,14 +130,14 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
     /// Calculate the spinodal lines for a mixture with fixed composition.
     pub fn spinodal(
         eos: &Arc<E>,
-        moles: &QuantityArray1<U>,
-        min_temperature: QuantityScalar<U>,
+        moles: &SIArray1,
+        min_temperature: SINumber,
         npoints: usize,
-        critical_temperature: Option<QuantityScalar<U>>,
+        critical_temperature: Option<SINumber>,
         options: SolverOptions,
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let mut states = Vec::with_capacity(npoints);
 
@@ -150,7 +150,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseDiagram<U, E, 2> {
 
         let max_temperature = min_temperature
             + (sc.temperature - min_temperature) * ((npoints - 2) as f64 / (npoints - 1) as f64);
-        let temperatures = QuantityArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
+        let temperatures = SIArray1::linspace(min_temperature, max_temperature, npoints - 1)?;
 
         for ti in &temperatures {
             let spinodal = State::spinodal(eos, ti, Some(moles), options).ok();

--- a/feos-core/src/phase_equilibria/tp_flash.rs
+++ b/feos-core/src/phase_equilibria/tp_flash.rs
@@ -4,7 +4,7 @@ use crate::errors::{EosError, EosResult};
 use crate::state::{Contributions, DensityInitialization, State};
 use ndarray::*;
 use num_dual::linalg::norm;
-use quantity::si::{SINumber, SIArray1};
+use quantity::si::{SIArray1, SINumber};
 use std::sync::Arc;
 
 const MAX_ITER_TP: usize = 400;

--- a/feos-core/src/phase_equilibria/vle_pure.rs
+++ b/feos-core/src/phase_equilibria/vle_pure.rs
@@ -21,8 +21,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         initial_state: Option<&PhaseEquilibrium<E, 2>>,
         options: SolverOptions,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         match TPSpec::try_from(temperature_or_pressure)? {
             TPSpec::Temperature(t) => Self::pure_t(eos, t, initial_state, options),
@@ -38,8 +37,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         initial_state: Option<&PhaseEquilibrium<E, 2>>,
         options: SolverOptions,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
 
@@ -68,8 +66,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     }
 
     fn iterate_pure_t(self, max_iter: usize, tol: f64, verbosity: Verbosity) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let mut p_old = self.vapor().pressure(Contributions::Total);
         let [mut vapor, mut liquid] = self.0;
@@ -172,8 +169,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         initial_state: Option<&Self>,
         options: SolverOptions,
     ) -> EosResult<Self>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
 
@@ -362,8 +358,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     /// Calculate the pure component vapor pressures of all
     /// components in the system for the given temperature.
     pub fn vapor_pressure(eos: &Arc<E>, temperature: SINumber) -> Vec<Option<SINumber>>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         (0..eos.components())
             .map(|i| {
@@ -378,8 +373,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     /// Calculate the pure component boiling temperatures of all
     /// components in the system for the given pressure.
     pub fn boiling_temperature(eos: &Arc<E>, pressure: SINumber) -> Vec<Option<SINumber>>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         (0..eos.components())
             .map(|i| {
@@ -397,8 +391,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         eos: &Arc<E>,
         temperature_or_pressure: SINumber,
     ) -> Vec<Option<PhaseEquilibrium<E, 2>>>
-    where
-        SINumber: std::fmt::Display + std::fmt::LowerExp,
+    
     {
         (0..eos.components())
             .map(|i| {

--- a/feos-core/src/phase_equilibria/vle_pure.rs
+++ b/feos-core/src/phase_equilibria/vle_pure.rs
@@ -20,9 +20,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         temperature_or_pressure: SINumber,
         initial_state: Option<&PhaseEquilibrium<E, 2>>,
         options: SolverOptions,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         match TPSpec::try_from(temperature_or_pressure)? {
             TPSpec::Temperature(t) => Self::pure_t(eos, t, initial_state, options),
             TPSpec::Pressure(p) => Self::pure_p(eos, p, initial_state, options),
@@ -36,9 +34,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         temperature: SINumber,
         initial_state: Option<&PhaseEquilibrium<E, 2>>,
         options: SolverOptions,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
 
         // First use given initial state if applicable
@@ -65,9 +61,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         )
     }
 
-    fn iterate_pure_t(self, max_iter: usize, tol: f64, verbosity: Verbosity) -> EosResult<Self>
-    
-    {
+    fn iterate_pure_t(self, max_iter: usize, tol: f64, verbosity: Verbosity) -> EosResult<Self> {
         let mut p_old = self.vapor().pressure(Contributions::Total);
         let [mut vapor, mut liquid] = self.0;
 
@@ -168,9 +162,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
         pressure: SINumber,
         initial_state: Option<&Self>,
         options: SolverOptions,
-    ) -> EosResult<Self>
-    
-    {
+    ) -> EosResult<Self> {
         let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
 
         // Initialize the phase equilibrium
@@ -357,9 +349,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
 impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     /// Calculate the pure component vapor pressures of all
     /// components in the system for the given temperature.
-    pub fn vapor_pressure(eos: &Arc<E>, temperature: SINumber) -> Vec<Option<SINumber>>
-    
-    {
+    pub fn vapor_pressure(eos: &Arc<E>, temperature: SINumber) -> Vec<Option<SINumber>> {
         (0..eos.components())
             .map(|i| {
                 let pure_eos = Arc::new(eos.subset(&[i]));
@@ -372,9 +362,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
 
     /// Calculate the pure component boiling temperatures of all
     /// components in the system for the given pressure.
-    pub fn boiling_temperature(eos: &Arc<E>, pressure: SINumber) -> Vec<Option<SINumber>>
-    
-    {
+    pub fn boiling_temperature(eos: &Arc<E>, pressure: SINumber) -> Vec<Option<SINumber>> {
         (0..eos.components())
             .map(|i| {
                 let pure_eos = Arc::new(eos.subset(&[i]));
@@ -390,9 +378,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     pub fn vle_pure_comps(
         eos: &Arc<E>,
         temperature_or_pressure: SINumber,
-    ) -> Vec<Option<PhaseEquilibrium<E, 2>>>
-    
-    {
+    ) -> Vec<Option<PhaseEquilibrium<E, 2>>> {
         (0..eos.components())
             .map(|i| {
                 let pure_eos = Arc::new(eos.subset(&[i]));

--- a/feos-core/src/phase_equilibria/vle_pure.rs
+++ b/feos-core/src/phase_equilibria/vle_pure.rs
@@ -4,26 +4,25 @@ use crate::errors::{EosError, EosResult};
 use crate::state::{Contributions, DensityInitialization, State, TPSpec};
 use crate::EosUnit;
 use ndarray::{arr1, Array1};
-use quantity::QuantityScalar;
+use quantity::si::{SINumber, SIUnit};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
 const SCALE_T_NEW: f64 = 0.7;
-
 const MAX_ITER_PURE: usize = 50;
 const TOL_PURE: f64 = 1e-12;
 
 /// # Pure component phase equilibria
-impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     /// Calculate a phase equilibrium for a pure component.
     pub fn pure(
         eos: &Arc<E>,
-        temperature_or_pressure: QuantityScalar<U>,
-        initial_state: Option<&PhaseEquilibrium<U, E, 2>>,
+        temperature_or_pressure: SINumber,
+        initial_state: Option<&PhaseEquilibrium<E, 2>>,
         options: SolverOptions,
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         match TPSpec::try_from(temperature_or_pressure)? {
             TPSpec::Temperature(t) => Self::pure_t(eos, t, initial_state, options),
@@ -35,12 +34,12 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
     /// and given temperature.
     fn pure_t(
         eos: &Arc<E>,
-        temperature: QuantityScalar<U>,
-        initial_state: Option<&PhaseEquilibrium<U, E, 2>>,
+        temperature: SINumber,
+        initial_state: Option<&PhaseEquilibrium<E, 2>>,
         options: SolverOptions,
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
 
@@ -70,7 +69,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
 
     fn iterate_pure_t(self, max_iter: usize, tol: f64, verbosity: Verbosity) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let mut p_old = self.vapor().pressure(Contributions::Total);
         let [mut vapor, mut liquid] = self.0;
@@ -107,12 +106,12 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
                 let mu_v = vapor.chemical_potential(Contributions::Total).get(0);
                 p_new = p_v
                     * (a_l - mu_v)
-                        .to_reduced(vapor.temperature * U::gas_constant())?
+                        .to_reduced(vapor.temperature * SIUnit::gas_constant())?
                         .exp();
             }
 
             // Improve the estimate by exploiting the almost ideal behavior of the gas phase
-            let kt = U::gas_constant() * vapor.temperature;
+            let kt = SIUnit::gas_constant() * vapor.temperature;
             let mut newton_iter = 0;
             let newton_tol = p_old * delta_v * tol;
             for _ in 0..20 {
@@ -169,12 +168,12 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
     /// and given pressure.
     fn pure_p(
         eos: &Arc<E>,
-        pressure: QuantityScalar<U>,
+        pressure: SINumber,
         initial_state: Option<&Self>,
         options: SolverOptions,
     ) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         let (max_iter, tol, verbosity) = options.unwrap_or(MAX_ITER_PURE, TOL_PURE);
 
@@ -228,7 +227,7 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
 
             if rho_l.is_sign_negative()
                 || rho_v.is_sign_negative()
-                || delta_t.abs() > U::reference_temperature()
+                || delta_t.abs() > SIUnit::reference_temperature()
             {
                 // if densities are negative or the temperature step is large use density iteration instead
                 vle = vle
@@ -265,40 +264,40 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
         Err(EosError::NotConverged("pure_p".to_owned()))
     }
 
-    fn init_pure_state(initial_state: &Self, temperature: QuantityScalar<U>) -> EosResult<Self> {
+    fn init_pure_state(initial_state: &Self, temperature: SINumber) -> EosResult<Self> {
         let vapor = initial_state.vapor().update_temperature(temperature)?;
         let liquid = initial_state.liquid().update_temperature(temperature)?;
         Ok(Self([vapor, liquid]))
     }
 
-    fn init_pure_ideal_gas(eos: &Arc<E>, temperature: QuantityScalar<U>) -> EosResult<Self> {
-        let m = arr1(&[1.0]) * U::reference_moles();
+    fn init_pure_ideal_gas(eos: &Arc<E>, temperature: SINumber) -> EosResult<Self> {
+        let m = arr1(&[1.0]) * SIUnit::reference_moles();
         let p = Self::starting_pressure_ideal_gas_bubble(eos, temperature, &arr1(&[1.0]))?.0;
         PhaseEquilibrium::new_npt(eos, temperature, p, &m, &m)?.check_trivial_solution()
     }
 
-    fn init_pure_spinodal(eos: &Arc<E>, temperature: QuantityScalar<U>) -> EosResult<Self>
+    fn init_pure_spinodal(eos: &Arc<E>, temperature: SINumber) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display,
+        SINumber: std::fmt::Display,
     {
         let p = Self::starting_pressure_spinodal(eos, temperature, &arr1(&[1.0]))?;
-        let m = arr1(&[1.0]) * U::reference_moles();
+        let m = arr1(&[1.0]) * SIUnit::reference_moles();
         PhaseEquilibrium::new_npt(eos, temperature, p, &m, &m)
     }
 
     /// Initialize a new VLE for a pure substance for a given pressure.
-    fn init_pure_p(eos: &Arc<E>, pressure: QuantityScalar<U>) -> EosResult<Self>
+    fn init_pure_p(eos: &Arc<E>, pressure: SINumber) -> EosResult<Self>
     where
-        QuantityScalar<U>: std::fmt::Display,
+        SINumber: std::fmt::Display,
     {
         let trial_temperatures = [
-            300.0 * U::reference_temperature(),
-            500.0 * U::reference_temperature(),
-            200.0 * U::reference_temperature(),
+            300.0 * SIUnit::reference_temperature(),
+            500.0 * SIUnit::reference_temperature(),
+            200.0 * SIUnit::reference_temperature(),
         ];
-        let m = arr1(&[1.0]) * U::reference_moles();
+        let m = arr1(&[1.0]) * SIUnit::reference_moles();
         let mut vle = None;
-        let mut t0 = U::reference_temperature();
+        let mut t0 = SIUnit::reference_temperature();
         for t in trial_temperatures.iter() {
             t0 = *t;
             let _vle = PhaseEquilibrium::new_npt(eos, *t, pressure, &m, &m)?;
@@ -359,15 +358,12 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
     }
 }
 
-impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
+impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
     /// Calculate the pure component vapor pressures of all
     /// components in the system for the given temperature.
-    pub fn vapor_pressure(
-        eos: &Arc<E>,
-        temperature: QuantityScalar<U>,
-    ) -> Vec<Option<QuantityScalar<U>>>
+    pub fn vapor_pressure(eos: &Arc<E>, temperature: SINumber) -> Vec<Option<SINumber>>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         (0..eos.components())
             .map(|i| {
@@ -381,12 +377,9 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
 
     /// Calculate the pure component boiling temperatures of all
     /// components in the system for the given pressure.
-    pub fn boiling_temperature(
-        eos: &Arc<E>,
-        pressure: QuantityScalar<U>,
-    ) -> Vec<Option<QuantityScalar<U>>>
+    pub fn boiling_temperature(eos: &Arc<E>, pressure: SINumber) -> Vec<Option<SINumber>>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         (0..eos.components())
             .map(|i| {
@@ -402,10 +395,10 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
     /// components in the system.
     pub fn vle_pure_comps(
         eos: &Arc<E>,
-        temperature_or_pressure: QuantityScalar<U>,
-    ) -> Vec<Option<PhaseEquilibrium<U, E, 2>>>
+        temperature_or_pressure: SINumber,
+    ) -> Vec<Option<PhaseEquilibrium<E, 2>>>
     where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+        SINumber: std::fmt::Display + std::fmt::LowerExp,
     {
         (0..eos.components())
             .map(|i| {
@@ -418,7 +411,8 @@ impl<U: EosUnit, E: EquationOfState> PhaseEquilibrium<U, E, 2> {
                 )
                 .ok()
                 .map(|vle_pure| {
-                    let mut moles_vapor = Array1::zeros(eos.components()) * U::reference_moles();
+                    let mut moles_vapor =
+                        Array1::zeros(eos.components()) * SIUnit::reference_moles();
                     let mut moles_liquid = moles_vapor.clone();
                     moles_vapor
                         .try_set(i, vle_pure.vapor().total_moles)

--- a/feos-core/src/python/phase_equilibria.rs
+++ b/feos-core/src/python/phase_equilibria.rs
@@ -4,7 +4,7 @@ macro_rules! impl_phase_equilibrium {
         /// A thermodynamic two phase equilibrium state.
         #[pyclass(name = "PhaseEquilibrium")]
         #[derive(Clone)]
-        pub struct PyPhaseEquilibrium(PhaseEquilibrium<SIUnit, $eos, 2>);
+        pub struct PyPhaseEquilibrium(PhaseEquilibrium<$eos, 2>);
 
         #[pymethods]
         impl PyPhaseEquilibrium {
@@ -330,7 +330,7 @@ macro_rules! impl_phase_equilibrium {
         /// A thermodynamic three phase equilibrium state.
         #[pyclass(name = "ThreePhaseEquilibrium")]
         #[derive(Clone)]
-        struct PyThreePhaseEquilibrium(PhaseEquilibrium<SIUnit, $eos, 3>);
+        struct PyThreePhaseEquilibrium(PhaseEquilibrium<$eos, 3>);
 
         #[pymethods]
         impl PyPhaseEquilibrium {
@@ -473,7 +473,7 @@ macro_rules! impl_phase_equilibrium {
         /// -------
         /// PhaseDiagram : the resulting phase diagram
         #[pyclass(name = "PhaseDiagram")]
-        pub struct PyPhaseDiagram(PhaseDiagram<SIUnit, $eos, 2>);
+        pub struct PyPhaseDiagram(PhaseDiagram<$eos, 2>);
 
         #[pymethods]
         impl PyPhaseDiagram {
@@ -921,7 +921,7 @@ macro_rules! impl_phase_equilibrium {
 
         /// Phase diagram for a binary mixture exhibiting a heteroazeotrope.
         #[pyclass(name = "PhaseDiagramHetero")]
-        pub struct PyPhaseDiagramHetero(PhaseDiagramHetero<SIUnit, $eos>);
+        pub struct PyPhaseDiagramHetero(PhaseDiagramHetero<$eos>);
 
         #[pymethods]
         impl PyPhaseDiagram {

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -49,7 +49,7 @@ macro_rules! impl_state {
         #[pyclass(name = "State")]
         #[derive(Clone)]
         #[pyo3(text_signature = "(eos, temperature=None, volume=None, density=None, partial_density=None, total_moles=None, moles=None, molefracs=None, pressure=None, molar_enthalpy=None, molar_entropy=None, molar_internal_energy=None, density_initialization=None, initial_temperature=None)")]
-        pub struct PyState(pub State<SIUnit, $eos>);
+        pub struct PyState(pub State<$eos>);
 
         #[pymethods]
         impl PyState {
@@ -1022,15 +1022,15 @@ macro_rules! impl_state {
         /// -------
         /// StateVec
         #[pyclass(name = "StateVec")]
-        pub struct PyStateVec(Vec<State<SIUnit, $eos>>);
+        pub struct PyStateVec(Vec<State<$eos>>);
 
-        impl From<StateVec<'_, SIUnit, $eos>> for PyStateVec {
-            fn from(vec: StateVec<SIUnit, $eos>) -> Self {
+        impl From<StateVec<'_, $eos>> for PyStateVec {
+            fn from(vec: StateVec<$eos>) -> Self {
                 Self(vec.into_iter().map(|s| s.clone()).collect())
             }
         }
 
-        impl<'a> From<&'a PyStateVec> for StateVec<'a, SIUnit, $eos> {
+        impl<'a> From<&'a PyStateVec> for StateVec<'a, $eos> {
             fn from(vec: &'a PyStateVec) -> Self {
                 Self(vec.0.iter().collect())
             }

--- a/feos-core/src/python/user_defined.rs
+++ b/feos-core/src/python/user_defined.rs
@@ -48,7 +48,7 @@ impl PyEoSObj {
     }
 }
 
-impl MolarWeight<SIUnit> for PyEoSObj {
+impl MolarWeight for PyEoSObj {
     fn molar_weight(&self) -> SIArray1 {
         let gil = Python::acquire_gil();
         let py = gil.python();

--- a/feos-core/src/state/builder.rs
+++ b/feos-core/src/state/builder.rs
@@ -1,9 +1,8 @@
 use super::{DensityInitialization, State};
 use crate::equation_of_state::EquationOfState;
 use crate::errors::EosResult;
-use crate::EosUnit;
 use ndarray::Array1;
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SIArray1, SINumber};
 use std::sync::Arc;
 
 /// A simple tool to construct [State]s with arbitrary input parameters.
@@ -53,24 +52,24 @@ use std::sync::Arc;
 /// # Ok(())
 /// # }
 /// ```
-pub struct StateBuilder<'a, U: EosUnit, E: EquationOfState> {
+pub struct StateBuilder<'a, E: EquationOfState> {
     eos: Arc<E>,
-    temperature: Option<QuantityScalar<U>>,
-    volume: Option<QuantityScalar<U>>,
-    density: Option<QuantityScalar<U>>,
-    partial_density: Option<&'a QuantityArray1<U>>,
-    total_moles: Option<QuantityScalar<U>>,
-    moles: Option<&'a QuantityArray1<U>>,
+    temperature: Option<SINumber>,
+    volume: Option<SINumber>,
+    density: Option<SINumber>,
+    partial_density: Option<&'a SIArray1>,
+    total_moles: Option<SINumber>,
+    moles: Option<&'a SIArray1>,
     molefracs: Option<&'a Array1<f64>>,
-    pressure: Option<QuantityScalar<U>>,
-    molar_enthalpy: Option<QuantityScalar<U>>,
-    molar_entropy: Option<QuantityScalar<U>>,
-    molar_internal_energy: Option<QuantityScalar<U>>,
-    density_initialization: DensityInitialization<U>,
-    initial_temperature: Option<QuantityScalar<U>>,
+    pressure: Option<SINumber>,
+    molar_enthalpy: Option<SINumber>,
+    molar_entropy: Option<SINumber>,
+    molar_internal_energy: Option<SINumber>,
+    density_initialization: DensityInitialization,
+    initial_temperature: Option<SINumber>,
 }
 
-impl<'a, U: EosUnit, E: EquationOfState> StateBuilder<'a, U, E> {
+impl<'a, E: EquationOfState> StateBuilder<'a, E> {
     /// Create a new `StateBuilder` for the given equation of state.
     pub fn new(eos: &Arc<E>) -> Self {
         StateBuilder {
@@ -92,37 +91,37 @@ impl<'a, U: EosUnit, E: EquationOfState> StateBuilder<'a, U, E> {
     }
 
     /// Provide the temperature for the new state.
-    pub fn temperature(mut self, temperature: QuantityScalar<U>) -> Self {
+    pub fn temperature(mut self, temperature: SINumber) -> Self {
         self.temperature = Some(temperature);
         self
     }
 
     /// Provide the volume for the new state.
-    pub fn volume(mut self, volume: QuantityScalar<U>) -> Self {
+    pub fn volume(mut self, volume: SINumber) -> Self {
         self.volume = Some(volume);
         self
     }
 
     /// Provide the density for the new state.
-    pub fn density(mut self, density: QuantityScalar<U>) -> Self {
+    pub fn density(mut self, density: SINumber) -> Self {
         self.density = Some(density);
         self
     }
 
     /// Provide partial densities for the new state.
-    pub fn partial_density(mut self, partial_density: &'a QuantityArray1<U>) -> Self {
+    pub fn partial_density(mut self, partial_density: &'a SIArray1) -> Self {
         self.partial_density = Some(partial_density);
         self
     }
 
     /// Provide the total moles for the new state.
-    pub fn total_moles(mut self, total_moles: QuantityScalar<U>) -> Self {
+    pub fn total_moles(mut self, total_moles: SINumber) -> Self {
         self.total_moles = Some(total_moles);
         self
     }
 
     /// Provide the moles for the new state.
-    pub fn moles(mut self, moles: &'a QuantityArray1<U>) -> Self {
+    pub fn moles(mut self, moles: &'a SIArray1) -> Self {
         self.moles = Some(moles);
         self
     }
@@ -134,25 +133,25 @@ impl<'a, U: EosUnit, E: EquationOfState> StateBuilder<'a, U, E> {
     }
 
     /// Provide the pressure for the new state.
-    pub fn pressure(mut self, pressure: QuantityScalar<U>) -> Self {
+    pub fn pressure(mut self, pressure: SINumber) -> Self {
         self.pressure = Some(pressure);
         self
     }
 
     /// Provide the molar enthalpy for the new state.
-    pub fn molar_enthalpy(mut self, molar_enthalpy: QuantityScalar<U>) -> Self {
+    pub fn molar_enthalpy(mut self, molar_enthalpy: SINumber) -> Self {
         self.molar_enthalpy = Some(molar_enthalpy);
         self
     }
 
     /// Provide the molar entropy for the new state.
-    pub fn molar_entropy(mut self, molar_entropy: QuantityScalar<U>) -> Self {
+    pub fn molar_entropy(mut self, molar_entropy: SINumber) -> Self {
         self.molar_entropy = Some(molar_entropy);
         self
     }
 
     /// Provide the molar internal energy for the new state.
-    pub fn molar_internal_energy(mut self, molar_internal_energy: QuantityScalar<U>) -> Self {
+    pub fn molar_internal_energy(mut self, molar_internal_energy: SINumber) -> Self {
         self.molar_internal_energy = Some(molar_internal_energy);
         self
     }
@@ -170,19 +169,19 @@ impl<'a, U: EosUnit, E: EquationOfState> StateBuilder<'a, U, E> {
     }
 
     /// Provide an initial density used in density iterations.
-    pub fn initial_density(mut self, initial_density: QuantityScalar<U>) -> Self {
+    pub fn initial_density(mut self, initial_density: SINumber) -> Self {
         self.density_initialization = DensityInitialization::InitialDensity(initial_density);
         self
     }
 
     /// Provide an initial temperature used in the Newton solver.
-    pub fn initial_temperature(mut self, initial_temperature: QuantityScalar<U>) -> Self {
+    pub fn initial_temperature(mut self, initial_temperature: SINumber) -> Self {
         self.initial_temperature = Some(initial_temperature);
         self
     }
 
     /// Try to build the state with the given inputs.
-    pub fn build(self) -> EosResult<State<U, E>> {
+    pub fn build(self) -> EosResult<State<E>> {
         State::new(
             &self.eos,
             self.temperature,
@@ -202,7 +201,7 @@ impl<'a, U: EosUnit, E: EquationOfState> StateBuilder<'a, U, E> {
     }
 }
 
-impl<'a, U: EosUnit, E: EquationOfState> Clone for StateBuilder<'a, U, E> {
+impl<'a, E: EquationOfState> Clone for StateBuilder<'a, E> {
     fn clone(&self) -> Self {
         Self {
             eos: self.eos.clone(),

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -55,7 +55,10 @@ impl Cache {
         derivative: Derivative,
         f: F,
     ) -> f64 {
-        if let Some(&value) = self.map.get(&PartialDerivative::SecondMixed(derivative, derivative)) {
+        if let Some(&value) = self
+            .map
+            .get(&PartialDerivative::SecondMixed(derivative, derivative))
+        {
             self.hit += 1;
             value
         } else {
@@ -64,8 +67,10 @@ impl Cache {
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
                 .insert(PartialDerivative::First(derivative), value.v1[0]);
-            self.map
-                .insert(PartialDerivative::SecondMixed(derivative, derivative), value.v2[0]);
+            self.map.insert(
+                PartialDerivative::SecondMixed(derivative, derivative),
+                value.v2[0],
+            );
             value.v2[0]
         }
     }

--- a/feos-core/src/state/critical_point.rs
+++ b/feos-core/src/state/critical_point.rs
@@ -7,7 +7,7 @@ use ndarray::{arr1, arr2, Array1, Array2};
 use num_dual::linalg::{norm, smallest_ev, LU};
 use num_dual::{Dual, Dual3, Dual64, DualNum, DualVec64, HyperDual, StaticVec};
 use num_traits::{One, Zero};
-use quantity::si::{SINumber, SIArray1, SIUnit};
+use quantity::si::{SIArray1, SINumber, SIUnit};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -409,7 +409,9 @@ impl<E: EquationOfState> State<E> {
         let mut rho = match density_initialization {
             DensityInitialization::Vapor => 1e-5 * max_density,
             DensityInitialization::Liquid => max_density,
-            DensityInitialization::InitialDensity(rho) => rho.to_reduced(SIUnit::reference_density())?,
+            DensityInitialization::InitialDensity(rho) => {
+                rho.to_reduced(SIUnit::reference_density())?
+            }
             DensityInitialization::None => unreachable!(),
         };
         let n = moles.to_reduced(SIUnit::reference_moles())?;

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -151,12 +151,12 @@ impl<E> Clone for State<E> {
     fn clone(&self) -> Self {
         Self {
             eos: self.eos.clone(),
-            total_moles: self.total_moles.clone(),
-            temperature: self.temperature.clone(),
-            volume: self.volume.clone(),
+            total_moles: self.total_moles,
+            temperature: self.temperature,
+            volume: self.volume,
             moles: self.moles.clone(),
             partial_density: self.partial_density.clone(),
-            density: self.density.clone(),
+            density: self.density,
             molefracs: self.molefracs.clone(),
             reduced_temperature: self.reduced_temperature,
             reduced_volume: self.reduced_volume,
@@ -746,11 +746,7 @@ fn is_close(x: SINumber, y: SINumber, atol: SINumber, rtol: f64) -> bool {
     (x - y).abs() <= atol + rtol * y.abs()
 }
 
-fn newton<E: EquationOfState, F>(
-    mut x0: SINumber,
-    mut f: F,
-    atol: SINumber,
-) -> EosResult<State<E>>
+fn newton<E: EquationOfState, F>(mut x0: SINumber, mut f: F, atol: SINumber) -> EosResult<State<E>>
 where
     F: FnMut(SINumber) -> EosResult<(SINumber, SINumber, State<E>)>,
 {

--- a/feos-derive/src/dft.rs
+++ b/feos-derive/src/dft.rs
@@ -174,7 +174,7 @@ fn impl_molar_weight(
         }
     }
     Ok(quote! {
-        impl MolarWeight<SIUnit> for FunctionalVariant {
+        impl MolarWeight for FunctionalVariant {
             fn molar_weight(&self) -> SIArray1 {
                 match self {
                     #(#molar_weight,)*

--- a/feos-derive/src/eos.rs
+++ b/feos-derive/src/eos.rs
@@ -102,7 +102,7 @@ fn impl_molar_weight(
         }
     }
     Ok(quote! {
-        impl MolarWeight<SIUnit> for EosVariant {
+        impl MolarWeight for EosVariant {
             fn molar_weight(&self) -> SIArray1 {
                 match self {
                     #(#molar_weight,)*
@@ -148,7 +148,7 @@ fn impl_entropy_scaling(
     }
 
     Ok(quote! {
-        impl EntropyScaling<SIUnit> for EosVariant {
+        impl EntropyScaling for EosVariant {
             fn viscosity_reference(
                 &self,
                 temperature: SINumber,

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed the `3d_dft` feature to `rayon` in accordance to the other feos crates. [#62](https://github.com/feos-org/feos/pull/62)
 - internally rewrote the implementation of the Euler-Lagrange equation to use a bulk density instead of the chemical potential as variable. [#60](https://github.com/feos-org/feos/pull/60)
 - Renamed the parameter `beta` of the Picard iteration and Anderson mixing solvers to `damping_coefficient`. [#75](https://github.com/feos-org/feos/pull/75)
+- Removed generics for units in all structs and traits in favor of static SI units. [#115](https://github.com/feos-org/feos/pull/115)
 
 ## [0.3.2] - 2022-10-13
 ### Changed

--- a/feos-dft/src/adsorption/fea_potential.rs
+++ b/feos-dft/src/adsorption/fea_potential.rs
@@ -4,19 +4,19 @@ use crate::Geometry;
 use feos_core::EosUnit;
 use gauss_quad::GaussLegendre;
 use ndarray::{Array1, Array2, Zip};
-use quantity::{QuantityArray2, QuantityScalar};
+use quantity::si::{SIArray2, SINumber, SIUnit};
 use std::f64::consts::PI;
 use std::usize;
 
 // Calculate free-energy average potential for given solid structure.
-pub fn calculate_fea_potential<U: EosUnit>(
+pub fn calculate_fea_potential(
     grid: &Array1<f64>,
     mi: f64,
-    coordinates: &QuantityArray2<U>,
+    coordinates: &SIArray2,
     sigma_sf: Array1<f64>,
     epsilon_k_sf: Array1<f64>,
     pore_center: &[f64; 3],
-    system_size: &[QuantityScalar<U>; 3],
+    system_size: &[SINumber; 3],
     n_grid: &[usize; 2],
     temperature: f64,
     geometry: Geometry,
@@ -31,14 +31,20 @@ pub fn calculate_fea_potential<U: EosUnit>(
     // dimensionless solid coordinates
     let coordinates = Array2::from_shape_fn(coordinates.raw_dim(), |(i, j)| {
         (coordinates.get((i, j)))
-            .to_reduced(U::reference_length())
+            .to_reduced(SIUnit::reference_length())
             .unwrap()
     });
 
     let system_size = [
-        system_size[0].to_reduced(U::reference_length()).unwrap(),
-        system_size[1].to_reduced(U::reference_length()).unwrap(),
-        system_size[2].to_reduced(U::reference_length()).unwrap(),
+        system_size[0]
+            .to_reduced(SIUnit::reference_length())
+            .unwrap(),
+        system_size[1]
+            .to_reduced(SIUnit::reference_length())
+            .unwrap(),
+        system_size[2]
+            .to_reduced(SIUnit::reference_length())
+            .unwrap(),
     ];
 
     // Create secondary axis:

--- a/feos-dft/src/ideal_chain_contribution.rs
+++ b/feos-dft/src/ideal_chain_contribution.rs
@@ -1,7 +1,7 @@
 use feos_core::{EosResult, EosUnit, HelmholtzEnergyDual, StateHD};
 use ndarray::*;
 use num_dual::DualNum;
-use quantity::{QuantityArray, QuantityScalar};
+use quantity::si::{SIArray, SINumber, SIUnit};
 use std::fmt;
 
 #[derive(Clone)]
@@ -61,17 +61,17 @@ impl IdealChainContribution {
         Ok(phi)
     }
 
-    pub fn helmholtz_energy_density<U: EosUnit, D>(
+    pub fn helmholtz_energy_density<D>(
         &self,
-        temperature: QuantityScalar<U>,
-        density: &QuantityArray<U, D::Larger>,
-    ) -> EosResult<QuantityArray<U, D>>
+        temperature: SINumber,
+        density: &SIArray<D::Larger>,
+    ) -> EosResult<SIArray<D>>
     where
         D: Dimension,
         D::Larger: Dimension<Smaller = D>,
     {
-        let rho = density.to_reduced(U::reference_density())?;
-        let t = temperature.to_reduced(U::reference_temperature())?;
-        Ok(self.calculate_helmholtz_energy_density(&rho)? * t * U::reference_pressure())
+        let rho = density.to_reduced(SIUnit::reference_density())?;
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
+        Ok(self.calculate_helmholtz_energy_density(&rho)? * t * SIUnit::reference_pressure())
     }
 }

--- a/feos-dft/src/python/adsorption/external_potential.rs
+++ b/feos-dft/src/python/adsorption/external_potential.rs
@@ -2,12 +2,11 @@ use crate::adsorption::ExternalPotential;
 use numpy::PyArray1;
 use pyo3::prelude::*;
 use quantity::python::{PySIArray2, PySINumber};
-use quantity::si::*;
 
 /// A collection of external potentials.
 #[pyclass(name = "ExternalPotential")]
 #[derive(Clone)]
-pub struct PyExternalPotential(pub ExternalPotential<SIUnit>);
+pub struct PyExternalPotential(pub ExternalPotential);
 
 #[pymethods]
 #[allow(non_snake_case)]

--- a/feos-dft/src/python/adsorption/mod.rs
+++ b/feos-dft/src/python/adsorption/mod.rs
@@ -8,11 +8,11 @@ macro_rules! impl_adsorption {
     ($func:ty, $py_func:ty) => {
         /// Container structure for adsorption isotherms in 1D pores.
         #[pyclass(name = "Adsorption1D")]
-        pub struct PyAdsorption1D(Adsorption1D<SIUnit, $func>);
+        pub struct PyAdsorption1D(Adsorption1D<$func>);
 
         /// Container structure for adsorption isotherms in 3D pores.
         #[pyclass(name = "Adsorption3D")]
-        pub struct PyAdsorption3D(Adsorption3D<SIUnit, $func>);
+        pub struct PyAdsorption3D(Adsorption3D<$func>);
 
         impl_adsorption_isotherm!($func, $py_func, PyAdsorption1D, PyPore1D, PyPoreProfile1D);
         impl_adsorption_isotherm!($func, $py_func, PyAdsorption3D, PyPore3D, PyPoreProfile3D);

--- a/feos-dft/src/python/adsorption/pore.rs
+++ b/feos-dft/src/python/adsorption/pore.rs
@@ -23,10 +23,10 @@ macro_rules! impl_pore {
         ///
         #[pyclass(name = "Pore1D")]
         #[pyo3(text_signature = "(geometry, pore_size, potential, n_grid=None, potential_cutoff=None)")]
-        pub struct PyPore1D(Pore1D<SIUnit>);
+        pub struct PyPore1D(Pore1D);
 
         #[pyclass(name = "PoreProfile1D")]
-        pub struct PyPoreProfile1D(PoreProfile1D<SIUnit, $func>);
+        pub struct PyPoreProfile1D(PoreProfile1D<$func>);
 
         impl_1d_profile!(PyPoreProfile1D, [get_r, get_z]);
 
@@ -149,10 +149,10 @@ macro_rules! impl_pore {
         ///
         #[pyclass(name = "Pore3D")]
         #[pyo3(text_signature = "(system_size, n_grid, coordinates, sigma_ss, epsilon_k_ss, potential_cutoff=None, cutoff_radius=None)")]
-        pub struct PyPore3D(Pore3D<SIUnit>);
+        pub struct PyPore3D(Pore3D);
 
         #[pyclass(name = "PoreProfile3D")]
-        pub struct PyPoreProfile3D(PoreProfile3D<SIUnit, $func>);
+        pub struct PyPoreProfile3D(PoreProfile3D<$func>);
 
         impl_3d_profile!(PyPoreProfile3D, get_x, get_y, get_z);
 

--- a/feos-dft/src/python/interface/mod.rs
+++ b/feos-dft/src/python/interface/mod.rs
@@ -5,7 +5,7 @@ macro_rules! impl_planar_interface {
     ($func:ty) => {
         /// A one-dimensional density profile of a vapor-liquid or liquid-liquid interface.
         #[pyclass(name = "PlanarInterface")]
-        pub struct PyPlanarInterface(PlanarInterface<SIUnit, $func>);
+        pub struct PyPlanarInterface(PlanarInterface<$func>);
 
         impl_1d_profile!(PyPlanarInterface, [get_z]);
 

--- a/feos-dft/src/python/interface/surface_tension_diagram.rs
+++ b/feos-dft/src/python/interface/surface_tension_diagram.rs
@@ -32,7 +32,7 @@ macro_rules! impl_surface_tension_diagram {
         ///
         #[pyclass(name = "SurfaceTensionDiagram")]
         #[pyo3(text_signature = "(dia, init_densities=None, n_grid=None, l_grid=None, critical_temperature=None, fix_equimolar_surface=None, solver=None)")]
-        pub struct PySurfaceTensionDiagram(SurfaceTensionDiagram<SIUnit, $func>);
+        pub struct PySurfaceTensionDiagram(SurfaceTensionDiagram<$func>);
 
         #[pymethods]
         impl PySurfaceTensionDiagram {

--- a/feos-dft/src/python/profile.rs
+++ b/feos-dft/src/python/profile.rs
@@ -21,7 +21,7 @@ macro_rules! impl_profile {
                 log: bool,
                 py: Python<'py>,
             ) -> PyResult<(&'py $arr2<f64>, &'py PyArray1<f64>, f64)> {
-                let (res_rho, res_mres_norm) = self.0.profile.residual(log)?;
+                let (res_rho, res_mu, res_norm) = self.0.profile.residual(log)?;
                 Ok((res_rho.view().to_pyarray(py), res_mu.view().to_pyarray(py), res_norm))
             }
 

--- a/feos-dft/src/python/profile.rs
+++ b/feos-dft/src/python/profile.rs
@@ -21,7 +21,7 @@ macro_rules! impl_profile {
                 log: bool,
                 py: Python<'py>,
             ) -> PyResult<(&'py $arr2<f64>, &'py PyArray1<f64>, f64)> {
-                let (res_rho, res_mu, res_norm) = self.0.profile.residual(log)?;
+                let (res_rho, res_mres_norm) = self.0.profile.residual(log)?;
                 Ok((res_rho.view().to_pyarray(py), res_mu.view().to_pyarray(py), res_norm))
             }
 

--- a/feos-dft/src/python/solvation.rs
+++ b/feos-dft/src/python/solvation.rs
@@ -28,7 +28,7 @@ macro_rules! impl_solvation_profile {
         ///
         #[pyclass(name = "SolvationProfile")]
         #[pyo3(text_signature = "(bulk, n_grid, coordinates, sigma, epsilon_k, system_size=None, cutoff_radius=None, potential_cutoff=None)")]
-        pub struct PySolvationProfile(SolvationProfile<SIUnit, $func>);
+        pub struct PySolvationProfile(SolvationProfile<$func>);
 
         impl_3d_profile!(PySolvationProfile, get_x, get_y, get_z);
 
@@ -94,7 +94,7 @@ macro_rules! impl_pair_correlation {
         ///
         #[pyclass(name = "PairCorrelation")]
         #[pyo3(text_signature = "(bulk, test_particle, n_grid, width)")]
-        pub struct PyPairCorrelation(PairCorrelation<SIUnit, $func>);
+        pub struct PyPairCorrelation(PairCorrelation<$func>);
 
         impl_1d_profile!(PyPairCorrelation, [get_r]);
 

--- a/feos-dft/src/solver.rs
+++ b/feos-dft/src/solver.rs
@@ -6,6 +6,7 @@ use num_dual::linalg::LU;
 use petgraph::graph::Graph;
 use petgraph::visit::EdgeRef;
 use petgraph::Directed;
+use quantity::si::SIUnit;
 use quantity::si::{SIArray1, SECOND};
 use std::collections::VecDeque;
 use std::fmt;
@@ -204,7 +205,7 @@ impl DFTSolverLog {
     }
 }
 
-impl<U: EosUnit, D: Dimension, F: HelmholtzEnergyFunctional> DFTProfile<U, D, F>
+impl<D: Dimension, F: HelmholtzEnergyFunctional> DFTProfile<D, F>
 where
     D::Larger: Dimension<Smaller = D>,
     <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
@@ -550,7 +551,9 @@ where
         &self,
         density: &Array<f64, D::Larger>,
     ) -> EosResult<Vec<Array<f64, <D::Larger as Dimension>::Larger>>> {
-        let temperature = self.temperature.to_reduced(U::reference_temperature())?;
+        let temperature = self
+            .temperature
+            .to_reduced(SIUnit::reference_temperature())?;
         let contributions = self.dft.contributions();
         let weighted_densities = self.convolver.weighted_densities(density);
         let mut second_partial_derivatives = Vec::with_capacity(contributions.len());
@@ -611,7 +614,7 @@ where
     ) -> Array<f64, D::Larger> {
         let temperature = self
             .temperature
-            .to_reduced(U::reference_temperature())
+            .to_reduced(SIUnit::reference_temperature())
             .unwrap();
 
         // calculate weight functions

--- a/src/estimator/diffusion.rs
+++ b/src/estimator/diffusion.rs
@@ -51,9 +51,7 @@ impl<E: EquationOfState + EntropyScaling> DataSet<E> for Diffusion {
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
-    
-    {
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
         let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         let ts = self
             .temperature

--- a/src/estimator/diffusion.rs
+++ b/src/estimator/diffusion.rs
@@ -1,24 +1,24 @@
 use super::{DataSet, EstimatorError};
 use feos_core::{DensityInitialization, EntropyScaling, EosUnit, EquationOfState, State};
 use ndarray::{arr1, Array1};
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SIArray1, SIUnit};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Store experimental diffusion data.
 #[derive(Clone)]
-pub struct Diffusion<U: EosUnit> {
-    pub target: QuantityArray1<U>,
-    temperature: QuantityArray1<U>,
-    pressure: QuantityArray1<U>,
+pub struct Diffusion {
+    pub target: SIArray1,
+    temperature: SIArray1,
+    pressure: SIArray1,
 }
 
-impl<U: EosUnit> Diffusion<U> {
+impl Diffusion {
     /// Create a new data set for experimental diffusion data.
     pub fn new(
-        target: QuantityArray1<U>,
-        temperature: QuantityArray1<U>,
-        pressure: QuantityArray1<U>,
+        target: SIArray1,
+        temperature: SIArray1,
+        pressure: SIArray1,
     ) -> Result<Self, EstimatorError> {
         Ok(Self {
             target,
@@ -28,18 +28,18 @@ impl<U: EosUnit> Diffusion<U> {
     }
 
     /// Return temperature.
-    pub fn temperature(&self) -> QuantityArray1<U> {
+    pub fn temperature(&self) -> SIArray1 {
         self.temperature.clone()
     }
 
     /// Return pressure.
-    pub fn pressure(&self) -> QuantityArray1<U> {
+    pub fn pressure(&self) -> SIArray1 {
         self.pressure.clone()
     }
 }
 
-impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Diffusion<U> {
-    fn target(&self) -> &QuantityArray1<U> {
+impl<E: EquationOfState + EntropyScaling> DataSet<E> for Diffusion {
+    fn target(&self) -> &SIArray1 {
         &self.target
     }
 
@@ -51,16 +51,18 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Diffu
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<QuantityArray1<U>, EstimatorError>
-    where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
+    
     {
-        let moles = arr1(&[1.0]) * U::reference_moles();
+        let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         let ts = self
             .temperature
-            .to_reduced(U::reference_temperature())
+            .to_reduced(SIUnit::reference_temperature())
             .unwrap();
-        let ps = self.pressure.to_reduced(U::reference_pressure()).unwrap();
+        let ps = self
+            .pressure
+            .to_reduced(SIUnit::reference_pressure())
+            .unwrap();
 
         let res = ts
             .iter()
@@ -68,20 +70,20 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Diffu
             .map(|(&t, &p)| {
                 State::new_npt(
                     eos,
-                    t * U::reference_temperature(),
-                    p * U::reference_pressure(),
+                    t * SIUnit::reference_temperature(),
+                    p * SIUnit::reference_pressure(),
                     &moles,
                     DensityInitialization::None,
                 )?
                 .diffusion()?
-                .to_reduced(U::reference_diffusion())
+                .to_reduced(SIUnit::reference_diffusion())
                 .map_err(EstimatorError::from)
             })
             .collect::<Result<Vec<f64>, EstimatorError>>();
-        Ok(Array1::from_vec(res?) * U::reference_diffusion())
+        Ok(Array1::from_vec(res?) * SIUnit::reference_diffusion())
     }
 
-    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+    fn get_input(&self) -> HashMap<String, SIArray1> {
         let mut m = HashMap::with_capacity(1);
         m.insert("temperature".to_owned(), self.temperature());
         m.insert("pressure".to_owned(), self.pressure());

--- a/src/estimator/liquid_density.rs
+++ b/src/estimator/liquid_density.rs
@@ -4,27 +4,27 @@ use feos_core::{
     State,
 };
 use ndarray::arr1;
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SIArray1, SIUnit};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Liquid mass density data as function of pressure and temperature.
 #[derive(Clone)]
-pub struct LiquidDensity<U: EosUnit> {
+pub struct LiquidDensity {
     /// mass density
-    pub target: QuantityArray1<U>,
+    pub target: SIArray1,
     /// temperature
-    temperature: QuantityArray1<U>,
+    temperature: SIArray1,
     /// pressure
-    pressure: QuantityArray1<U>,
+    pressure: SIArray1,
 }
 
-impl<U: EosUnit> LiquidDensity<U> {
+impl LiquidDensity {
     /// A new data set for liquid densities with pressures and temperatures as input.
     pub fn new(
-        target: QuantityArray1<U>,
-        temperature: QuantityArray1<U>,
-        pressure: QuantityArray1<U>,
+        target: SIArray1,
+        temperature: SIArray1,
+        pressure: SIArray1,
     ) -> Result<Self, EstimatorError> {
         Ok(Self {
             target,
@@ -34,18 +34,18 @@ impl<U: EosUnit> LiquidDensity<U> {
     }
 
     /// Returns temperature of data points.
-    pub fn temperature(&self) -> QuantityArray1<U> {
+    pub fn temperature(&self) -> SIArray1 {
         self.temperature.clone()
     }
 
     /// Returns pressure of data points.
-    pub fn pressure(&self) -> QuantityArray1<U> {
+    pub fn pressure(&self) -> SIArray1 {
         self.pressure.clone()
     }
 }
 
-impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E> for LiquidDensity<U> {
-    fn target(&self) -> &QuantityArray1<U> {
+impl<E: EquationOfState + MolarWeight> DataSet<E> for LiquidDensity {
+    fn target(&self) -> &SIArray1 {
         &self.target
     }
 
@@ -57,8 +57,8 @@ impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E> for LiquidDe
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<QuantityArray1<U>, EstimatorError> {
-        let moles = arr1(&[1.0]) * U::reference_moles();
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
+        let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         Ok(self
             .temperature
             .into_iter()
@@ -68,13 +68,13 @@ impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E> for LiquidDe
                 if let Ok(s) = state {
                     s.mass_density()
                 } else {
-                    f64::NAN * U::reference_mass() / U::reference_volume()
+                    f64::NAN * SIUnit::reference_mass() / SIUnit::reference_volume()
                 }
             })
             .collect())
     }
 
-    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+    fn get_input(&self) -> HashMap<String, SIArray1> {
         let mut m = HashMap::with_capacity(2);
         m.insert("temperature".to_owned(), self.temperature());
         m.insert("pressure".to_owned(), self.pressure());
@@ -84,17 +84,17 @@ impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E> for LiquidDe
 
 /// Store experimental data of liquid densities and compare to the equation of state.
 #[derive(Clone)]
-pub struct EquilibriumLiquidDensity<U: EosUnit> {
-    pub target: QuantityArray1<U>,
-    temperature: QuantityArray1<U>,
+pub struct EquilibriumLiquidDensity {
+    pub target: SIArray1,
+    temperature: SIArray1,
     solver_options: SolverOptions,
 }
 
-impl<U: EosUnit> EquilibriumLiquidDensity<U> {
+impl EquilibriumLiquidDensity {
     /// A new data set for liquid densities with pressures and temperatures as input.
     pub fn new(
-        target: QuantityArray1<U>,
-        temperature: QuantityArray1<U>,
+        target: SIArray1,
+        temperature: SIArray1,
         vle_options: Option<SolverOptions>,
     ) -> Result<Self, EstimatorError> {
         Ok(Self {
@@ -105,15 +105,13 @@ impl<U: EosUnit> EquilibriumLiquidDensity<U> {
     }
 
     /// Returns temperature of data points.
-    pub fn temperature(&self) -> QuantityArray1<U> {
+    pub fn temperature(&self) -> SIArray1 {
         self.temperature.clone()
     }
 }
 
-impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E>
-    for EquilibriumLiquidDensity<U>
-{
-    fn target(&self) -> &QuantityArray1<U> {
+impl<E: EquationOfState + MolarWeight> DataSet<E> for EquilibriumLiquidDensity {
+    fn target(&self) -> &SIArray1 {
         &self.target
     }
 
@@ -125,10 +123,7 @@ impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E>
         vec!["temperature"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<QuantityArray1<U>, EstimatorError>
-    where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
-    {
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
         Ok(self
             .temperature
             .into_iter()
@@ -136,13 +131,13 @@ impl<U: EosUnit, E: EquationOfState + MolarWeight<U>> DataSet<U, E>
                 if let Ok(state) = PhaseEquilibrium::pure(eos, t, None, self.solver_options) {
                     state.liquid().mass_density()
                 } else {
-                    f64::NAN * U::reference_mass() / U::reference_volume()
+                    f64::NAN * SIUnit::reference_mass() / SIUnit::reference_volume()
                 }
             })
             .collect())
     }
 
-    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+    fn get_input(&self) -> HashMap<String, SIArray1> {
         let mut m = HashMap::with_capacity(2);
         m.insert("temperature".to_owned(), self.temperature());
         m

--- a/src/estimator/python.rs
+++ b/src/estimator/python.rs
@@ -117,7 +117,7 @@ macro_rules! impl_estimator {
         /// cost functions and make predictions using an equation of state.
         #[pyclass(name = "DataSet")]
         #[derive(Clone)]
-        pub struct PyDataSet(Arc<dyn DataSet<SIUnit, $eos>>);
+        pub struct PyDataSet(Arc<dyn DataSet<$eos>>);
 
         #[pymethods]
         impl PyDataSet {
@@ -135,7 +135,7 @@ macro_rules! impl_estimator {
             /// -------
             /// numpy.ndarray[Float]
             ///     The cost function evaluated for each experimental data point.
-            /// 
+            ///
             /// Note
             /// ----
             /// The cost function that is used depends on the
@@ -257,7 +257,7 @@ macro_rules! impl_estimator {
                 tol: Option<f64>,
                 verbosity: Option<Verbosity>,
             ) -> PyResult<Self> {
-                Ok(Self(Arc::new(VaporPressure::<SIUnit>::new(
+                Ok(Self(Arc::new(VaporPressure::new(
                     target.clone().into(),
                     temperature.clone().into(),
                     extrapolate.unwrap_or(false),
@@ -287,7 +287,7 @@ macro_rules! impl_estimator {
                 temperature: &PySIArray1,
                 pressure: &PySIArray1,
             ) -> PyResult<Self> {
-                Ok(Self(Arc::new(LiquidDensity::<SIUnit>::new(
+                Ok(Self(Arc::new(LiquidDensity::new(
                     target.clone().into(),
                     temperature.clone().into(),
                     pressure.clone().into(),
@@ -325,7 +325,7 @@ macro_rules! impl_estimator {
                 tol: Option<f64>,
                 verbosity: Option<Verbosity>,
             ) -> PyResult<Self> {
-                Ok(Self(Arc::new(EquilibriumLiquidDensity::<SIUnit>::new(
+                Ok(Self(Arc::new(EquilibriumLiquidDensity::new(
                     target.clone().into(),
                     temperature.clone().into(),
                     Some((max_iter, tol, verbosity).into()),
@@ -482,7 +482,7 @@ macro_rules! impl_estimator {
         /// Estimator
         #[pyclass(name = "Estimator")]
         #[pyo3(text_signature = "(data, weights, losses)")]
-        pub struct PyEstimator(Estimator<SIUnit, $eos>);
+        pub struct PyEstimator(Estimator<$eos>);
 
         #[pymethods]
         impl PyEstimator {
@@ -507,11 +507,11 @@ macro_rules! impl_estimator {
             /// numpy.ndarray[Float]
             ///     The cost function evaluated for each experimental data point
             ///     of each ``DataSet``.
-            /// 
+            ///
             /// Note
             /// ----
             /// The cost function is:
-            /// 
+            ///
             /// - The relative difference between prediction and target value,
             /// - to which a loss function is applied,
             /// - and which is weighted according to the number of datapoints,
@@ -650,7 +650,7 @@ macro_rules! impl_estimator_entropy_scaling {
                 temperature: &PySIArray1,
                 pressure: &PySIArray1,
             ) -> PyResult<Self> {
-                Ok(Self(Arc::new(Viscosity::<SIUnit>::new(
+                Ok(Self(Arc::new(Viscosity::new(
                     target.clone().into(),
                     temperature.clone().into(),
                     pressure.clone().into(),
@@ -678,7 +678,7 @@ macro_rules! impl_estimator_entropy_scaling {
                 temperature: &PySIArray1,
                 pressure: &PySIArray1,
             ) -> PyResult<Self> {
-                Ok(Self(Arc::new(ThermalConductivity::<SIUnit>::new(
+                Ok(Self(Arc::new(ThermalConductivity::new(
                     target.clone().into(),
                     temperature.clone().into(),
                     pressure.clone().into(),
@@ -706,7 +706,7 @@ macro_rules! impl_estimator_entropy_scaling {
                 temperature: &PySIArray1,
                 pressure: &PySIArray1,
             ) -> PyResult<Self> {
-                Ok(Self(Arc::new(Diffusion::<SIUnit>::new(
+                Ok(Self(Arc::new(Diffusion::new(
                     target.clone().into(),
                     temperature.clone().into(),
                     pressure.clone().into(),

--- a/src/estimator/thermal_conductivity.rs
+++ b/src/estimator/thermal_conductivity.rs
@@ -51,15 +51,16 @@ impl<E: EquationOfState + EntropyScaling> DataSet<E> for ThermalConductivity {
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
-    
-    {
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
         let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         let ts = self
             .temperature
             .to_reduced(SIUnit::reference_temperature())
             .unwrap();
-        let ps = self.pressure.to_reduced(SIUnit::reference_pressure()).unwrap();
+        let ps = self
+            .pressure
+            .to_reduced(SIUnit::reference_pressure())
+            .unwrap();
         let unit = SIUnit::reference_energy()
             / SIUnit::reference_time()
             / SIUnit::reference_temperature()

--- a/src/estimator/thermal_conductivity.rs
+++ b/src/estimator/thermal_conductivity.rs
@@ -1,24 +1,24 @@
 use super::{DataSet, EstimatorError};
 use feos_core::{DensityInitialization, EntropyScaling, EosUnit, EquationOfState, State};
 use ndarray::{arr1, Array1};
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SIArray1, SIUnit};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Store experimental thermal conductivity data.
 #[derive(Clone)]
-pub struct ThermalConductivity<U: EosUnit> {
-    pub target: QuantityArray1<U>,
-    temperature: QuantityArray1<U>,
-    pressure: QuantityArray1<U>,
+pub struct ThermalConductivity {
+    pub target: SIArray1,
+    temperature: SIArray1,
+    pressure: SIArray1,
 }
 
-impl<U: EosUnit> ThermalConductivity<U> {
+impl ThermalConductivity {
     /// Create a new data set for experimental thermal conductivity data.
     pub fn new(
-        target: QuantityArray1<U>,
-        temperature: QuantityArray1<U>,
-        pressure: QuantityArray1<U>,
+        target: SIArray1,
+        temperature: SIArray1,
+        pressure: SIArray1,
     ) -> Result<Self, EstimatorError> {
         Ok(Self {
             target,
@@ -28,18 +28,18 @@ impl<U: EosUnit> ThermalConductivity<U> {
     }
 
     /// Return temperature.
-    pub fn temperature(&self) -> QuantityArray1<U> {
+    pub fn temperature(&self) -> SIArray1 {
         self.temperature.clone()
     }
 
     /// Return pressure.
-    pub fn pressure(&self) -> QuantityArray1<U> {
+    pub fn pressure(&self) -> SIArray1 {
         self.pressure.clone()
     }
 }
 
-impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for ThermalConductivity<U> {
-    fn target(&self) -> &QuantityArray1<U> {
+impl<E: EquationOfState + EntropyScaling> DataSet<E> for ThermalConductivity {
+    fn target(&self) -> &SIArray1 {
         &self.target
     }
 
@@ -51,20 +51,19 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Therm
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<QuantityArray1<U>, EstimatorError>
-    where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
+    
     {
-        let moles = arr1(&[1.0]) * U::reference_moles();
+        let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         let ts = self
             .temperature
-            .to_reduced(U::reference_temperature())
+            .to_reduced(SIUnit::reference_temperature())
             .unwrap();
-        let ps = self.pressure.to_reduced(U::reference_pressure()).unwrap();
-        let unit = U::reference_energy()
-            / U::reference_time()
-            / U::reference_temperature()
-            / U::reference_length();
+        let ps = self.pressure.to_reduced(SIUnit::reference_pressure()).unwrap();
+        let unit = SIUnit::reference_energy()
+            / SIUnit::reference_time()
+            / SIUnit::reference_temperature()
+            / SIUnit::reference_length();
 
         let res = ts
             .iter()
@@ -72,8 +71,8 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Therm
             .map(|(&t, &p)| {
                 State::new_npt(
                     eos,
-                    t * U::reference_temperature(),
-                    p * U::reference_pressure(),
+                    t * SIUnit::reference_temperature(),
+                    p * SIUnit::reference_pressure(),
                     &moles,
                     DensityInitialization::None,
                 )?
@@ -85,7 +84,7 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Therm
         Ok(Array1::from_vec(res?) * unit)
     }
 
-    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+    fn get_input(&self) -> HashMap<String, SIArray1> {
         let mut m = HashMap::with_capacity(1);
         m.insert("temperature".to_owned(), self.temperature());
         m.insert("pressure".to_owned(), self.pressure());

--- a/src/estimator/vapor_pressure.rs
+++ b/src/estimator/vapor_pressure.rs
@@ -70,9 +70,7 @@ impl<E: EquationOfState> DataSet<E> for VaporPressure {
         vec!["temperature"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
-    
-    {
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
         let critical_point =
             State::critical_point(eos, None, Some(self.max_temperature), self.solver_options)
                 .or_else(|_| State::critical_point(eos, None, None, self.solver_options))?;
@@ -94,7 +92,10 @@ impl<E: EquationOfState> DataSet<E> for VaporPressure {
             if let Some(pvap) = PhaseEquilibrium::vapor_pressure(eos, t)[0] {
                 prediction.try_set(i, pvap)?;
             } else if self.extrapolate {
-                prediction.try_set(i, (a + b.to_reduced(t)?).exp() * SIUnit::reference_pressure())?;
+                prediction.try_set(
+                    i,
+                    (a + b.to_reduced(t)?).exp() * SIUnit::reference_pressure(),
+                )?;
             } else {
                 prediction.try_set(i, f64::NAN * SIUnit::reference_pressure())?
             }

--- a/src/estimator/vapor_pressure.rs
+++ b/src/estimator/vapor_pressure.rs
@@ -1,22 +1,22 @@
 use super::{DataSet, EstimatorError};
 use feos_core::{Contributions, EosUnit, EquationOfState, PhaseEquilibrium, SolverOptions, State};
 use ndarray::Array1;
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SIArray1, SINumber, SIUnit};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Store experimental vapor pressure data.
 #[derive(Clone)]
-pub struct VaporPressure<U: EosUnit> {
-    pub target: QuantityArray1<U>,
-    temperature: QuantityArray1<U>,
-    max_temperature: QuantityScalar<U>,
+pub struct VaporPressure {
+    pub target: SIArray1,
+    temperature: SIArray1,
+    max_temperature: SINumber,
     datapoints: usize,
     extrapolate: bool,
     solver_options: SolverOptions,
 }
 
-impl<U: EosUnit> VaporPressure<U> {
+impl VaporPressure {
     /// Create a new data set for vapor pressure.
     ///
     /// If the equation of state fails to compute the vapor pressure
@@ -26,20 +26,20 @@ impl<U: EosUnit> VaporPressure<U> {
     /// calculating the slope of ln(p) over 1/T.
     /// If `extrapolate` is `false`, it is set to `NAN`.
     pub fn new(
-        target: QuantityArray1<U>,
-        temperature: QuantityArray1<U>,
+        target: SIArray1,
+        temperature: SIArray1,
         extrapolate: bool,
-        critical_temperature: Option<QuantityScalar<U>>,
+        critical_temperature: Option<SINumber>,
         solver_options: Option<SolverOptions>,
     ) -> Result<Self, EstimatorError> {
         let datapoints = target.len();
         let max_temperature = critical_temperature.unwrap_or(
             temperature
-                .to_reduced(U::reference_temperature())?
+                .to_reduced(SIUnit::reference_temperature())?
                 .into_iter()
                 .reduce(|a, b| a.max(b))
                 .unwrap()
-                * U::reference_temperature(),
+                * SIUnit::reference_temperature(),
         );
         Ok(Self {
             target,
@@ -52,13 +52,13 @@ impl<U: EosUnit> VaporPressure<U> {
     }
 
     /// Return temperature.
-    pub fn temperature(&self) -> QuantityArray1<U> {
+    pub fn temperature(&self) -> SIArray1 {
         self.temperature.clone()
     }
 }
 
-impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for VaporPressure<U> {
-    fn target(&self) -> &QuantityArray1<U> {
+impl<E: EquationOfState> DataSet<E> for VaporPressure {
+    fn target(&self) -> &SIArray1 {
         &self.target
     }
 
@@ -70,9 +70,8 @@ impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for VaporPressure<U> {
         vec!["temperature"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<QuantityArray1<U>, EstimatorError>
-    where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
+    
     {
         let critical_point =
             State::critical_point(eos, None, Some(self.max_temperature), self.solver_options)
@@ -86,7 +85,7 @@ impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for VaporPressure<U> {
             .pressure(Contributions::Total);
 
         let b = pc.to_reduced(p0)?.ln() / (1.0 / tc - 1.0 / t0);
-        let a = pc.to_reduced(U::reference_pressure())?.ln() - b.to_reduced(tc)?;
+        let a = pc.to_reduced(SIUnit::reference_pressure())?.ln() - b.to_reduced(tc)?;
 
         let unit = self.target.get(0);
         let mut prediction = Array1::zeros(self.datapoints) * unit;
@@ -95,15 +94,15 @@ impl<U: EosUnit, E: EquationOfState> DataSet<U, E> for VaporPressure<U> {
             if let Some(pvap) = PhaseEquilibrium::vapor_pressure(eos, t)[0] {
                 prediction.try_set(i, pvap)?;
             } else if self.extrapolate {
-                prediction.try_set(i, (a + b.to_reduced(t)?).exp() * U::reference_pressure())?;
+                prediction.try_set(i, (a + b.to_reduced(t)?).exp() * SIUnit::reference_pressure())?;
             } else {
-                prediction.try_set(i, f64::NAN * U::reference_pressure())?
+                prediction.try_set(i, f64::NAN * SIUnit::reference_pressure())?
             }
         }
         Ok(prediction)
     }
 
-    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+    fn get_input(&self) -> HashMap<String, SIArray1> {
         let mut m = HashMap::with_capacity(1);
         m.insert("temperature".to_owned(), self.temperature());
         m

--- a/src/estimator/viscosity.rs
+++ b/src/estimator/viscosity.rs
@@ -1,24 +1,24 @@
 use super::{DataSet, EstimatorError};
 use feos_core::{DensityInitialization, EntropyScaling, EosUnit, EquationOfState, State};
 use ndarray::arr1;
-use quantity::{QuantityArray1, QuantityScalar};
+use quantity::si::{SIArray1, SIUnit};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Store experimental viscosity data.
 #[derive(Clone)]
-pub struct Viscosity<U: EosUnit> {
-    pub target: QuantityArray1<U>,
-    temperature: QuantityArray1<U>,
-    pressure: QuantityArray1<U>,
+pub struct Viscosity {
+    pub target: SIArray1,
+    temperature: SIArray1,
+    pressure: SIArray1,
 }
 
-impl<U: EosUnit> Viscosity<U> {
+impl Viscosity {
     /// Create a new data set for experimental viscosity data.
     pub fn new(
-        target: QuantityArray1<U>,
-        temperature: QuantityArray1<U>,
-        pressure: QuantityArray1<U>,
+        target: SIArray1,
+        temperature: SIArray1,
+        pressure: SIArray1,
     ) -> Result<Self, EstimatorError> {
         Ok(Self {
             target,
@@ -28,18 +28,18 @@ impl<U: EosUnit> Viscosity<U> {
     }
 
     /// Return temperature.
-    pub fn temperature(&self) -> QuantityArray1<U> {
+    pub fn temperature(&self) -> SIArray1 {
         self.temperature.clone()
     }
 
     /// Return pressure.
-    pub fn pressure(&self) -> QuantityArray1<U> {
+    pub fn pressure(&self) -> SIArray1 {
         self.pressure.clone()
     }
 }
 
-impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Viscosity<U> {
-    fn target(&self) -> &QuantityArray1<U> {
+impl<E: EquationOfState + EntropyScaling> DataSet<E> for Viscosity {
+    fn target(&self) -> &SIArray1 {
         &self.target
     }
 
@@ -51,11 +51,10 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Visco
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<QuantityArray1<U>, EstimatorError>
-    where
-        QuantityScalar<U>: std::fmt::Display + std::fmt::LowerExp,
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
+    
     {
-        let moles = arr1(&[1.0]) * U::reference_moles();
+        let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         self.temperature
             .into_iter()
             .zip(self.pressure.into_iter())
@@ -67,7 +66,7 @@ impl<U: EosUnit, E: EquationOfState + EntropyScaling<U>> DataSet<U, E> for Visco
             .collect()
     }
 
-    fn get_input(&self) -> HashMap<String, QuantityArray1<U>> {
+    fn get_input(&self) -> HashMap<String, SIArray1> {
         let mut m = HashMap::with_capacity(1);
         m.insert("temperature".to_owned(), self.temperature());
         m.insert("pressure".to_owned(), self.pressure());

--- a/src/estimator/viscosity.rs
+++ b/src/estimator/viscosity.rs
@@ -51,9 +51,7 @@ impl<E: EquationOfState + EntropyScaling> DataSet<E> for Viscosity {
         vec!["temperature", "pressure"]
     }
 
-    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError>
-    
-    {
+    fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
         let moles = arr1(&[1.0]) * SIUnit::reference_moles();
         self.temperature
             .into_iter()

--- a/src/gc_pcsaft/dft/mod.rs
+++ b/src/gc_pcsaft/dft/mod.rs
@@ -8,7 +8,7 @@ use feos_dft::{FunctionalContribution, HelmholtzEnergyFunctional, MoleculeShape,
 use ndarray::Array1;
 use num_dual::DualNum;
 use petgraph::graph::UnGraph;
-use quantity::si::{SIArray1, SIUnit, GRAM, MOL};
+use quantity::si::{SIArray1, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
@@ -116,7 +116,7 @@ impl HelmholtzEnergyFunctional for GcPcSaftFunctional {
     }
 }
 
-impl MolarWeight<SIUnit> for GcPcSaftFunctional {
+impl MolarWeight for GcPcSaftFunctional {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/gc_pcsaft/eos/mod.rs
+++ b/src/gc_pcsaft/eos/mod.rs
@@ -111,7 +111,7 @@ impl EquationOfState for GcPcSaft {
     }
 }
 
-impl MolarWeight<SIUnit> for GcPcSaft {
+impl MolarWeight for GcPcSaft {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/gc_pcsaft/micelles.rs
+++ b/src/gc_pcsaft/micelles.rs
@@ -4,7 +4,7 @@ use feos_dft::{
     HelmholtzEnergyFunctional, WeightFunctionInfo, DFT,
 };
 use ndarray::prelude::*;
-use quantity::{SIArray1, QuantityArray2, QuantityScalar};
+use quantity::{QuantityArray2, QuantityScalar, SIArray1};
 use std::sync::Arc;
 
 pub enum MicelleInitialization {
@@ -53,7 +53,8 @@ impl<U: EosUnit, F: HelmholtzEnergyFunctional> DFTSpecification<U, Ix1, F>
                 let mu_bulk = bulk.chemical_potential(Contributions::Total);
                 let mu_s_bulk = mu_bulk.get(1);
                 let mu_w_bulk = mu_bulk.get(0);
-                let n_s_bulk = (rho_s_bulk * profile.volume()).to_reduced(SIUnit::reference_moles())?;
+                let n_s_bulk =
+                    (rho_s_bulk * profile.volume()).to_reduced(SIUnit::reference_moles())?;
                 let mut spec = (delta_n_surfactant + n_s_bulk) / z;
                 spec[0] = ((pressure + f_bulk - rho_s_bulk * mu_s_bulk) / mu_w_bulk)
                     .to_reduced(SIUnit::reference_density())?;
@@ -139,7 +140,9 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
         let dft = &bulk.eos;
 
         // calculate external potential
-        let t = bulk.temperature.to_reduced(SIUnit::reference_temperature())?;
+        let t = bulk
+            .temperature
+            .to_reduced(SIUnit::reference_temperature())?;
         let mut external_potential = Array2::zeros((dft.component_index().len(), axis.grid.len()));
         if let MicelleInitialization::ExternalPotential(peak, width) = initialization {
             external_potential.index_axis_mut(Axis(0), 0).assign(

--- a/src/gc_pcsaft/micelles.rs
+++ b/src/gc_pcsaft/micelles.rs
@@ -4,16 +4,16 @@ use feos_dft::{
     HelmholtzEnergyFunctional, WeightFunctionInfo, DFT,
 };
 use ndarray::prelude::*;
-use quantity::{QuantityArray1, QuantityArray2, QuantityScalar};
+use quantity::{SIArray1, QuantityArray2, QuantityScalar};
 use std::sync::Arc;
 
-pub enum MicelleInitialization<U> {
+pub enum MicelleInitialization {
     ExternalPotential(f64, f64),
-    Density(QuantityArray2<U>),
+    Density(QuantityArray2),
 }
 
-impl<U> MicelleInitialization<U> {
-    fn density(&self) -> Option<&QuantityArray2<U>> {
+impl MicelleInitialization {
+    fn density(&self) -> Option<&QuantityArray2> {
         match self {
             Self::ExternalPotential(_, _) => None,
             Self::Density(density) => Some(density),
@@ -21,16 +21,16 @@ impl<U> MicelleInitialization<U> {
     }
 }
 
-pub enum MicelleSpecification<U> {
+pub enum MicelleSpecification {
     ChemicalPotential,
     Size {
         delta_n_surfactant: f64,
-        pressure: QuantityScalar<U>,
+        pressure: SINumber,
     },
 }
 
 impl<U: EosUnit, F: HelmholtzEnergyFunctional> DFTSpecification<U, Ix1, F>
-    for MicelleSpecification<U>
+    for MicelleSpecification
 {
     fn calculate_bulk_density(
         &self,
@@ -46,17 +46,17 @@ impl<U: EosUnit, F: HelmholtzEnergyFunctional> DFTSpecification<U, Ix1, F>
             } => {
                 let rho_s_bulk = bulk_density[1];
                 let rho_w_bulk = bulk_density[0];
-                let volume = U::reference_volume();
-                let moles = arr1(&[rho_w_bulk, rho_s_bulk]) * U::reference_density() * volume;
+                let volume = SIUnit::reference_volume();
+                let moles = arr1(&[rho_w_bulk, rho_s_bulk]) * SIUnit::reference_density() * volume;
                 let bulk = State::new_nvt(&profile.dft, profile.temperature, volume, &moles)?;
                 let f_bulk = bulk.helmholtz_energy(Contributions::Total) / bulk.volume;
                 let mu_bulk = bulk.chemical_potential(Contributions::Total);
                 let mu_s_bulk = mu_bulk.get(1);
                 let mu_w_bulk = mu_bulk.get(0);
-                let n_s_bulk = (rho_s_bulk * profile.volume()).to_reduced(U::reference_moles())?;
+                let n_s_bulk = (rho_s_bulk * profile.volume()).to_reduced(SIUnit::reference_moles())?;
                 let mut spec = (delta_n_surfactant + n_s_bulk) / z;
                 spec[0] = ((pressure + f_bulk - rho_s_bulk * mu_s_bulk) / mu_w_bulk)
-                    .to_reduced(U::reference_density())?;
+                    .to_reduced(SIUnit::reference_density())?;
                 spec
             }
         })
@@ -65,8 +65,8 @@ impl<U: EosUnit, F: HelmholtzEnergyFunctional> DFTSpecification<U, Ix1, F>
 
 pub struct MicelleProfile<U: EosUnit, F: HelmholtzEnergyFunctional> {
     pub profile: DFTProfile<U, Ix1, F>,
-    pub delta_omega: Option<QuantityScalar<U>>,
-    pub delta_n: Option<QuantityArray1<U>>,
+    pub delta_omega: Option<SINumber>,
+    pub delta_n: Option<SIArray1>,
 }
 
 impl<U: EosUnit, F: HelmholtzEnergyFunctional> Clone for MicelleProfile<U, F> {
@@ -133,13 +133,13 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
     fn new(
         bulk: &State<U, DFT<F>>,
         axis: Axis,
-        initialization: MicelleInitialization<U>,
-        specification: MicelleSpecification<U>,
+        initialization: MicelleInitialization,
+        specification: MicelleSpecification,
     ) -> EosResult<Self> {
         let dft = &bulk.eos;
 
         // calculate external potential
-        let t = bulk.temperature.to_reduced(U::reference_temperature())?;
+        let t = bulk.temperature.to_reduced(SIUnit::reference_temperature())?;
         let mut external_potential = Array2::zeros((dft.component_index().len(), axis.grid.len()));
         if let MicelleInitialization::ExternalPotential(peak, width) = initialization {
             external_potential.index_axis_mut(Axis(0), 0).assign(
@@ -184,9 +184,9 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
     pub fn new_spherical(
         bulk: &State<U, DFT<F>>,
         n_grid: usize,
-        width: QuantityScalar<U>,
-        initialization: MicelleInitialization<U>,
-        specification: MicelleSpecification<U>,
+        width: SINumber,
+        initialization: MicelleInitialization,
+        specification: MicelleSpecification,
     ) -> EosResult<Self> {
         Self::new(
             bulk,
@@ -199,9 +199,9 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
     pub fn new_cylindrical(
         bulk: &State<U, DFT<F>>,
         n_grid: usize,
-        width: QuantityScalar<U>,
-        initialization: MicelleInitialization<U>,
-        specification: MicelleSpecification<U>,
+        width: SINumber,
+        initialization: MicelleInitialization,
+        specification: MicelleSpecification,
     ) -> EosResult<Self> {
         Self::new(
             bulk,
@@ -211,7 +211,7 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
         )
     }
 
-    pub fn update_specification(&self, specification: MicelleSpecification<U>) -> Self {
+    pub fn update_specification(&self, specification: MicelleSpecification) -> Self {
         let mut profile = self.clone();
         profile.profile.specification = Arc::new(specification);
         profile.delta_omega = None;
@@ -231,7 +231,7 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
     ) -> EosResult<Self> {
         let n_grid = self.profile.r().len();
         let temperature = self.profile.bulk.temperature;
-        let t = temperature.to_reduced(U::reference_temperature())?;
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
         let pressure = self.profile.bulk.pressure(Contributions::Total);
         let eos = self.profile.bulk.eos.clone();
         let indices = self.profile.bulk.eos.component_index().into_owned();
@@ -242,7 +242,7 @@ impl<U: EosUnit + 'static, F: HelmholtzEnergyFunctional> MicelleProfile<U, F> {
             if self
                 .delta_omega
                 .unwrap()
-                .to_reduced(U::reference_energy())?
+                .to_reduced(SIUnit::reference_energy())?
                 .abs()
                 < options.tol.unwrap_or(TOL_MICELLE) * t
             {

--- a/src/pcsaft/dft/mod.rs
+++ b/src/pcsaft/dft/mod.rs
@@ -131,7 +131,7 @@ impl HelmholtzEnergyFunctional for PcSaftFunctional {
     }
 }
 
-impl MolarWeight<SIUnit> for PcSaftFunctional {
+impl MolarWeight for PcSaftFunctional {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/pcsaft/eos/mod.rs
+++ b/src/pcsaft/eos/mod.rs
@@ -139,7 +139,7 @@ impl EquationOfState for PcSaft {
     }
 }
 
-impl MolarWeight<SIUnit> for PcSaft {
+impl MolarWeight for PcSaft {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }
@@ -174,7 +174,7 @@ fn chapman_enskog_thermal_conductivity(
         / KELVIN
 }
 
-impl EntropyScaling<SIUnit> for PcSaft {
+impl EntropyScaling for PcSaft {
     fn viscosity_reference(
         &self,
         temperature: SINumber,

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -1,5 +1,5 @@
-use super::DQVariants;
 use super::parameters::{PcSaftBinaryRecord, PcSaftParameters, PcSaftRecord};
+use super::DQVariants;
 use feos_core::joback::JobackRecord;
 use feos_core::parameter::{
     BinaryRecord, Identifier, IdentifierOption, Parameter, ParameterError, PureRecord,
@@ -184,7 +184,7 @@ pub fn pcsaft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<IdentifierOption>()?;
     m.add_class::<PyChemicalRecord>()?;
     m.add_class::<PyJobackRecord>()?;
-    
+
     m.add_class::<DQVariants>()?;
     m.add_class::<PyPcSaftRecord>()?;
     m.add_class::<PyPureRecord>()?;

--- a/src/pets/dft/mod.rs
+++ b/src/pets/dft/mod.rs
@@ -117,7 +117,7 @@ impl HelmholtzEnergyFunctional for PetsFunctional {
     }
 }
 
-impl MolarWeight<SIUnit> for PetsFunctional {
+impl MolarWeight for PetsFunctional {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/pets/eos/mod.rs
+++ b/src/pets/eos/mod.rs
@@ -104,7 +104,7 @@ impl EquationOfState for Pets {
     }
 }
 
-impl MolarWeight<SIUnit> for Pets {
+impl MolarWeight for Pets {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }
@@ -122,7 +122,7 @@ fn omega22(t: f64) -> f64 {
         - 6.435e-4 * t.powf(0.14874) * (18.0323 * t.powf(-0.76830) - 7.27371).sin()
 }
 
-impl EntropyScaling<SIUnit> for Pets {
+impl EntropyScaling for Pets {
     fn viscosity_reference(
         &self,
         temperature: SINumber,
@@ -221,7 +221,7 @@ impl EntropyScaling<SIUnit> for Pets {
 
     // fn thermal_conductivity_reference(
     //     &self,
-    //     state: &State<SIUnit, E>,
+    //     state: &State<E>,
     // ) -> EosResult<SINumber> {
     //     if self.components() != 1 {
     //         return Err(EosError::IncompatibleComponents(self.components(), 1));

--- a/src/saftvrqmie/dft/mod.rs
+++ b/src/saftvrqmie/dft/mod.rs
@@ -105,7 +105,7 @@ impl HelmholtzEnergyFunctional for SaftVRQMieFunctional {
     }
 }
 
-impl MolarWeight<SIUnit> for SaftVRQMieFunctional {
+impl MolarWeight for SaftVRQMieFunctional {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/saftvrqmie/eos/mod.rs
+++ b/src/saftvrqmie/eos/mod.rs
@@ -108,7 +108,7 @@ impl EquationOfState for SaftVRQMie {
     }
 }
 
-impl MolarWeight<SIUnit> for SaftVRQMie {
+impl MolarWeight for SaftVRQMie {
     fn molar_weight(&self) -> SIArray1 {
         self.parameters.molarweight.clone() * GRAM / MOL
     }
@@ -143,7 +143,7 @@ fn chapman_enskog_thermal_conductivity(
         / KELVIN
 }
 
-impl EntropyScaling<SIUnit> for SaftVRQMie {
+impl EntropyScaling for SaftVRQMie {
     fn viscosity_reference(
         &self,
         temperature: SINumber,

--- a/src/saftvrqmie/mod.rs
+++ b/src/saftvrqmie/mod.rs
@@ -1,5 +1,5 @@
 //! SAFT-VRQ Mie equation of state.
-//! 
+//!
 //! Quantum effects are described by the first order Feynman–Hibbs corrections to Mie fluids.
 //! The model accurately predicts properties for pure substances and mixtures down to 20K.
 //! For mixtures, the additive hard-sphere reference contribution is extended with a non-additive correction.

--- a/tests/pcsaft/state_creation_pure.rs
+++ b/tests/pcsaft/state_creation_pure.rs
@@ -2,11 +2,9 @@ use approx::assert_relative_eq;
 use feos::pcsaft::{PcSaft, PcSaftParameters};
 use feos_core::parameter::{IdentifierOption, Parameter, ParameterError};
 use feos_core::{
-    Contributions, DensityInitialization, EosUnit, EquationOfState, PhaseEquilibrium, State,
-    StateBuilder,
+    Contributions, DensityInitialization, EquationOfState, PhaseEquilibrium, State, StateBuilder,
 };
 use quantity::si::*;
-use quantity::QuantityScalar;
 use std::error::Error;
 use std::sync::Arc;
 
@@ -309,12 +307,12 @@ fn temperature_entropy_vapor() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn assert_multiple_states<E: EquationOfState, U: EosUnit + std::fmt::Debug>(
-    states: &[(&State<U, E>, &str)],
-    pressure: QuantityScalar<U>,
-    enthalpy: QuantityScalar<U>,
-    entropy: QuantityScalar<U>,
-    density: QuantityScalar<U>,
+fn assert_multiple_states<E: EquationOfState>(
+    states: &[(&State<E>, &str)],
+    pressure: SINumber,
+    enthalpy: SINumber,
+    entropy: SINumber,
+    density: SINumber,
     max_relative: f64,
 ) {
     for (s, name) in states {


### PR DESCRIPTION
This PR removes all generics, using `SIUnit` instead of the current generic `EosUnit` trait bound.

- [x] feos-core
- [x] feos-dft
- [x] feos-derive
- [x] feos