### PR TITLE
Add benchmark for different PC-SAFT contributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ inherits = "release"
 lto = true
 
 [features]
-default = []
+default = ["pcsaft"]
 dft = ["feos-dft", "petgraph"]
 estimator = []
 association = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,22 +48,6 @@ optional = true
 approx = "0.4"
 criterion = "0.4"
 
-[[bench]]
-name = "state_properties"
-harness = false
-
-[[bench]]
-name = "state_creation"
-harness = false
-
-[[bench]]
-name = "dual_numbers"
-harness = false
-
-[[bench]]
-name = "dft_pore"
-harness = false
-
 [profile.release-lto]
 inherits = "release"
 lto = true
@@ -81,3 +65,23 @@ saftvrqmie = []
 rayon = ["dep:rayon", "ndarray/rayon", "feos-core/rayon", "feos-dft?/rayon"]
 python = ["pyo3", "numpy", "feos-core/python", "feos-dft?/python", "rayon"]
 all_models = ["dft", "estimator", "pcsaft", "gc_pcsaft", "uvtheory", "pets", "saftvrqmie"]
+
+[[bench]]
+name = "state_properties"
+harness = false
+
+[[bench]]
+name = "state_creation"
+harness = false
+
+[[bench]]
+name = "dual_numbers"
+harness = false
+
+[[bench]]
+name = "contributions"
+harness = false
+
+[[bench]]
+name = "dft_pore"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ inherits = "release"
 lto = true
 
 [features]
-default = ["pcsaft"]
+default = []
 dft = ["feos-dft", "petgraph"]
 estimator = []
 association = []

--- a/benches/README.md
+++ b/benches/README.md
@@ -15,5 +15,5 @@ cargo bench --profile=release-lto --features=pcsaft --bench=dual_numbers
 |`dual_numbers`|Helmholtz energy function evaluated using `StateHD` with different dual number types.|`pcsaft`|
 |`state_properties`|Properties of `State`. Including state creation using the natural variables of the Helmholtz energy (no density iteration).|`pcsaft`|
 |`state_creation`|Different constructors of `State` and `PhaseEquilibrium` including critical point calculations. For pure substances and mixtures.|`pcsaft`|
-|`contributions`|Helmholtz energy evaluated for various binary mixtures with different Helmholtz energy contributions. |`pcsaft`
+|`contributions`|Helmholtz energy evaluated for various binary mixtures with different Helmholtz energy contributions. |`pcsaft`|
 |`dft_pore`|Calculation of density profiles in pores using different functionals and bulk conditions. For pure substances, mixtures and heterosegmented chains.|`pcsaft`, `gc_pcsaft`, `dft`|

--- a/benches/README.md
+++ b/benches/README.md
@@ -15,4 +15,5 @@ cargo bench --profile=release-lto --features=pcsaft --bench=dual_numbers
 |`dual_numbers`|Helmholtz energy function evaluated using `StateHD` with different dual number types.|`pcsaft`|
 |`state_properties`|Properties of `State`. Including state creation using the natural variables of the Helmholtz energy (no density iteration).|`pcsaft`|
 |`state_creation`|Different constructors of `State` and `PhaseEquilibrium` including critical point calculations. For pure substances and mixtures.|`pcsaft`|
+|`contributions`|Helmholtz energy evaluated for various binary mixtures with different Helmholtz energy contributions. |`pcsaft`
 |`dft_pore`|Calculation of density profiles in pores using different functionals and bulk conditions. For pure substances, mixtures and heterosegmented chains.|`pcsaft`, `gc_pcsaft`, `dft`|

