### PR TITLE
Partial derivatives of density profiles

### DIFF
--- a/docs/theory/dft/derivatives.md
+++ b/docs/theory/dft/derivatives.md
@@ -1,0 +1,76 @@
+## Derivatives of density profiles
+For converged density properties equilibrium properties can be calculated as partial derivatives of thermodynamic potentials analogous to classical (bulk) thermodynamics. The difference is that the derivatives have to be along a path of valid density profiles (solutions of the [Euler-Lagrange equation](euler_lagrange_equation.md)).
+
+The density profiles are calculated implicitly from the Euler-Lagrange equation, which can be written simplified as
+
+$$\Omega_{\rho_i}(T,\lbrace\mu_k\rbrace,[\lbrace\rho_k(\mathbf{r})\rbrace])=\mathcal{F}_{\rho_i}(T,[\lbrace\rho_k(\mathbf{r})\rbrace])-\mu_i+V^\mathrm{ext}(\mathbf{r})=0$$ (eqn:euler_lagrange)
+
+Incorporating bond integrals can be done similar to the section on the [Newton solver](solver.md) but will not be discussed in this section. The derivatives of the density profiles can then be calculated from the total differential of eq. {eq}`eqn:euler_lagrange`.
+
+$$\mathrm{d}\Omega_{\rho_i}(\mathbf{r})=\left(\frac{\partial\Omega_{\rho_i}(\mathbf{r})}{\partial T}\right)_{\mu_k,\rho_k}\mathrm{d}T+\sum_j\left(\frac{\partial\Omega_{\rho_i}(\mathbf{r})}{\partial\mu_j}\right)_{T,\mu_k,\rho_k}\mathrm{d}\mu_j+\int\sum_j\left(\frac{\delta\Omega_{\rho_i}(\mathbf{r})}{\delta\rho_j(\mathbf{r}')}\right)_{T,\mu_k,\rho_k}\delta\rho_j(\mathbf{r}')\mathrm{d}\mathbf{r}'=0$$
+
+Using eq. {eq}`eqn:euler_lagrange` and the shortened notation for derivatives of functionals in their natural variables, e.g., $\mathcal{F}_T=\left(\frac{\partial\mathcal{F}}{\partial T}\right)_{\rho_k}$, the expression can be simplified to
+
+$$\mathcal{F}_{T\rho_i}(\mathbf{r})\mathrm{d}T-\mathrm{d}\mu_i+\int\sum_j\mathcal{F}_{\rho_i\rho_j}(\mathbf{r},\mathbf{r}')\delta\rho_j(\mathbf{r}')\mathrm{d}\mathbf{r}'=0$$ (eqn:gibbs_duhem)
+
+Similar to the Gibbs-Duhem relation for bulk phases, eq. {eq}`eqn:gibbs_duhem` shows how temperature, chemical potentials and the density profiles in an inhomogeneous system cannot be varied independently. The derivatives of the density profiles with respect to the intensive variables can be directly identified as
+
+$$\int\sum_j\mathcal{F}_{\rho_i\rho_j}(\mathbf{r},\mathbf{r}')\left(\frac{\partial\rho_j(\mathbf{r}')}{\partial T}\right)_{\mu_k}\mathrm{d}\mathbf{r}'=-\mathcal{F}_{T\rho_i}(\mathbf{r})$$
+
+and
+
+$$\int\sum_j\mathcal{F}_{\rho_i\rho_j}(\mathbf{r},\mathbf{r}')\left(\frac{\partial\rho_j(\mathbf{r}')}{\partial\mu_k}\right)_{T}\mathrm{d}\mathbf{r}'=\delta_{ik}$$ (eqn:drho_dmu)
+
+Both of these expressions are implicit (linear) equations for the derivatives. They can be solved rapidly analogously to the implicit expression appearing in the [Newton solver](solver.md). In practice, it is useful to explicitly cancel out the (often unknown) thermal de Broglie wavelength $\Lambda_i$ from the expression where it has no influence. This is done by splitting the intrinsic Helmholtz energy into an ideal gas and a residual part.
+
+$$\mathcal{F}=k_\mathrm{B}T\int\sum_im_i\rho_i(\mathbf{r})\left(\ln\left(\rho_i(\mathbf{r})\Lambda_i^3\right)-1\right)\mathrm{d}\mathbf{r}+\mathcal{\hat F}^\mathrm{res}$$
+
+Then $\mathcal{F}_{\rho_i\rho_j}(\mathbf{r},\mathbf{r}')=m_i\frac{k_\mathrm{B}T}{\rho_i(\mathbf{r})}\delta_{ij}\delta(\mathbf{r}-\mathbf{r}')+\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')$ and eq. {eq}`eqn:drho_dmu` can be rewritten as
+
+$$m_i\frac{k_\mathrm{B}T}{\rho_i(\mathbf{r})}\left(\frac{\partial\rho_i(\mathbf{r})}{\partial\mu_k}\right)_T+\int\sum_j\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')\left(\frac{\partial\rho_j(\mathbf{r}')}{\partial\mu_k}\right)_{T}\mathrm{d}\mathbf{r}'=\delta_{ik}$$
+
+In practice, the division by the density should be avoided for numerical reasons and the energetic properties are reduced with the factor $\beta=\frac{1}{k_\mathrm{B}T}$. The final expression is
+
+$$m_i\left(\frac{\partial\rho_i(\mathbf{r})}{\partial\beta\mu_k}\right)_T+\rho_i(\mathbf{r})\int\sum_j\beta\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')\left(\frac{\partial\rho_j(\mathbf{r}')}{\partial\beta\mu_k}\right)_{T}\mathrm{d}\mathbf{r}'=\rho_i(\mathbf{r})\delta_{ik}$$
+
+For the temperature derivative, it is more convenient to express eq. {eq}`eqn:gibbs_duhem` in terms of the pressure of a bulk phase that is in equilibrium with the inhomogeneous system. In the following, only paths along **constant bulk composition** are considered. With this constraint, the total differential of the chemical potential simplifies to
+
+$$\mathrm{d}\mu_i=-s_i\mathrm{d}T+v_i\mathrm{d}p$$
+
+which can be used in eq. {eq}`eqn:gibbs_duhem` to give
+
+$$\left(\mathcal{F}_{T\rho_i}(\mathbf{r})+s_i\right)\mathrm{d}T+\int\sum_j\mathcal{F}_{\rho_i\rho_j}(\mathbf{r},\mathbf{r}')\delta\rho_j(\mathbf{r}')\mathrm{d}\mathbf{r}'=v_i\mathrm{d}p$$
+
+Even though $s_i$ is readily available in $\text{FeO}_\text{s}$ it is useful at this point to rewrite the partial molar entropy as
+
+$$s_i=v_i\left(\frac{\partial p}{\partial T}\right)_{V,N_k}-\mathcal{F}_{T\rho_i}^\mathrm{b}$$
+
+Then, the intrinsic Helmholtz energy can be split into an ideal gas and a residual part again, and the de Broglie wavelength cancels.
+
+$$\begin{align*}
+&\left(m_ik_\mathrm{B}\ln\left(\frac{\rho_i(\mathbf{r})}{\rho_i^\mathrm{b}}\right)+\mathcal{F}_{T\rho_i}^\mathrm{res}(\mathbf{r})-\mathcal{F}_{T\rho_i}^\mathrm{b,res}+v_i\left(\frac{\partial p}{\partial T}\right)_{V,N_k}\right)\mathrm{d}T\\
+&~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+m_i\frac{k_\mathrm{B}T}{\rho_i(\mathbf{r})}\delta\rho_i(\mathbf{r})+\int\sum_j\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')\delta\rho_j(\mathbf{r}')\mathrm{d}\mathbf{r}'=v_i\mathrm{d}p
+\end{align*}$$
+
+Finally the expressions for the derivatives with respect to pressure
+
+$$m_i\left(\frac{\partial\rho_i(\mathbf{r})}{\partial\beta p}\right)_{T,x_k}+\rho_i(\mathbf{r})\int\sum_j\beta\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')\left(\frac{\partial\rho_j(\mathbf{r}')}{\partial\beta p}\right)_{T,x_k}\mathrm{d}\mathbf{r}'=v_i\rho_i(\mathbf{r})$$
+
+and temperature
+
+$$\begin{align*}
+&m_i\left(\frac{\partial\rho_i(\mathbf{r})}{\partial T}\right)_{p,x_k}+\rho_i(\mathbf{r})\int\sum_j\beta\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')\left(\frac{\partial\rho_j(\mathbf{r}')}{\partial T}\right)_{p,x_k}\mathrm{d}\mathbf{r}'\\
+&~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~=-\frac{\rho_i(\mathbf{r})}{k_\mathrm{B}T}\left(m_ik_\mathrm{B}\ln\left(\frac{\rho_i(\mathbf{r})}{\rho_i^\mathrm{b}}\right)+\mathcal{F}_{T\rho_i}^\mathrm{res}(\mathbf{r})-\mathcal{F}_{T\rho_i}^\mathrm{b,res}+v_i\left(\frac{\partial p}{\partial T}\right)_{V,N_k}\right)
+\end{align*}$$
+
+follow. All derivatives $x_i$ shown here can be calculated from the same linear equation
+
+$$m_ix_i+\rho_i(\mathbf{r})\int\sum_j\beta\mathcal{\hat F}_{\rho_i\rho_j}^\mathrm{res}(\mathbf{r},\mathbf{r}')x_i\mathrm{d}\mathbf{r}'=y_i$$
+
+by just replacing the right hand side $y_i$.
+
+|derivative|right hand side|
+|-|-|
+|$\left(\frac{\partial\rho_i(\mathbf{r})}{\partial\beta\mu_k}\right)_T$|$\rho_i(\mathbf{r})\delta_{ik}$|
+|$\left(\frac{\partial\rho_i(\mathbf{r})}{\partial\beta p}\right)_{T,x_k}$|$\rho_i(\mathbf{r})v_i$|
+|$\left(\frac{\partial\rho_i(\mathbf{r})}{\partial T}\right)_{p,x_k}$|$-\frac{\rho_i(\mathbf{r})}{k_\mathrm{B}T}\left(m_ik_\mathrm{B}\ln\left(\frac{\rho_i(\mathbf{r})}{\rho_i^\mathrm{b}}\right)+\mathcal{F}_{T\rho_i}^\mathrm{res}(\mathbf{r})-\mathcal{F}_{T\rho_i}^\mathrm{b,res}+v_i\left(\frac{\partial p}{\partial T}\right)_{V,N_k}\right)$|

--- a/docs/theory/dft/index.md
+++ b/docs/theory/dft/index.md
@@ -8,6 +8,7 @@ This section explains the implementation of the core expressions from classical 
    euler_lagrange_equation
    functional_derivatives
    solver
+   derivatives
    pdgt
 ```
 

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added new methods `drho_dmu`, `drho_dp` and `drho_dt` that calculate partial derivatives of density profiles to every DFT profile. Also includes direct access to the integrated derivatives `dn_dmu`, `dn_dp` and `dn_dt`.
 
 ## [0.4.0] - 2023-01-27
 ### Added

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added new methods `drho_dmu`, `drho_dp` and `drho_dt` that calculate partial derivatives of density profiles to every DFT profile. Also includes direct access to the integrated derivatives `dn_dmu`, `dn_dp` and `dn_dt`.
+- Added new methods `drho_dmu`, `drho_dp` and `drho_dt` that calculate partial derivatives of density profiles to every DFT profile. Also includes direct access to the integrated derivatives `dn_dmu`, `dn_dp` and `dn_dt`. [#134](https://github.com/feos-org/feos/pull/134)
 
 ## [0.4.0] - 2023-01-27
 ### Added

--- a/feos-dft/src/geometry.rs
+++ b/feos-dft/src/geometry.rs
@@ -149,11 +149,9 @@ impl Axis {
         }
         let x0 = 0.5 * ((-alpha * points as f64).exp() + (-alpha * (points - 1) as f64).exp());
         let grid = (0..points)
-            .into_iter()
             .map(|i| l * x0 * (alpha * i as f64).exp())
             .collect();
         let edges = (0..=points)
-            .into_iter()
             .map(|i| {
                 if i == 0 {
                     0.0
@@ -166,7 +164,6 @@ impl Axis {
         let k0 = (2.0 * alpha).exp() * (2.0 * alpha.exp() + (2.0 * alpha).exp() - 1.0)
             / ((1.0 + alpha.exp()).powi(2) * ((2.0 * alpha).exp() - 1.0));
         let integration_weights = (0..points)
-            .into_iter()
             .map(|i| {
                 (match i {
                     0 => k0 * (2.0 * alpha).exp(),

--- a/feos-dft/src/profile.rs
+++ b/feos-dft/src/profile.rs
@@ -3,14 +3,13 @@ use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::Grid;
 use crate::solver::{DFTSolver, DFTSolverLog};
 use crate::weight_functions::WeightFunctionInfo;
-use feos_core::{Contributions, EosError, EosResult, EosUnit, EquationOfState, State};
+use feos_core::{Contributions, EosError, EosResult, EosUnit, EquationOfState, State, Verbosity};
 use ndarray::{
     Array, Array1, ArrayBase, Axis as Axis_nd, Data, Dimension, Ix1, Ix2, Ix3, RemoveAxis,
 };
 use num_dual::Dual64;
-use quantity::si::{SIArray, SIArray1, SINumber, SIUnit};
+use quantity::si::{SIArray, SIArray1, SIArray2, SINumber, SIUnit};
 use quantity::Quantity;
-// use quantity::{Quantity, QuantityArray, SIArray1, SINumber};
 use std::ops::MulAssign;
 use std::sync::Arc;
 
@@ -530,5 +529,157 @@ where
             contributions,
         )? * SIUnit::reference_pressure();
         Ok(self.integrate(&internal_energy_density))
+    }
+
+    pub fn drho_dmu(&self) -> EosResult<SIArray<<D::Larger as Dimension>::Larger>> {
+        let rho = self.density.to_reduced(SIUnit::reference_density())?;
+        let second_partial_derivatives = self.second_partial_derivatives(&rho)?;
+
+        let shape = rho.shape();
+        let shape: Vec<_> = std::iter::once(&shape[0]).chain(shape).copied().collect();
+        let mut drho_dmu = Array::zeros(shape).into_dimensionality().unwrap();
+        let rhs = |x: &_| {
+            let delta_functional_derivative =
+                self.delta_functional_derivative(x, &second_partial_derivatives);
+            let mut xm = x.clone();
+            xm.outer_iter_mut()
+                .zip(self.dft.m().iter())
+                .for_each(|(mut x, &m)| x *= m);
+            // let delta_i = self.delta_bond_integrals(&exp_dfdrho, &delta_functional_derivative);
+            // x + (delta_functional_derivative - delta_i) * rho
+            xm + delta_functional_derivative * &rho
+        };
+        let mut log = DFTSolverLog::new(Verbosity::None);
+        for (k, mut d) in drho_dmu.outer_iter_mut().enumerate() {
+            let mut lhs = rho.clone();
+            for (i, mut l) in lhs.outer_iter_mut().enumerate() {
+                if i != k {
+                    l.fill(0.0);
+                }
+            }
+            d.assign(&Self::gmres(rhs, &lhs, 200, 1e-13, &mut log)?);
+        }
+        Ok(drho_dmu
+            * (SIUnit::reference_density() / SIUnit::reference_molar_entropy() / self.temperature))
+    }
+
+    pub fn dn_dmu(&self) -> EosResult<SIArray2> {
+        let drho_dmu = self.drho_dmu()?;
+        let n = drho_dmu.shape()[0];
+        let dn_dmu = SIArray2::from_shape_fn([n; 2], |(i, j)| {
+            self.integrate(&drho_dmu.index_axis(Axis_nd(0), i).index_axis(Axis_nd(0), j))
+        });
+        Ok(dn_dmu)
+    }
+
+    pub fn drho_dp(&self) -> EosResult<SIArray<D::Larger>> {
+        let rho = self.density.to_reduced(SIUnit::reference_density())?;
+        let partial_density = self
+            .bulk
+            .partial_density
+            .to_reduced(SIUnit::reference_density())?;
+        let rho_bulk = self.dft.component_index().mapv(|i| partial_density[i]);
+
+        let second_partial_derivatives = self.second_partial_derivatives(&rho)?;
+        let (_, _, _, exp_dfdrho, _) = self.euler_lagrange_equation(&rho, &rho_bulk, false)?;
+
+        let rhs = |x: &_| {
+            let delta_functional_derivative =
+                self.delta_functional_derivative(x, &second_partial_derivatives);
+            let mut xm = x.clone();
+            xm.outer_iter_mut()
+                .zip(self.dft.m().iter())
+                .for_each(|(mut x, &m)| x *= m);
+            let delta_i = self.delta_bond_integrals(&exp_dfdrho, &delta_functional_derivative);
+            xm + (delta_functional_derivative - delta_i) * &rho
+        };
+        let mut lhs = rho.clone();
+        let v = self
+            .bulk
+            .partial_molar_volume(Contributions::Total)
+            .to_reduced(SIUnit::reference_volume() / SIUnit::reference_moles())?;
+        for (mut l, &c) in lhs.outer_iter_mut().zip(self.dft.component_index().iter()) {
+            l *= v[c];
+        }
+        let mut log = DFTSolverLog::new(Verbosity::None);
+        Self::gmres(rhs, &lhs, 200, 1e-13, &mut log)
+            .map(|x| x / (SIUnit::reference_molar_entropy() * self.temperature))
+    }
+
+    pub fn dn_dp(&self) -> EosResult<SIArray1> {
+        let dn_dp = self.integrate_comp(&self.drho_dp()?);
+        let mut dn_dp_comp = Array1::zeros(self.dft.components()) * SIUnit::reference_moles()
+            / SIUnit::reference_pressure();
+        for (i, &j) in self.dft.component_index().iter().enumerate() {
+            dn_dp_comp.try_set(j, dn_dp.get(i)).unwrap();
+        }
+        Ok(dn_dp_comp)
+    }
+
+    pub fn drho_dt(&self) -> EosResult<SIArray<D::Larger>> {
+        let rho = self.density.to_reduced(SIUnit::reference_density())?;
+        let t = self
+            .temperature
+            .to_reduced(SIUnit::reference_temperature())?;
+
+        let second_partial_derivatives = self.second_partial_derivatives(&rho)?;
+
+        // define rhs
+        let rhs = |x: &_| {
+            let delta_functional_derivative =
+                self.delta_functional_derivative(x, &second_partial_derivatives);
+            let mut xm = x.clone();
+            xm.outer_iter_mut()
+                .zip(self.dft.m().iter())
+                .for_each(|(mut x, &m)| x *= m);
+            // let delta_i = self.delta_bond_integrals(&exp_dfdrho, &delta_functional_derivative);
+            // (xm + (delta_functional_derivative - delta_i) * &rho) * t
+            (xm + delta_functional_derivative * &rho) * t
+        };
+
+        // calculate temperature derivative of functional derivative
+        let functional_contributions = self.dft.contributions();
+        let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
+            .iter()
+            .map(|c| c.weight_functions(Dual64::from(t).derive()))
+            .collect();
+        let convolver: Arc<dyn Convolver<_, D>> =
+            ConvolverFFT::plan(&self.grid, &weight_functions, None);
+        let (_, dfdrhodt) = self.dft.functional_derivative_dual(t, &rho, &convolver)?;
+
+        // calculate temperature derivative of bulk functional derivative
+        let partial_density = self
+            .bulk
+            .partial_density
+            .to_reduced(SIUnit::reference_density())?;
+        let rho_bulk = self.dft.component_index().mapv(|i| partial_density[i]);
+        let bulk_convolver = BulkConvolver::new(weight_functions);
+        let (_, dfdrhodt_bulk) =
+            self.dft
+                .functional_derivative_dual(t, &rho_bulk, &bulk_convolver)?;
+
+        // solve for drho_dt
+        let x = (self.bulk.dp_dni(Contributions::Total) * self.bulk.dp_dt(Contributions::Total)
+            / self.bulk.dp_dv(Contributions::Total))
+        .to_reduced(SIUnit::reference_molar_entropy())?;
+        let mut lhs = dfdrhodt.mapv(|d| d.eps[0]);
+        lhs.outer_iter_mut()
+            .zip(dfdrhodt_bulk.into_iter())
+            .zip(x.into_iter())
+            .for_each(|((mut lhs, d), x)| lhs -= d.eps[0] + x);
+        lhs.outer_iter_mut()
+            .zip(rho.outer_iter())
+            .zip(rho_bulk.into_iter())
+            .zip(self.dft.m().iter())
+            .for_each(|(((mut lhs, rho), rho_b), &m)| lhs += &((&rho / rho_b).mapv(f64::ln) * m));
+
+        lhs *= &(-&rho);
+        let mut log = DFTSolverLog::new(Verbosity::None);
+        let drho_dt = Self::gmres(rhs, &lhs, 200, 1e-13, &mut log)?;
+        Ok(drho_dt * (SIUnit::reference_density() / SIUnit::reference_temperature()))
+    }
+
+    pub fn dn_dt(&self) -> EosResult<SIArray1> {
+        Ok(self.integrate_comp(&self.drho_dt()?))
     }
 }

--- a/feos-dft/src/python/profile.rs
+++ b/feos-dft/src/python/profile.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! impl_profile {
-    ($struct:ident, $arr:ident, $arr2:ident, $si_arr:ident, $si_arr2:ident, $py_arr2:ident, [$([$ind:expr, $ax:ident]),+]) => {
+    ($struct:ident, $arr:ident, $arr2:ident, $si_arr:ident, $si_arr2:ident, $py_arr2:ident, [$([$ind:expr, $ax:ident]),+]$(, $si_arr3:ident)?) => {
         #[pymethods]
         impl $struct {
             /// Calculate the residual for the given profile.
@@ -178,6 +178,37 @@ macro_rules! impl_profile {
                     self.0.profile.grand_potential_density()?,
                 ))
             }
+            $(
+                #[getter]
+                fn get_drho_dmu(&self) -> PyResult<$si_arr3> {
+                    Ok(($si_arr3::from(self.0.profile.drho_dmu()?)))
+                }
+            )?
+
+            #[getter]
+            fn get_dn_dmu(&self) -> PyResult<PySIArray2> {
+                Ok((PySIArray2::from(self.0.profile.dn_dmu()?)))
+            }
+
+            #[getter]
+            fn get_drho_dp(&self) -> PyResult<$si_arr2> {
+                Ok(($si_arr2::from(self.0.profile.drho_dp()?)))
+            }
+
+            #[getter]
+            fn get_dn_dp(&self) -> PyResult<PySIArray1> {
+                Ok((PySIArray1::from(self.0.profile.dn_dp()?)))
+            }
+
+            #[getter]
+            fn get_drho_dt(&self) -> PyResult<$si_arr2> {
+                Ok(($si_arr2::from(self.0.profile.drho_dt()?)))
+            }
+
+            #[getter]
+            fn get_dn_dt(&self) -> PyResult<PySIArray1> {
+                Ok((PySIArray1::from(self.0.profile.dn_dt()?)))
+            }
         }
     };
 }
@@ -192,7 +223,8 @@ macro_rules! impl_1d_profile {
             PySIArray1,
             PySIArray2,
             PyArray2,
-            [$([0, $ax]),+]
+            [$([0, $ax]),+],
+            PySIArray3
         );
     };
 }

--- a/feos-dft/src/solver.rs
+++ b/feos-dft/src/solver.rs
@@ -150,6 +150,7 @@ impl DFTSolver {
     }
 }
 
+/// A log that stores the residuals and execution time of DFT solvers.
 #[derive(Clone)]
 pub struct DFTSolverLog {
     verbosity: Verbosity,

--- a/feos-dft/src/solver.rs
+++ b/feos-dft/src/solver.rs
@@ -160,7 +160,7 @@ pub struct DFTSolverLog {
 }
 
 impl DFTSolverLog {
-    fn new(verbosity: Verbosity) -> Self {
+    pub(crate) fn new(verbosity: Verbosity) -> Self {
         log_iter!(
             verbosity,
             "solver                 | iter |    time    | residual "
@@ -474,7 +474,7 @@ where
         Ok((false, newton.max_iter))
     }
 
-    fn gmres<R>(
+    pub(crate) fn gmres<R>(
         rhs: R,
         r0: &Array<f64, D::Larger>,
         max_iter: usize,
@@ -547,7 +547,7 @@ where
         Ok(x)
     }
 
-    fn second_partial_derivatives(
+    pub(crate) fn second_partial_derivatives(
         &self,
         density: &Array<f64, D::Larger>,
     ) -> EosResult<Vec<Array<f64, <D::Larger as Dimension>::Larger>>> {
@@ -577,7 +577,7 @@ where
         Ok(second_partial_derivatives)
     }
 
-    fn delta_functional_derivative(
+    pub(crate) fn delta_functional_derivative(
         &self,
         delta_density: &Array<f64, D::Larger>,
         second_partial_derivatives: &[Array<f64, <D::Larger as Dimension>::Larger>],
@@ -607,7 +607,7 @@ where
             .functional_derivative(&delta_partial_derivatives)
     }
 
-    fn delta_bond_integrals(
+    pub(crate) fn delta_bond_integrals(
         &self,
         exponential: &Array<f64, D::Larger>,
         delta_functional_derivative: &Array<f64, D::Larger>,
@@ -770,7 +770,7 @@ impl DFTSolver {
                     newton.tol,
                 ),
             };
-            res += &format!("\n|{}|{}|{:e}|", solver, max_iter, tol);
+            res += &format!("\n|{solver}|{max_iter}|{tol:e}|");
         }
         res
     }


### PR DESCRIPTION
This PR introduces routines for the calculation of partial derivatives of density profiles with respect to chemical potential, pressure, and temperature. Since the calculation of the density profiles is implicit, a procedure similiar to that used in the Newton solver is used. The derivatives are calculated analytically using automatic differentiation. Therefore, the calculation is faster and more robust compared to approximating the profiles using numerical differentiation.

With the derivatives in place, enthalpies of adsorption should be readily available. In addition, the derivatives can be used to generate better initial values for the calculation of adsorption isotherms or surface tension diagrams.

While derivatives with respect to $p$ or $\mu$ are also available for heterosegmented functionals, temperature derivatives currently can not be implemented without breaking the interface.