### PR TITLE
Fix the sign of vector weighted densities in cartesian and cylindrical geometry

### DIFF
--- a/feos-dft/src/weight_functions.rs
+++ b/feos-dft/src/weight_functions.rs
@@ -116,7 +116,7 @@ impl<T: DualNum<f64>> WeightFunction<T> {
                 w_i.assign(&match self.shape {
                     WeightFunctionShape::DeltaVec => {
                         &rik.mapv(|rik| {
-                            (rik.sph_j0() + rik.sph_j2()) * (-radius.powi(3) * 4.0 * FRAC_PI_3 * p)
+                            (rik.sph_j0() + rik.sph_j2()) * (radius.powi(3) * 4.0 * FRAC_PI_3 * p)
                         }) * &k_x
                     }
                     _ => unreachable!(),


### PR DESCRIPTION
With this change vector weighted densities will have the correct signs in all geometries.

While this is an important validation of the correctness of the transforms in general, the sign of vector weighted densities had no effect on results as they always appear in dot products in the calculation of Helmholtz energies, which cancel out their sign.

Shout out to @RolfStierle and @oivindwi.