--- a/benches/contributions.rs
+++ b/benches/contributions.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 /// Benchmark for the PC-SAFT equation of state
 fn pcsaft(c: &mut Criterion) {
-    let mut group = c.benchmark_group("fugacity");
+    let mut group = c.benchmark_group("pcsaft");
 
     // non-polar components
     let mut records = PcSaftParameters::from_json(

--- a/benches/contributions.rs
+++ b/benches/contributions.rs
@@ -8,7 +8,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use feos::pcsaft::{PcSaft, PcSaftParameters};
 use feos_core::parameter::{IdentifierOption, Parameter};
-use feos_core::{Contributions, DensityInitialization, Derivative, EquationOfState, State};
+use feos_core::{DensityInitialization, Derivative, EquationOfState, State};
 use ndarray::arr1;
 use quantity::si::*;
 use std::sync::Arc;

--- a/benches/contributions.rs
+++ b/benches/contributions.rs
@@ -1,8 +1,10 @@
-//! Benchmarks for the evaluation of the Helmholtz energy function
-//! for a given `StateHD` for different types of dual numbers.
-//! These should give an idea about the expected slow-down depending
-//! on the dual number type used without the overhead of the `State`
-//! creation.
+//! Benchmarks for the evaluation of the first derivative of the
+//! Helmholtz energy function for various binary mixtures.
+//! The mixtures contain fluids of different polarities that are
+//! modeled using additional Helmholtz energy contributions.
+//! It is supposed to demonstrate the expected reduction in
+//! performance when more complex physical interactions are
+//! modeled.
 use criterion::{criterion_group, criterion_main, Criterion};
 use feos::pcsaft::{PcSaft, PcSaftParameters};
 use feos_core::parameter::{IdentifierOption, Parameter};
@@ -10,52 +12,6 @@ use feos_core::{Contributions, DensityInitialization, Derivative, EquationOfStat
 use ndarray::arr1;
 use quantity::si::*;
 use std::sync::Arc;
-
-// /// Helper function to create a state for given parameters.
-// /// - temperature is 80% of critical temperature,
-// /// - volume is critical volume,
-// /// - molefracs (or moles) for equimolar mixture.
-// fn state_pcsaft(parameters: PcSaftParameters) -> State<PcSaft> {
-//     let n = parameters.pure_records.len();
-//     let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
-//     let moles = Array::from_elem(n, 1.0 / n as f64) * 10.0 * MOL;
-//     let cp = State::critical_point(&eos, Some(&moles), None, Default::default()).unwrap();
-//     let temperature = 0.8 * cp.temperature;
-//     State::new_nvt(&eos, temperature, cp.volume, &moles).unwrap()
-// }
-
-// /// Residual Helmholtz energy given an equation of state and a StateHD.
-// fn a_res<D: DualNum<f64>, E: EquationOfState>(inp: (&Arc<E>, &StateHD<D>)) -> D
-// where
-//     (dyn HelmholtzEnergy + 'static): HelmholtzEnergyDual<D>,
-// {
-//     inp.0.evaluate_residual(inp.1)
-// }
-
-// /// Benchmark for evaluation of the Helmholtz energy for different dual number types.
-// fn bench_fugacity<E: EquationOfState>(c: &mut Criterion, group_name: &str, state: State<E>) {
-//     let mut group = c.benchmark_group(group_name);
-//     group.bench_function("a_f64", |b| {
-//         b.iter(|| a_res((&state.eos, &state.derive0())))
-//     });
-//     group.bench_function("a_dual", |b| {
-//         b.iter(|| a_res((&state.eos, &state.derive1(Derivative::DV))))
-//     });
-//     group.bench_function("a_dual2", |b| {
-//         b.iter(|| a_res((&state.eos, &state.derive2(Derivative::DV))))
-//     });
-//     group.bench_function("a_hyperdual", |b| {
-//         b.iter(|| {
-//             a_res((
-//                 &state.eos,
-//                 &state.derive2_mixed(Derivative::DV, Derivative::DV),
-//             ))
-//         })
-//     });
-//     group.bench_function("a_dual3", |b| {
-//         b.iter(|| a_res((&state.eos, &state.derive3(Derivative::DV))))
-//     });
-// }
 
 /// Benchmark for the PC-SAFT equation of state
 fn pcsaft(c: &mut Criterion) {
@@ -124,34 +80,6 @@ fn pcsaft(c: &mut Criterion) {
             group.bench_function(mix, |b| b.iter(|| eos.evaluate_residual(&state_hd)));
         }
     }
-
-    // // water (4C, polar)
-    // let parameters = PcSaftParameters::from_json(
-    //     vec!["water_4C_polar"],
-    //     "./parameters/pcsaft/rehner2020.json",
-    //     None,
-    //     IdentifierOption::Name,
-    // )
-    // .unwrap();
-    // bench_dual_numbers(
-    //     c,
-    //     "dual_numbers_pcsaft_water_4c_polar",
-    //     state_pcsaft(parameters),
-    // );
-
-    // // methane, ethane, propane
-    // let parameters = PcSaftParameters::from_json(
-    //     vec!["methane", "ethane", "propane"],
-    //     "./parameters/pcsaft/gross2001.json",
-    //     None,
-    //     IdentifierOption::Name,
-    // )
-    // .unwrap();
-    // bench_dual_numbers(
-    //     c,
-    //     "dual_numbers_pcsaft_methane_ethane_propane",
-    //     state_pcsaft(parameters),
-    // );
 }
 
 criterion_group!(bench, pcsaft);

--- a/benches/contributions.rs
+++ b/benches/contributions.rs
@@ -1,0 +1,158 @@
+//! Benchmarks for the evaluation of the Helmholtz energy function
+//! for a given `StateHD` for different types of dual numbers.
+//! These should give an idea about the expected slow-down depending
+//! on the dual number type used without the overhead of the `State`
+//! creation.
+use criterion::{criterion_group, criterion_main, Criterion};
+use feos::pcsaft::{PcSaft, PcSaftParameters};
+use feos_core::parameter::{IdentifierOption, Parameter};
+use feos_core::{Contributions, DensityInitialization, Derivative, EquationOfState, State};
+use ndarray::arr1;
+use quantity::si::*;
+use std::sync::Arc;
+
+// /// Helper function to create a state for given parameters.
+// /// - temperature is 80% of critical temperature,
+// /// - volume is critical volume,
+// /// - molefracs (or moles) for equimolar mixture.
+// fn state_pcsaft(parameters: PcSaftParameters) -> State<PcSaft> {
+//     let n = parameters.pure_records.len();
+//     let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
+//     let moles = Array::from_elem(n, 1.0 / n as f64) * 10.0 * MOL;
+//     let cp = State::critical_point(&eos, Some(&moles), None, Default::default()).unwrap();
+//     let temperature = 0.8 * cp.temperature;
+//     State::new_nvt(&eos, temperature, cp.volume, &moles).unwrap()
+// }
+
+// /// Residual Helmholtz energy given an equation of state and a StateHD.
+// fn a_res<D: DualNum<f64>, E: EquationOfState>(inp: (&Arc<E>, &StateHD<D>)) -> D
+// where
+//     (dyn HelmholtzEnergy + 'static): HelmholtzEnergyDual<D>,
+// {
+//     inp.0.evaluate_residual(inp.1)
+// }
+
+// /// Benchmark for evaluation of the Helmholtz energy for different dual number types.
+// fn bench_fugacity<E: EquationOfState>(c: &mut Criterion, group_name: &str, state: State<E>) {
+//     let mut group = c.benchmark_group(group_name);
+//     group.bench_function("a_f64", |b| {
+//         b.iter(|| a_res((&state.eos, &state.derive0())))
+//     });
+//     group.bench_function("a_dual", |b| {
+//         b.iter(|| a_res((&state.eos, &state.derive1(Derivative::DV))))
+//     });
+//     group.bench_function("a_dual2", |b| {
+//         b.iter(|| a_res((&state.eos, &state.derive2(Derivative::DV))))
+//     });
+//     group.bench_function("a_hyperdual", |b| {
+//         b.iter(|| {
+//             a_res((
+//                 &state.eos,
+//                 &state.derive2_mixed(Derivative::DV, Derivative::DV),
+//             ))
+//         })
+//     });
+//     group.bench_function("a_dual3", |b| {
+//         b.iter(|| a_res((&state.eos, &state.derive3(Derivative::DV))))
+//     });
+// }
+
+/// Benchmark for the PC-SAFT equation of state
+fn pcsaft(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fugacity");
+
+    // non-polar components
+    let mut records = PcSaftParameters::from_json(
+        vec!["hexane", "heptane"],
+        "./parameters/pcsaft/gross2001.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap()
+    .pure_records;
+    let hexane = records.remove(0);
+    let heptane = records.remove(0);
+
+    // dipolar components
+    records = PcSaftParameters::from_json(
+        vec!["acetone", "dimethyl ether"],
+        "./parameters/pcsaft/gross2006.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap()
+    .pure_records;
+    let acetone = records.remove(0);
+    let dme = records.remove(0);
+
+    // quadrupolar components
+    records = PcSaftParameters::from_json(
+        vec!["carbon dioxide", "acetylene"],
+        "./parameters/pcsaft/gross2005_literature.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap()
+    .pure_records;
+    let co2 = records.remove(0);
+    let acetylene = records.remove(0);
+
+    // associating components
+    records = PcSaftParameters::from_json(
+        vec!["ethanol", "1-propanol"],
+        "./parameters/pcsaft/gross2002.json",
+        None,
+        IdentifierOption::Name,
+    )
+    .unwrap()
+    .pure_records;
+    let ethanol = records.remove(0);
+    let propanol = records.remove(0);
+
+    let t = 300.0 * KELVIN;
+    let p = BAR;
+    let moles = arr1(&[1.0, 1.0]) * MOL;
+    for comp1 in &[hexane, acetone, co2, ethanol] {
+        for comp2 in [&heptane, &dme, &acetylene, &propanol] {
+            let params = PcSaftParameters::new_binary(vec![comp1.clone(), comp2.clone()], None);
+            let eos = Arc::new(PcSaft::new(Arc::new(params)));
+            let state = State::new_npt(&eos, t, p, &moles, DensityInitialization::Liquid).unwrap();
+            let state_hd = state.derive1(Derivative::DT);
+            let name1 = comp1.identifier.name.as_deref().unwrap();
+            let name2 = comp2.identifier.name.as_deref().unwrap();
+            let mix = format!("{name1}_{name2}");
+            group.bench_function(mix, |b| b.iter(|| eos.evaluate_residual(&state_hd)));
+        }
+    }
+
+    // // water (4C, polar)
+    // let parameters = PcSaftParameters::from_json(
+    //     vec!["water_4C_polar"],
+    //     "./parameters/pcsaft/rehner2020.json",
+    //     None,
+    //     IdentifierOption::Name,
+    // )
+    // .unwrap();
+    // bench_dual_numbers(
+    //     c,
+    //     "dual_numbers_pcsaft_water_4c_polar",
+    //     state_pcsaft(parameters),
+    // );
+
+    // // methane, ethane, propane
+    // let parameters = PcSaftParameters::from_json(
+    //     vec!["methane", "ethane", "propane"],
+    //     "./parameters/pcsaft/gross2001.json",
+    //     None,
+    //     IdentifierOption::Name,
+    // )
+    // .unwrap();
+    // bench_dual_numbers(
+    //     c,
+    //     "dual_numbers_pcsaft_methane_ethane_propane",
+    //     state_pcsaft(parameters),
+    // );
+}
+
+criterion_group!(bench, pcsaft);
+criterion_main!(bench);


### PR DESCRIPTION
times for calculating the first derivative for the following binary mixtures

||heptane|dme|acetylene|1-propanol|
|-|-|-|-|-|
|**hexane**|0.92μs|1.37μs|1.37μs|1.24μs|
|**acetone**|1.37μs|1.56μs|2.28μs|1.60μs|
|**co2**|1.37μs|2.29μs|1.58μs|1.69μs|
|**ethanol**|1.24μs|1.69μs|1.69μs|9.18μs|

Actually nice how symmetric everything is. Speaks for the reprocubility of the benchmarks.