### PR TITLE
Early return if vapor pressure data set is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed incorrect indexing that lead to panics in the polar contribution of gc-PC-SAFT. [#104](https://github.com/feos-org/feos/pull/104)
+- `VaporPressure` now returns an empty array instead of crashing. [#124](https://github.com/feos-org/feos/pull/124)
 
 ## [0.3.0] - 2022-09-14
 - Major restructuring of the entire `feos` project. All individual models are reunited in the `feos` crate. `feos-core` and `feos-dft` still live as individual crates within the `feos` workspace.

--- a/src/estimator/vapor_pressure.rs
+++ b/src/estimator/vapor_pressure.rs
@@ -1,6 +1,6 @@
 use super::{DataSet, EstimatorError};
 use feos_core::{Contributions, EosUnit, EquationOfState, PhaseEquilibrium, SolverOptions, State};
-use ndarray::Array1;
+use ndarray::{arr1, Array1};
 use quantity::si::{SIArray1, SINumber, SIUnit};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -72,7 +72,7 @@ impl<E: EquationOfState> DataSet<E> for VaporPressure {
 
     fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
         if self.datapoints == 0 {
-            return Ok(arr1(&[]) * SIUnit::reference_pressure())
+            return Ok(arr1(&[]) * SIUnit::reference_pressure());
         }
 
         let critical_point =

--- a/src/estimator/vapor_pressure.rs
+++ b/src/estimator/vapor_pressure.rs
@@ -71,6 +71,10 @@ impl<E: EquationOfState> DataSet<E> for VaporPressure {
     }
 
     fn predict(&self, eos: &Arc<E>) -> Result<SIArray1, EstimatorError> {
+        if self.datapoints == 0 {
+            return Ok(arr1(&[]) * SIUnit::reference_pressure())
+        }
+
         let critical_point =
             State::critical_point(eos, None, Some(self.max_temperature), self.solver_options)
                 .or_else(|_| State::critical_point(eos, None, None, self.solver_options))?;


### PR DESCRIPTION
Fixes #58 

Other properties are fine because we use iterators instead of a for-loop.