### PR TITLE
Update num-dual dependency to 0.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,9 @@
 name: Build Wheels
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the internal implementation of the association contribution to accomodate more general association schemes. [#150](https://github.com/feos-org/feos/pull/150)
 - To comply with the new association implementation, the default values of `na` and `nb` are now `0` rather than `1`. Parameter files have been adapted accordingly. [#150](https://github.com/feos-org/feos/pull/150)
 
+### Packaging
+- Updated `num-dual` dependency to 0.7. [#137](https://github.com/feos-org/feos/pull/137)
+
 ## [0.4.3] - 2023-03-20
 - Python only: Release the changes introduced in `feos-core` 0.4.2.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 quantity = "0.6"
-#num-dual = "0.7"
-num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "scalar_numbers" }
+num-dual = "0.7"
 feos-core = { version = "0.4", path = "feos-core" }
 feos-dft = { version = "0.4", path = "feos-dft", optional = true }
 feos-derive = { version = "0.2", path = "feos-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 quantity = "0.6"
-num-dual = "0.6"
+num-dual = "0.7"
 feos-core = { version = "0.4", path = "feos-core" }
 feos-dft = { version = "0.4", path = "feos-dft", optional = true }
 feos-derive = { version = "0.2", path = "feos-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 quantity = "0.6"
-num-dual = "0.7"
+#num-dual = "0.7"
+num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "scalar_numbers" }
 feos-core = { version = "0.4", path = "feos-core" }
 feos-dft = { version = "0.4", path = "feos-dft", optional = true }
 feos-derive = { version = "0.2", path = "feos-derive" }

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -28,7 +28,7 @@ fn state_pcsaft(parameters: PcSaftParameters) -> State<PcSaft> {
 }
 
 /// Residual Helmholtz energy given an equation of state and a StateHD.
-fn a_res<D: DualNum<f64>, E: EquationOfState>(inp: (&Arc<E>, &StateHD<D>)) -> D
+fn a_res<D: DualNum<f64> + Copy, E: EquationOfState>(inp: (&Arc<E>, &StateHD<D>)) -> D
 where
     (dyn HelmholtzEnergy + 'static): HelmholtzEnergyDual<D>,
 {

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Packaging
+- Updated `num-dual` dependency to 0.7. [#137](https://github.com/feos-org/feos/pull/137)
 
 ## [0.4.2] - 2023-04-03
 ### Fixed

--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -19,7 +19,8 @@ features = [ "rayon" ]
 
 [dependencies]
 quantity = "0.6"
-num-dual = { version = "0.7", features = ["linalg"] }
+#num-dual = { version = "0.7", features = ["linalg"] }
+num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "scalar_numbers", features = ["linalg"] }
 ndarray = { version = "0.15", features = ["serde"] }
 nalgebra = "0.32"
 num-traits = "0.2"

--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -19,8 +19,7 @@ features = [ "rayon" ]
 
 [dependencies]
 quantity = "0.6"
-#num-dual = { version = "0.7", features = ["linalg"] }
-num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "scalar_numbers", features = ["linalg"] }
+num-dual = { version = "0.7", features = ["linalg"] }
 ndarray = { version = "0.15", features = ["serde"] }
 nalgebra = "0.32"
 num-traits = "0.2"

--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -19,8 +19,9 @@ features = [ "rayon" ]
 
 [dependencies]
 quantity = "0.6"
-num-dual = { version = "0.6", features = ["linalg"] }
+num-dual = { version = "0.7", features = ["linalg"] }
 ndarray = { version = "0.15", features = ["serde"] }
+nalgebra = "0.32"
 num-traits = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -37,4 +38,4 @@ approx = "0.4"
 [features]
 default = []
 rayon = ["dep:rayon", "ndarray/rayon"]
-python = ["pyo3", "numpy", "quantity/python", "num-dual/python", "rayon"]
+python = ["pyo3", "numpy", "quantity/python", "num-dual/python_macro", "rayon"]

--- a/feos-core/src/cubic.rs
+++ b/feos-core/src/cubic.rs
@@ -170,7 +170,7 @@ struct PengRobinsonContribution {
     parameters: Arc<PengRobinsonParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for PengRobinsonContribution {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for PengRobinsonContribution {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         // temperature dependent a parameter
         let p = &self.parameters;

--- a/feos-core/src/equation_of_state.rs
+++ b/feos-core/src/equation_of_state.rs
@@ -3,9 +3,10 @@ use crate::state::StateHD;
 use crate::EosUnit;
 use ndarray::prelude::*;
 use num_dual::{
-    Dual, Dual2_64, Dual3, Dual3_64, Dual64, DualNum, DualVec64, HyperDual, HyperDual64,
+    first_derivative, second_derivative, third_derivative, Dual, Dual2, Dual2_64, Dual3, Dual3_64,
+    Dual64, DualNum, DualSVec64, HyperDual, HyperDual64,
 };
-use num_traits::{One, Zero};
+use num_traits::Zero;
 use quantity::si::{SIArray1, SINumber, SIUnit};
 use std::fmt;
 
@@ -28,16 +29,17 @@ pub trait HelmholtzEnergyDual<D: DualNum<f64>> {
 pub trait HelmholtzEnergy:
     HelmholtzEnergyDual<f64>
     + HelmholtzEnergyDual<Dual64>
-    + HelmholtzEnergyDual<Dual<DualVec64<3>, f64>>
+    + HelmholtzEnergyDual<Dual<DualSVec64<3>, f64>>
     + HelmholtzEnergyDual<HyperDual64>
     + HelmholtzEnergyDual<Dual2_64>
     + HelmholtzEnergyDual<Dual3_64>
     + HelmholtzEnergyDual<HyperDual<Dual64, f64>>
-    + HelmholtzEnergyDual<HyperDual<DualVec64<2>, f64>>
-    + HelmholtzEnergyDual<HyperDual<DualVec64<3>, f64>>
+    + HelmholtzEnergyDual<HyperDual<DualSVec64<2>, f64>>
+    + HelmholtzEnergyDual<HyperDual<DualSVec64<3>, f64>>
+    + HelmholtzEnergyDual<Dual2<Dual64, f64>>
     + HelmholtzEnergyDual<Dual3<Dual64, f64>>
-    + HelmholtzEnergyDual<Dual3<DualVec64<2>, f64>>
-    + HelmholtzEnergyDual<Dual3<DualVec64<3>, f64>>
+    + HelmholtzEnergyDual<Dual3<DualSVec64<2>, f64>>
+    + HelmholtzEnergyDual<Dual3<DualSVec64<3>, f64>>
     + fmt::Display
     + Send
     + Sync
@@ -47,16 +49,17 @@ pub trait HelmholtzEnergy:
 impl<T> HelmholtzEnergy for T where
     T: HelmholtzEnergyDual<f64>
         + HelmholtzEnergyDual<Dual64>
-        + HelmholtzEnergyDual<Dual<DualVec64<3>, f64>>
+        + HelmholtzEnergyDual<Dual<DualSVec64<3>, f64>>
         + HelmholtzEnergyDual<HyperDual64>
         + HelmholtzEnergyDual<Dual2_64>
         + HelmholtzEnergyDual<Dual3_64>
         + HelmholtzEnergyDual<HyperDual<Dual64, f64>>
-        + HelmholtzEnergyDual<HyperDual<DualVec64<2>, f64>>
-        + HelmholtzEnergyDual<HyperDual<DualVec64<3>, f64>>
+        + HelmholtzEnergyDual<HyperDual<DualSVec64<2>, f64>>
+        + HelmholtzEnergyDual<HyperDual<DualSVec64<3>, f64>>
+        + HelmholtzEnergyDual<Dual2<Dual64, f64>>
         + HelmholtzEnergyDual<Dual3<Dual64, f64>>
-        + HelmholtzEnergyDual<Dual3<DualVec64<2>, f64>>
-        + HelmholtzEnergyDual<Dual3<DualVec64<3>, f64>>
+        + HelmholtzEnergyDual<Dual3<DualSVec64<2>, f64>>
+        + HelmholtzEnergyDual<Dual3<DualSVec64<3>, f64>>
         + fmt::Display
         + Send
         + Sync
@@ -70,7 +73,7 @@ impl<T> HelmholtzEnergy for T where
 /// the specific types in the supertraits of [IdealGasContribution]
 /// so that the implementor can be used as an ideal gas
 /// contribution in the equation of state.
-pub trait IdealGasContributionDual<D: DualNum<f64>> {
+pub trait IdealGasContributionDual<D: DualNum<f64> + Copy> {
     /// The thermal de Broglie wavelength of each component in the form $\ln\left(\frac{\Lambda^3}{\AA^3}\right)$
     fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D>;
 
@@ -101,16 +104,17 @@ pub trait IdealGasContributionDual<D: DualNum<f64>> {
 pub trait IdealGasContribution:
     IdealGasContributionDual<f64>
     + IdealGasContributionDual<Dual64>
-    + IdealGasContributionDual<Dual<DualVec64<3>, f64>>
+    + IdealGasContributionDual<Dual<DualSVec64<3>, f64>>
     + IdealGasContributionDual<HyperDual64>
     + IdealGasContributionDual<Dual2_64>
     + IdealGasContributionDual<Dual3_64>
     + IdealGasContributionDual<HyperDual<Dual64, f64>>
-    + IdealGasContributionDual<HyperDual<DualVec64<2>, f64>>
-    + IdealGasContributionDual<HyperDual<DualVec64<3>, f64>>
+    + IdealGasContributionDual<HyperDual<DualSVec64<2>, f64>>
+    + IdealGasContributionDual<HyperDual<DualSVec64<3>, f64>>
+    + IdealGasContributionDual<Dual2<Dual64, f64>>
     + IdealGasContributionDual<Dual3<Dual64, f64>>
-    + IdealGasContributionDual<Dual3<DualVec64<2>, f64>>
-    + IdealGasContributionDual<Dual3<DualVec64<3>, f64>>
+    + IdealGasContributionDual<Dual3<DualSVec64<2>, f64>>
+    + IdealGasContributionDual<Dual3<DualSVec64<3>, f64>>
     + fmt::Display
 {
 }
@@ -118,22 +122,23 @@ pub trait IdealGasContribution:
 impl<T> IdealGasContribution for T where
     T: IdealGasContributionDual<f64>
         + IdealGasContributionDual<Dual64>
-        + IdealGasContributionDual<Dual<DualVec64<3>, f64>>
+        + IdealGasContributionDual<Dual<DualSVec64<3>, f64>>
         + IdealGasContributionDual<HyperDual64>
         + IdealGasContributionDual<Dual2_64>
         + IdealGasContributionDual<Dual3_64>
         + IdealGasContributionDual<HyperDual<Dual64, f64>>
-        + IdealGasContributionDual<HyperDual<DualVec64<2>, f64>>
-        + IdealGasContributionDual<HyperDual<DualVec64<3>, f64>>
+        + IdealGasContributionDual<HyperDual<DualSVec64<2>, f64>>
+        + IdealGasContributionDual<HyperDual<DualSVec64<3>, f64>>
+        + IdealGasContributionDual<Dual2<Dual64, f64>>
         + IdealGasContributionDual<Dual3<Dual64, f64>>
-        + IdealGasContributionDual<Dual3<DualVec64<2>, f64>>
-        + IdealGasContributionDual<Dual3<DualVec64<3>, f64>>
+        + IdealGasContributionDual<Dual3<DualSVec64<2>, f64>>
+        + IdealGasContributionDual<Dual3<DualSVec64<3>, f64>>
         + fmt::Display
 {
 }
 
 struct DefaultIdealGasContribution;
-impl<D: DualNum<f64>> IdealGasContributionDual<D> for DefaultIdealGasContribution {
+impl<D: DualNum<f64> + Copy> IdealGasContributionDual<D> for DefaultIdealGasContribution {
     fn de_broglie_wavelength(&self, _: D, components: usize) -> Array1<D> {
         Array1::zeros(components)
     }
@@ -175,7 +180,7 @@ pub trait EquationOfState: Send + Sync {
     fn residual(&self) -> &[Box<dyn HelmholtzEnergy>];
 
     /// Evaluate the residual reduced Helmholtz energy $\beta A^\mathrm{res}$.
-    fn evaluate_residual<D: DualNum<f64>>(&self, state: &StateHD<D>) -> D
+    fn evaluate_residual<D: DualNum<f64> + Copy>(&self, state: &StateHD<D>) -> D
     where
         dyn HelmholtzEnergy: HelmholtzEnergyDual<D>,
     {
@@ -187,7 +192,7 @@ pub trait EquationOfState: Send + Sync {
 
     /// Evaluate the reduced Helmholtz energy of each individual contribution
     /// and return them together with a string representation of the contribution.
-    fn evaluate_residual_contributions<D: DualNum<f64>>(
+    fn evaluate_residual_contributions<D: DualNum<f64> + Copy>(
         &self,
         state: &StateHD<D>,
     ) -> Vec<(String, D)>
@@ -252,12 +257,10 @@ pub trait EquationOfState: Send + Sync {
     ) -> EosResult<SINumber> {
         let mr = self.validate_moles(moles)?;
         let x = mr.to_reduced(mr.sum())?;
-        let mut rho = HyperDual64::zero();
-        rho.eps1[0] = 1.0;
-        rho.eps2[0] = 1.0;
-        let t = HyperDual64::from(temperature.to_reduced(SIUnit::reference_temperature())?);
-        let s = StateHD::new_virial(t, rho, x);
-        Ok(self.evaluate_residual(&s).eps1eps2[(0, 0)] * 0.5 / SIUnit::reference_density())
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
+        let a_res = |rho| self.evaluate_residual(&StateHD::new_virial(t.into(), rho, x));
+        let (_, _, b) = second_derivative(a_res, 0.0);
+        Ok(b * 0.5 / SIUnit::reference_density())
     }
 
     /// Calculate the third virial coefficient $C(T)$
@@ -268,10 +271,10 @@ pub trait EquationOfState: Send + Sync {
     ) -> EosResult<SINumber> {
         let mr = self.validate_moles(moles)?;
         let x = mr.to_reduced(mr.sum())?;
-        let rho = Dual3_64::zero().derive();
-        let t = Dual3_64::from(temperature.to_reduced(SIUnit::reference_temperature())?);
-        let s = StateHD::new_virial(t, rho, x);
-        Ok(self.evaluate_residual(&s).v3 / 3.0 / SIUnit::reference_density().powi(2))
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
+        let a_res = |rho| self.evaluate_residual(&StateHD::new_virial(t.into(), rho, x));
+        let (_, _, _, c) = third_derivative(a_res, 0.0);
+        Ok(c / 3.0 / SIUnit::reference_density().powi(2))
     }
 
     /// Calculate the temperature derivative of the second virial coefficient $B'(T)$
@@ -282,15 +285,16 @@ pub trait EquationOfState: Send + Sync {
     ) -> EosResult<SINumber> {
         let mr = self.validate_moles(moles)?;
         let x = mr.to_reduced(mr.sum())?;
-        let mut rho = HyperDual::zero();
-        rho.eps1[0] = Dual64::one();
-        rho.eps2[0] = Dual64::one();
-        let t = HyperDual::from_re(
-            Dual64::from(temperature.to_reduced(SIUnit::reference_temperature())?).derive(),
-        );
-        let s = StateHD::new_virial(t, rho, x);
-        Ok(self.evaluate_residual(&s).eps1eps2[(0, 0)].eps[0] * 0.5
-            / (SIUnit::reference_density() * SIUnit::reference_temperature()))
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
+        let b = |t| {
+            let a_res = |rho: Dual2<Dual64, f64>| {
+                self.evaluate_residual(&StateHD::new_virial(Dual2::from_re(t), rho, x))
+            };
+            let (_, _, b) = second_derivative(a_res, Dual64::zero());
+            b
+        };
+        let (_, b_t) = first_derivative(b, t);
+        Ok(b_t * 0.5 / (SIUnit::reference_density() * SIUnit::reference_temperature()))
     }
 
     /// Calculate the temperature derivative of the third virial coefficient $C'(T)$
@@ -301,14 +305,15 @@ pub trait EquationOfState: Send + Sync {
     ) -> EosResult<SINumber> {
         let mr = self.validate_moles(moles)?;
         let x = mr.to_reduced(mr.sum())?;
-        let rho = Dual3::zero().derive();
-        let t = Dual3::from_re(
-            Dual64::from(temperature.to_reduced(SIUnit::reference_temperature())?).derive(),
-        );
-        let s = StateHD::new_virial(t, rho, x);
-        Ok(self.evaluate_residual(&s).v3.eps[0]
-            / 3.0
-            / (SIUnit::reference_density().powi(2) * SIUnit::reference_temperature()))
+        let t = temperature.to_reduced(SIUnit::reference_temperature())?;
+        let c = |t| {
+            let a_res =
+                |rho| self.evaluate_residual(&StateHD::new_virial(Dual3::from_re(t), rho, x));
+            let (_, _, _, c) = third_derivative(a_res, Dual64::zero());
+            c
+        };
+        let (_, c_t) = first_derivative(c, t);
+        Ok(c_t / 3.0 / (SIUnit::reference_density().powi(2) * SIUnit::reference_temperature()))
     }
 }
 

--- a/feos-core/src/joback.rs
+++ b/feos-core/src/joback.rs
@@ -107,7 +107,7 @@ const P0: f64 = 1.0e5;
 const A3: f64 = 1e-30;
 const KB: f64 = 1.38064852e-23;
 
-impl<D: DualNum<f64>> IdealGasContributionDual<D> for Joback {
+impl<D: DualNum<f64> + Copy> IdealGasContributionDual<D> for Joback {
     fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D> {
         let t = temperature;
         let t2 = t * t;

--- a/feos-core/src/python/user_defined.rs
+++ b/feos-core/src/python/user_defined.rs
@@ -2,11 +2,11 @@ use crate::{EquationOfState, HelmholtzEnergy, HelmholtzEnergyDual, MolarWeight, 
 use ndarray::Array1;
 use num_dual::*;
 use numpy::convert::IntoPyArray;
-use numpy::{PyReadonlyArrayDyn, PyArray};
+use numpy::{PyArray, PyReadonlyArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use quantity::python::PySIArray1;
-use quantity::si::{SIArray1};
+use quantity::si::SIArray1;
 use std::fmt;
 
 struct PyHelmholtzEnergy(Py<PyAny>);
@@ -205,34 +205,35 @@ state!(PyStateF, f64, f64);
 helmholtz_energy!(PyStateF, f64, f64);
 
 impl_dual_state_helmholtz_energy!(PyStateD, PyDual64, Dual64, f64);
-dual_number!(PyDualVec3, DualVec64<3>, f64);
+dual_number!(PyDualVec3, DualSVec64<3>, f64);
 impl_dual_state_helmholtz_energy!(
     PyStateDualDualVec3,
     PyDualDualVec3,
-    Dual<DualVec64<3>, f64>,
+    Dual<DualSVec64<3>, f64>,
     PyDualVec3
 );
-impl_dual_state_helmholtz_energy!(
-    PyStateHD,
-    PyHyperDual64,
-    HyperDual64,
-    f64
-);
+impl_dual_state_helmholtz_energy!(PyStateHD, PyHyperDual64, HyperDual64, f64);
 impl_dual_state_helmholtz_energy!(PyStateD2, PyDual2_64, Dual2_64, f64);
 impl_dual_state_helmholtz_energy!(PyStateD3, PyDual3_64, Dual3_64, f64);
 impl_dual_state_helmholtz_energy!(PyStateHDD, PyHyperDualDual64, HyperDual<Dual64, f64>, PyDual64);
-dual_number!(PyDualVec2, DualVec64<2>, f64);
+dual_number!(PyDualVec2, DualSVec64<2>, f64);
 impl_dual_state_helmholtz_energy!(
     PyStateHDDVec2,
     PyHyperDualVec2,
-    HyperDual<DualVec64<2>, f64>,
+    HyperDual<DualSVec64<2>, f64>,
     PyDualVec2
 );
 impl_dual_state_helmholtz_energy!(
     PyStateHDDVec3,
     PyHyperDualVec3,
-    HyperDual<DualVec64<3>, f64>,
+    HyperDual<DualSVec64<3>, f64>,
     PyDualVec3
+);
+impl_dual_state_helmholtz_energy!(
+    PyStateD2D,
+    PyDual2Dual64,
+    Dual2<Dual64, f64>,
+    PyDual64
 );
 impl_dual_state_helmholtz_energy!(
     PyStateD3D,
@@ -243,12 +244,12 @@ impl_dual_state_helmholtz_energy!(
 impl_dual_state_helmholtz_energy!(
     PyStateD3DVec2,
     PyDual3DualVec2,
-    Dual3<DualVec64<2>, f64>,
+    Dual3<DualSVec64<2>, f64>,
     PyDualVec2
 );
 impl_dual_state_helmholtz_energy!(
     PyStateD3DVec3,
     PyDual3DualVec3,
-    Dual3<DualVec64<3>, f64>,
+    Dual3<DualSVec64<3>, f64>,
     PyDualVec3
 );

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -45,8 +45,8 @@ impl Cache {
             let value = f();
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
-                .insert(PartialDerivative::First(derivative), value.eps.unwrap());
-            value.eps.unwrap()
+                .insert(PartialDerivative::First(derivative), value.eps);
+            value.eps
         }
     }
 
@@ -66,12 +66,12 @@ impl Cache {
             let value = f();
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
-                .insert(PartialDerivative::First(derivative), value.v1.unwrap());
+                .insert(PartialDerivative::First(derivative), value.v1);
             self.map.insert(
                 PartialDerivative::SecondMixed(derivative, derivative),
-                value.v2.unwrap(),
+                value.v2,
             );
-            value.v2.unwrap()
+            value.v2
         }
     }
 
@@ -91,14 +91,12 @@ impl Cache {
             let value = f();
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
-                .insert(PartialDerivative::First(derivative1), value.eps1.unwrap());
+                .insert(PartialDerivative::First(derivative1), value.eps1);
             self.map
-                .insert(PartialDerivative::First(derivative2), value.eps2.unwrap());
-            self.map.insert(
-                PartialDerivative::SecondMixed(d1, d2),
-                value.eps1eps2.unwrap(),
-            );
-            value.eps1eps2.unwrap()
+                .insert(PartialDerivative::First(derivative2), value.eps2);
+            self.map
+                .insert(PartialDerivative::SecondMixed(d1, d2), value.eps1eps2);
+            value.eps1eps2
         }
     }
 

--- a/feos-core/src/state/cache.rs
+++ b/feos-core/src/state/cache.rs
@@ -45,8 +45,8 @@ impl Cache {
             let value = f();
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
-                .insert(PartialDerivative::First(derivative), value.eps[0]);
-            value.eps[0]
+                .insert(PartialDerivative::First(derivative), value.eps.unwrap());
+            value.eps.unwrap()
         }
     }
 
@@ -66,12 +66,12 @@ impl Cache {
             let value = f();
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
-                .insert(PartialDerivative::First(derivative), value.v1[0]);
+                .insert(PartialDerivative::First(derivative), value.v1.unwrap());
             self.map.insert(
                 PartialDerivative::SecondMixed(derivative, derivative),
-                value.v2[0],
+                value.v2.unwrap(),
             );
-            value.v2[0]
+            value.v2.unwrap()
         }
     }
 
@@ -91,14 +91,14 @@ impl Cache {
             let value = f();
             self.map.insert(PartialDerivative::Zeroth, value.re);
             self.map
-                .insert(PartialDerivative::First(derivative1), value.eps1[0]);
+                .insert(PartialDerivative::First(derivative1), value.eps1.unwrap());
             self.map
-                .insert(PartialDerivative::First(derivative2), value.eps2[0]);
+                .insert(PartialDerivative::First(derivative2), value.eps2.unwrap());
             self.map.insert(
                 PartialDerivative::SecondMixed(d1, d2),
-                value.eps1eps2[(0, 0)],
+                value.eps1eps2.unwrap(),
             );
-            value.eps1eps2[(0, 0)]
+            value.eps1eps2.unwrap()
         }
     }
 

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -58,7 +58,7 @@ pub struct StateHD<D: DualNum<f64>> {
     pub partial_density: Array1<D>,
 }
 
-impl<D: DualNum<f64>> StateHD<D> {
+impl<D: DualNum<f64> + Copy> StateHD<D> {
     /// Create a new `StateHD` for given temperature volume and moles.
     pub fn new(temperature: D, volume: D, moles: Array1<D>) -> Self {
         let total_moles = moles.sum();
@@ -686,9 +686,9 @@ impl<E: EquationOfState> State<E> {
         let mut v = Dual64::from(self.reduced_volume);
         let mut n = self.reduced_moles.mapv(Dual64::from);
         match derivative {
-            Derivative::DT => t = t.derive(),
-            Derivative::DV => v = v.derive(),
-            Derivative::DN(i) => n[i] = n[i].derive(),
+            Derivative::DT => t = t.derivative(),
+            Derivative::DV => v = v.derivative(),
+            Derivative::DN(i) => n[i] = n[i].derivative(),
         }
         StateHD::new(t, v, n)
     }
@@ -699,9 +699,9 @@ impl<E: EquationOfState> State<E> {
         let mut v = Dual2_64::from(self.reduced_volume);
         let mut n = self.reduced_moles.mapv(Dual2_64::from);
         match derivative {
-            Derivative::DT => t = t.derive(),
-            Derivative::DV => v = v.derive(),
-            Derivative::DN(i) => n[i] = n[i].derive(),
+            Derivative::DT => t = t.derivative(),
+            Derivative::DV => v = v.derivative(),
+            Derivative::DN(i) => n[i] = n[i].derivative(),
         }
         StateHD::new(t, v, n)
     }
@@ -716,14 +716,14 @@ impl<E: EquationOfState> State<E> {
         let mut v = HyperDual64::from(self.reduced_volume);
         let mut n = self.reduced_moles.mapv(HyperDual64::from);
         match derivative1 {
-            Derivative::DT => t = t.derive1(),
-            Derivative::DV => v = v.derive1(),
-            Derivative::DN(i) => n[i] = n[i].derive1(),
+            Derivative::DT => t = t.derivative1(),
+            Derivative::DV => v = v.derivative1(),
+            Derivative::DN(i) => n[i] = n[i].derivative1(),
         }
         match derivative2 {
-            Derivative::DT => t = t.derive2(),
-            Derivative::DV => v = v.derive2(),
-            Derivative::DN(i) => n[i] = n[i].derive2(),
+            Derivative::DT => t = t.derivative2(),
+            Derivative::DV => v = v.derivative2(),
+            Derivative::DN(i) => n[i] = n[i].derivative2(),
         }
         StateHD::new(t, v, n)
     }
@@ -734,9 +734,9 @@ impl<E: EquationOfState> State<E> {
         let mut v = Dual3_64::from(self.reduced_volume);
         let mut n = self.reduced_moles.mapv(Dual3_64::from);
         match derivative {
-            Derivative::DT => t = t.derive(),
-            Derivative::DV => v = v.derive(),
-            Derivative::DN(i) => n[i] = n[i].derive(),
+            Derivative::DT => t = t.derivative(),
+            Derivative::DV => v = v.derivative(),
+            Derivative::DN(i) => n[i] = n[i].derivative(),
         };
         StateHD::new(t, v, n)
     }

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -47,18 +47,23 @@ impl<E: EquationOfState> State<E> {
                 }
                 PartialDerivative::First(v) => {
                     let new_state = self.derive1(v);
-                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln()).eps[0]
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
+                        .eps
+                        .unwrap()
                         * (SIUnit::reference_energy() / v.reference())
                 }
                 PartialDerivative::Second(v) => {
                     let new_state = self.derive2(v);
-                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln()).v2[0]
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
+                        .v2
+                        .unwrap()
                         * (SIUnit::reference_energy() / (v.reference() * v.reference()))
                 }
                 PartialDerivative::SecondMixed(v1, v2) => {
                     let new_state = self.derive2_mixed(v1, v2);
                     -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
-                        .eps1eps2[(0, 0)]
+                        .eps1eps2
+                        .unwrap()
                         * (SIUnit::reference_energy() / (v1.reference() * v2.reference()))
                 }
                 PartialDerivative::Third(v) => {
@@ -123,20 +128,25 @@ impl<E: EquationOfState> State<E> {
                 }
                 PartialDerivative::First(v) => {
                     let new_state = self.derive1(v);
-                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).eps[0]
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature)
+                        .eps
+                        .unwrap()
                         * SIUnit::reference_energy()
                         / v.reference()
                 }
                 PartialDerivative::Second(v) => {
                     let new_state = self.derive2(v);
-                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).v2[0]
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature)
+                        .v2
+                        .unwrap()
                         * SIUnit::reference_energy()
                         / (v.reference() * v.reference())
                 }
                 PartialDerivative::SecondMixed(v1, v2) => {
                     let new_state = self.derive2_mixed(v1, v2);
-                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).eps1eps2
-                        [(0, 0)]
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature)
+                        .eps1eps2
+                        .unwrap()
                         * SIUnit::reference_energy()
                         / (v1.reference() * v2.reference())
                 }
@@ -541,13 +551,15 @@ impl<E: EquationOfState> State<E> {
         let ig = self.eos.ideal_gas();
         res.push((
             ig.to_string(),
-            -(ig.evaluate(&new_state) * new_state.temperature).eps[0]
+            -(ig.evaluate(&new_state) * new_state.temperature)
+                .eps
+                .unwrap()
                 * SIUnit::reference_pressure(),
         ));
         for (s, v) in contributions {
             res.push((
                 s,
-                -(v * new_state.temperature).eps[0] * SIUnit::reference_pressure(),
+                -(v * new_state.temperature).eps.unwrap() * SIUnit::reference_pressure(),
             ));
         }
         res
@@ -561,13 +573,15 @@ impl<E: EquationOfState> State<E> {
         let ig = self.eos.ideal_gas();
         res.push((
             ig.to_string(),
-            (ig.evaluate(&new_state) * new_state.temperature).eps[0]
+            (ig.evaluate(&new_state) * new_state.temperature)
+                .eps
+                .unwrap()
                 * SIUnit::reference_molar_energy(),
         ));
         for (s, v) in contributions {
             res.push((
                 s,
-                (v * new_state.temperature).eps[0] * SIUnit::reference_molar_energy(),
+                (v * new_state.temperature).eps.unwrap() * SIUnit::reference_molar_energy(),
             ));
         }
         res

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -47,23 +47,18 @@ impl<E: EquationOfState> State<E> {
                 }
                 PartialDerivative::First(v) => {
                     let new_state = self.derive1(v);
-                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
-                        .eps
-                        .unwrap()
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln()).eps
                         * (SIUnit::reference_energy() / v.reference())
                 }
                 PartialDerivative::Second(v) => {
                     let new_state = self.derive2(v);
-                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
-                        .v2
-                        .unwrap()
+                    -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln()).v2
                         * (SIUnit::reference_energy() / (v.reference() * v.reference()))
                 }
                 PartialDerivative::SecondMixed(v1, v2) => {
                     let new_state = self.derive2_mixed(v1, v2);
                     -(new_state.moles.sum() * new_state.temperature * new_state.volume.ln())
                         .eps1eps2
-                        .unwrap()
                         * (SIUnit::reference_energy() / (v1.reference() * v2.reference()))
                 }
                 PartialDerivative::Third(v) => {
@@ -128,25 +123,19 @@ impl<E: EquationOfState> State<E> {
                 }
                 PartialDerivative::First(v) => {
                     let new_state = self.derive1(v);
-                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature)
-                        .eps
-                        .unwrap()
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).eps
                         * SIUnit::reference_energy()
                         / v.reference()
                 }
                 PartialDerivative::Second(v) => {
                     let new_state = self.derive2(v);
-                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature)
-                        .v2
-                        .unwrap()
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).v2
                         * SIUnit::reference_energy()
                         / (v.reference() * v.reference())
                 }
                 PartialDerivative::SecondMixed(v1, v2) => {
                     let new_state = self.derive2_mixed(v1, v2);
-                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature)
-                        .eps1eps2
-                        .unwrap()
+                    (self.eos.ideal_gas().evaluate(&new_state) * new_state.temperature).eps1eps2
                         * SIUnit::reference_energy()
                         / (v1.reference() * v2.reference())
                 }
@@ -551,15 +540,12 @@ impl<E: EquationOfState> State<E> {
         let ig = self.eos.ideal_gas();
         res.push((
             ig.to_string(),
-            -(ig.evaluate(&new_state) * new_state.temperature)
-                .eps
-                .unwrap()
-                * SIUnit::reference_pressure(),
+            -(ig.evaluate(&new_state) * new_state.temperature).eps * SIUnit::reference_pressure(),
         ));
         for (s, v) in contributions {
             res.push((
                 s,
-                -(v * new_state.temperature).eps.unwrap() * SIUnit::reference_pressure(),
+                -(v * new_state.temperature).eps * SIUnit::reference_pressure(),
             ));
         }
         res
@@ -573,15 +559,13 @@ impl<E: EquationOfState> State<E> {
         let ig = self.eos.ideal_gas();
         res.push((
             ig.to_string(),
-            (ig.evaluate(&new_state) * new_state.temperature)
-                .eps
-                .unwrap()
+            (ig.evaluate(&new_state) * new_state.temperature).eps
                 * SIUnit::reference_molar_energy(),
         ));
         for (s, v) in contributions {
             res.push((
                 s,
-                (v * new_state.temperature).eps.unwrap() * SIUnit::reference_molar_energy(),
+                (v * new_state.temperature).eps * SIUnit::reference_molar_energy(),
             ));
         }
         res

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Packaging
+- Updated `num-dual` dependency to 0.7. [#137](https://github.com/feos-org/feos/pull/137)
 
 ## [0.4.1] - 2023-03-20
 ### Added

--- a/feos-dft/Cargo.toml
+++ b/feos-dft/Cargo.toml
@@ -18,9 +18,10 @@ features = [ "rayon" ]
 
 [dependencies]
 quantity = { version = "0.6", features = ["linalg"] }
-num-dual = "0.6"
+num-dual = "0.7"
 feos-core = { version = "0.4", path = "../feos-core" }
 ndarray = "0.15"
+nalgebra = "0.32"
 rustdct = "0.7"
 rustfft = "6.0"
 ang = "0.6"

--- a/feos-dft/Cargo.toml
+++ b/feos-dft/Cargo.toml
@@ -18,8 +18,7 @@ features = [ "rayon" ]
 
 [dependencies]
 quantity = { version = "0.6", features = ["linalg"] }
-#num-dual = "0.7"
-num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "scalar_numbers" }
+num-dual = "0.7"
 feos-core = { version = "0.4", path = "../feos-core" }
 ndarray = "0.15"
 nalgebra = "0.32"

--- a/feos-dft/Cargo.toml
+++ b/feos-dft/Cargo.toml
@@ -18,7 +18,8 @@ features = [ "rayon" ]
 
 [dependencies]
 quantity = { version = "0.6", features = ["linalg"] }
-num-dual = "0.7"
+#num-dual = "0.7"
+num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "scalar_numbers" }
 feos-core = { version = "0.4", path = "../feos-core" }
 ndarray = "0.15"
 nalgebra = "0.32"

--- a/feos-dft/src/convolver/mod.rs
+++ b/feos-dft/src/convolver/mod.rs
@@ -40,7 +40,7 @@ pub(crate) struct BulkConvolver<T> {
     weight_constants: Vec<Array2<T>>,
 }
 
-impl<T: DualNum<f64>> BulkConvolver<T> {
+impl<T: DualNum<f64> + Copy + Send + Sync> BulkConvolver<T> {
     pub(crate) fn new(weight_functions: Vec<WeightFunctionInfo<T>>) -> Arc<dyn Convolver<T, Ix0>> {
         let weight_constants = weight_functions
             .into_iter()
@@ -50,7 +50,7 @@ impl<T: DualNum<f64>> BulkConvolver<T> {
     }
 }
 
-impl<T: DualNum<f64>> Convolver<T, Ix0> for BulkConvolver<T>
+impl<T: DualNum<f64> + Copy + Send + Sync> Convolver<T, Ix0> for BulkConvolver<T>
 where
     Array2<T>: Dot<Array1<T>, Output = Array1<T>>,
 {

--- a/feos-dft/src/functional.rs
+++ b/feos-dft/src/functional.rs
@@ -51,7 +51,7 @@ impl<T: MolarWeight> MolarWeight for DFT<T> {
 }
 
 struct DefaultIdealGasContribution();
-impl<D: DualNum<f64>> IdealGasContributionDual<D> for DefaultIdealGasContribution {
+impl<D: DualNum<f64> + Copy> IdealGasContributionDual<D> for DefaultIdealGasContribution {
     fn de_broglie_wavelength(&self, _: D, components: usize) -> Array1<D> {
         Array1::zeros(components)
     }
@@ -80,7 +80,7 @@ impl<T: HelmholtzEnergyFunctional> EquationOfState for DFT<T> {
         unreachable!()
     }
 
-    fn evaluate_residual<D: DualNum<f64>>(&self, state: &StateHD<D>) -> D
+    fn evaluate_residual<D: DualNum<f64> + Copy>(&self, state: &StateHD<D>) -> D
     where
         dyn HelmholtzEnergy: HelmholtzEnergyDual<D>,
     {
@@ -91,7 +91,7 @@ impl<T: HelmholtzEnergyFunctional> EquationOfState for DFT<T> {
             + self.ideal_chain_contribution().helmholtz_energy(state)
     }
 
-    fn evaluate_residual_contributions<D: DualNum<f64>>(
+    fn evaluate_residual_contributions<D: DualNum<f64> + Copy>(
         &self,
         state: &StateHD<D>,
     ) -> Vec<(String, D)>
@@ -278,7 +278,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         convolver: &Arc<dyn Convolver<N, D>>,
     ) -> EosResult<Array<N, D>>
     where
-        N: DualNum<f64> + ScalarOperand,
+        N: DualNum<f64> + Copy + ScalarOperand,
         dyn FunctionalContribution: FunctionalContributionDual<N>,
         D: Dimension,
         D::Larger: Dimension<Smaller = D>,
@@ -318,7 +318,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         D: Dimension,
         D::Larger: Dimension<Smaller = D>,
     {
-        let temperature_dual = Dual64::from(temperature).derive();
+        let temperature_dual = Dual64::from(temperature).derivative();
         let mut helmholtz_energy_density =
             self.intrinsic_helmholtz_energy_density(temperature_dual, density, convolver)?;
         match contributions {
@@ -328,7 +328,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
             Contributions::ResidualNpt|Contributions::IdealGas => panic!("Entropy density can only be calculated for Contributions::Residual or Contributions::Total"),
             Contributions::ResidualNvt => (),
         }
-        Ok(helmholtz_energy_density.mapv(|f| -f.eps[0]))
+        Ok(helmholtz_energy_density.mapv(|f| -f.eps.unwrap()))
     }
 
     /// Calculate the individual contributions to the entropy density.
@@ -346,7 +346,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
     {
         let density_dual = density.mapv(Dual64::from);
-        let temperature_dual = Dual64::from(temperature).derive();
+        let temperature_dual = Dual64::from(temperature).derivative();
         let weighted_densities = convolver.weighted_densities(&density_dual);
         let functional_contributions = self.contributions();
         let mut helmholtz_energy_density: Vec<Array<Dual64, D>> =
@@ -370,7 +370,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         }
         Ok(helmholtz_energy_density
             .iter()
-            .map(|v| v.mapv(|f| -(f * temperature_dual).eps[0]))
+            .map(|v| v.mapv(|f| -(f * temperature_dual).eps.unwrap()))
             .collect())
     }
 
@@ -389,7 +389,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         D: Dimension,
         D::Larger: Dimension<Smaller = D>,
     {
-        let temperature_dual = Dual64::from(temperature).derive();
+        let temperature_dual = Dual64::from(temperature).derivative();
         let mut helmholtz_energy_density_dual =
             self.intrinsic_helmholtz_energy_density(temperature_dual, density, convolver)?;
         match contributions {
@@ -400,7 +400,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
                 Contributions::ResidualNvt => (),
             }
         let helmholtz_energy_density = helmholtz_energy_density_dual
-            .mapv(|f| f.re - f.eps[0] * temperature)
+            .mapv(|f| f.re - f.eps.unwrap() * temperature)
             + (external_potential * density).sum_axis(Axis(0)) * temperature;
         Ok(helmholtz_energy_density)
     }
@@ -452,7 +452,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         D: Dimension,
         D::Larger: Dimension<Smaller = D>,
     {
-        let temperature_dual = Dual64::from(temperature).derive();
+        let temperature_dual = Dual64::from(temperature).derivative();
         let density_dual = density.mapv(Dual64::from);
         let weighted_densities = convolver.weighted_densities(&density_dual);
         let contributions = self.contributions();

--- a/feos-dft/src/functional.rs
+++ b/feos-dft/src/functional.rs
@@ -328,7 +328,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
             Contributions::ResidualNpt|Contributions::IdealGas => panic!("Entropy density can only be calculated for Contributions::Residual or Contributions::Total"),
             Contributions::ResidualNvt => (),
         }
-        Ok(helmholtz_energy_density.mapv(|f| -f.eps.unwrap()))
+        Ok(helmholtz_energy_density.mapv(|f| -f.eps))
     }
 
     /// Calculate the individual contributions to the entropy density.
@@ -370,7 +370,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
         }
         Ok(helmholtz_energy_density
             .iter()
-            .map(|v| v.mapv(|f| -(f * temperature_dual).eps.unwrap()))
+            .map(|v| v.mapv(|f| -(f * temperature_dual).eps))
             .collect())
     }
 
@@ -400,7 +400,7 @@ impl<T: HelmholtzEnergyFunctional> DFT<T> {
                 Contributions::ResidualNvt => (),
             }
         let helmholtz_energy_density = helmholtz_energy_density_dual
-            .mapv(|f| f.re - f.eps.unwrap() * temperature)
+            .mapv(|f| f.re - f.eps * temperature)
             + (external_potential * density).sum_axis(Axis(0)) * temperature;
         Ok(helmholtz_energy_density)
     }

--- a/feos-dft/src/ideal_chain_contribution.rs
+++ b/feos-dft/src/ideal_chain_contribution.rs
@@ -19,7 +19,7 @@ impl IdealChainContribution {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for IdealChainContribution {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for IdealChainContribution {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let segments = self.component_index.len();
         if self.component_index[segments - 1] + 1 != segments {

--- a/feos-dft/src/pdgt.rs
+++ b/feos-dft/src/pdgt.rs
@@ -11,11 +11,7 @@ impl WeightFunctionInfo<Dual2_64> {
     fn pdgt_weight_constants(&self) -> (Array2<f64>, Array2<f64>, Array2<f64>) {
         let k = Dual2_64::from(0.0).derivative();
         let w = self.weight_constants(k, 1);
-        (
-            w.mapv(|w| w.re),
-            w.mapv(|w| -w.v1.unwrap()),
-            w.mapv(|w| -0.5 * w.v2.unwrap()),
-        )
+        (w.mapv(|w| w.re), w.mapv(|w| -w.v1), w.mapv(|w| -0.5 * w.v2))
     }
 }
 

--- a/feos-dft/src/profile.rs
+++ b/feos-dft/src/profile.rs
@@ -485,7 +485,7 @@ where
         let functional_contributions = self.dft.contributions();
         let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
             .iter()
-            .map(|c| c.weight_functions(Dual64::from(t).derive()))
+            .map(|c| c.weight_functions(Dual64::from(t).derivative()))
             .collect();
         let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
 
@@ -518,7 +518,7 @@ where
         let functional_contributions = self.dft.contributions();
         let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
             .iter()
-            .map(|c| c.weight_functions(Dual64::from(t).derive()))
+            .map(|c| c.weight_functions(Dual64::from(t).derivative()))
             .collect();
         let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
 
@@ -617,7 +617,7 @@ where
         let functional_contributions = self.dft.contributions();
         let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
             .iter()
-            .map(|c| c.weight_functions(Dual64::from(t).derive()))
+            .map(|c| c.weight_functions(Dual64::from(t).derivative()))
             .collect();
         let convolver: Arc<dyn Convolver<_, D>> =
             ConvolverFFT::plan(&self.grid, &weight_functions, None);
@@ -638,11 +638,11 @@ where
         let x = (self.bulk.partial_molar_volume(Contributions::Total)
             * self.bulk.dp_dt(Contributions::Total))
         .to_reduced(SIUnit::reference_molar_entropy())?;
-        let mut lhs = dfdrhodt.mapv(|d| d.eps[0]);
+        let mut lhs = dfdrhodt.mapv(|d| d.eps.unwrap());
         lhs.outer_iter_mut()
             .zip(dfdrhodt_bulk.into_iter())
             .zip(x.into_iter())
-            .for_each(|((mut lhs, d), x)| lhs -= d.eps[0] - x);
+            .for_each(|((mut lhs, d), x)| lhs -= d.eps.unwrap() - x);
         lhs.outer_iter_mut()
             .zip(rho.outer_iter())
             .zip(rho_bulk.into_iter())

--- a/feos-dft/src/profile.rs
+++ b/feos-dft/src/profile.rs
@@ -638,11 +638,11 @@ where
         let x = (self.bulk.partial_molar_volume(Contributions::Total)
             * self.bulk.dp_dt(Contributions::Total))
         .to_reduced(SIUnit::reference_molar_entropy())?;
-        let mut lhs = dfdrhodt.mapv(|d| d.eps.unwrap());
+        let mut lhs = dfdrhodt.mapv(|d| d.eps);
         lhs.outer_iter_mut()
             .zip(dfdrhodt_bulk.into_iter())
             .zip(x.into_iter())
-            .for_each(|((mut lhs, d), x)| lhs -= d.eps.unwrap() - x);
+            .for_each(|((mut lhs, d), x)| lhs -= d.eps - x);
         lhs.outer_iter_mut()
             .zip(rho.outer_iter())
             .zip(rho_bulk.into_iter())

--- a/feos-dft/src/weight_functions.rs
+++ b/feos-dft/src/weight_functions.rs
@@ -15,7 +15,7 @@ pub struct WeightFunction<T> {
     pub shape: WeightFunctionShape,
 }
 
-impl<T: DualNum<f64>> WeightFunction<T> {
+impl<T: DualNum<f64> + Copy> WeightFunction<T> {
     /// Create a new weight function without prefactor
     pub fn new_unscaled(kernel_radius: Array1<T>, shape: WeightFunctionShape) -> Self {
         Self {
@@ -276,7 +276,7 @@ impl<T> WeightFunctionInfo<T> {
     }
 }
 
-impl<T: DualNum<f64>> WeightFunctionInfo<T> {
+impl<T: DualNum<f64> + Copy> WeightFunctionInfo<T> {
     /// calculates the matrix of weight constants for this set of weighted densities
     pub fn weight_constants(&self, k: T, dimensions: usize) -> Array2<T> {
         let segments = self.component_index.len();

--- a/src/association/dft.rs
+++ b/src/association/dft.rs
@@ -12,7 +12,7 @@ pub const N0_CUTOFF: f64 = 1e-9;
 
 impl<N, P> FunctionalContributionDual<N> for Association<P>
 where
-    N: DualNum<f64> + ScalarOperand,
+    N: DualNum<f64> + Copy + ScalarOperand,
     P: HardSphereProperties,
 {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
@@ -111,7 +111,7 @@ where
 
 impl<P: HardSphereProperties> Association<P> {
     pub fn calculate_helmholtz_energy_density<
-        N: DualNum<f64> + ScalarOperand,
+        N: DualNum<f64> + Copy + ScalarOperand,
         S: Data<Elem = N>,
     >(
         &self,
@@ -183,7 +183,10 @@ impl<P: HardSphereProperties> Association<P> {
         }
     }
 
-    fn helmholtz_energy_density_ab_analytic<N: DualNum<f64> + ScalarOperand, S: Data<Elem = N>>(
+    fn helmholtz_energy_density_ab_analytic<
+        N: DualNum<f64> + Copy + ScalarOperand,
+        S: Data<Elem = N>,
+    >(
         &self,
         temperature: N,
         rho0: &Array2<N>,
@@ -217,7 +220,10 @@ impl<P: HardSphereProperties> Association<P> {
         rhoa * xa.mapv(f) + rhob * xb.mapv(f)
     }
 
-    fn helmholtz_energy_density_cc_analytic<N: DualNum<f64> + ScalarOperand, S: Data<Elem = N>>(
+    fn helmholtz_energy_density_cc_analytic<
+        N: DualNum<f64> + Copy + ScalarOperand,
+        S: Data<Elem = N>,
+    >(
         &self,
         temperature: N,
         rho0: &Array2<N>,

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -212,7 +212,7 @@ impl<P: HardSphereProperties> Association<P> {
         res
     }
 
-    fn association_strength<D: DualNum<f64>>(
+    fn association_strength<D: DualNum<f64> + Copy>(
         &self,
         temperature: D,
         diameter: &Array1<D>,
@@ -241,7 +241,7 @@ impl<P: HardSphereProperties> Association<P> {
     }
 }
 
-impl<D: DualNum<f64> + ScalarOperand, P: HardSphereProperties> HelmholtzEnergyDual<D>
+impl<D: DualNum<f64> + Copy + ScalarOperand, P: HardSphereProperties> HelmholtzEnergyDual<D>
     for Association<P>
 {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
@@ -305,7 +305,11 @@ impl<P> fmt::Display for Association<P> {
 }
 
 impl<P: HardSphereProperties> Association<P> {
-    fn helmholtz_energy_ab_analytic<D: DualNum<f64>>(&self, state: &StateHD<D>, delta: D) -> D {
+    fn helmholtz_energy_ab_analytic<D: DualNum<f64> + Copy>(
+        &self,
+        state: &StateHD<D>,
+        delta: D,
+    ) -> D {
         let a = &self.association_parameters;
 
         // site densities
@@ -322,7 +326,11 @@ impl<P: HardSphereProperties> Association<P> {
         (rhoa * (xa.ln() - xa * 0.5 + 0.5) + rhob * (xb.ln() - xb * 0.5 + 0.5)) * state.volume
     }
 
-    fn helmholtz_energy_cc_analytic<D: DualNum<f64>>(&self, state: &StateHD<D>, delta: D) -> D {
+    fn helmholtz_energy_cc_analytic<D: DualNum<f64> + Copy>(
+        &self,
+        state: &StateHD<D>,
+        delta: D,
+    ) -> D {
         let a = &self.association_parameters;
 
         // site density
@@ -337,7 +345,7 @@ impl<P: HardSphereProperties> Association<P> {
 
     #[allow(clippy::too_many_arguments)]
     fn helmholtz_energy_density_cross_association<
-        D: DualNum<f64> + ScalarOperand,
+        D: DualNum<f64> + Copy + ScalarOperand,
         S: Data<Elem = D>,
     >(
         rho: &ArrayBase<S, Ix1>,
@@ -396,7 +404,7 @@ impl<P: HardSphereProperties> Association<P> {
         Ok((rho * x_dual.mapv(f)).sum())
     }
 
-    fn newton_step_cross_association<D: DualNum<f64> + ScalarOperand, S: Data<Elem = D>>(
+    fn newton_step_cross_association<D: DualNum<f64> + Copy + ScalarOperand, S: Data<Elem = D>>(
         x: &mut Array1<D>,
         delta_ab: &Array2<D>,
         delta_cc: &Array2<D>,
@@ -541,11 +549,12 @@ mod tests_gc_pcsaft {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -561,11 +570,12 @@ mod tests_gc_pcsaft {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -583,11 +593,12 @@ mod tests_gc_pcsaft {
             .unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             moles.mapv(Dual64::from_re),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -26.105606376765632 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -552,9 +552,8 @@ mod tests_gc_pcsaft {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -573,9 +572,8 @@ mod tests_gc_pcsaft {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -596,9 +594,8 @@ mod tests_gc_pcsaft {
             Dual64::from_re(volume).derivative(),
             moles.mapv(Dual64::from_re),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -26.105606376765632 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/dft/dispersion.rs
+++ b/src/gc_pcsaft/dft/dispersion.rs
@@ -24,7 +24,9 @@ impl AttractiveFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for AttractiveFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N>
+    for AttractiveFunctional
+{
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let p = &self.parameters;
 

--- a/src/gc_pcsaft/dft/hard_chain.rs
+++ b/src/gc_pcsaft/dft/hard_chain.rs
@@ -23,7 +23,7 @@ impl ChainFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for ChainFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N> for ChainFunctional {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let p = &self.parameters;
         let d = p.hs_diameter(temperature);

--- a/src/gc_pcsaft/dft/mod.rs
+++ b/src/gc_pcsaft/dft/mod.rs
@@ -128,7 +128,7 @@ impl HardSphereProperties for GcPcSaftFunctionalParameters {
         MonomerShape::Heterosegmented([m.clone(), m.clone(), m.clone(), m], &self.component_index)
     }
 
-    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         let ti = temperature.recip() * -3.0;
         Array1::from_shape_fn(self.sigma.len(), |i| {
             -((ti * self.epsilon_k[i]).exp() * 0.12 - 1.0) * self.sigma[i]

--- a/src/gc_pcsaft/eos/dispersion.rs
+++ b/src/gc_pcsaft/eos/dispersion.rs
@@ -66,7 +66,7 @@ pub struct Dispersion {
     pub parameters: Arc<GcPcSaftEosParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dispersion {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Dispersion {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         // auxiliary variables
         let p = &self.parameters;
@@ -151,11 +151,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -2.846724434944439 * PASCAL, max_relative = 1e-10);
     }
 
@@ -173,11 +174,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -5.432173507270732 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/eos/dispersion.rs
+++ b/src/gc_pcsaft/eos/dispersion.rs
@@ -154,9 +154,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -2.846724434944439 * PASCAL, max_relative = 1e-10);
     }
 
@@ -177,9 +176,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -5.432173507270732 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/eos/hard_chain.rs
+++ b/src/gc_pcsaft/eos/hard_chain.rs
@@ -10,7 +10,7 @@ pub struct HardChain {
     pub parameters: Arc<GcPcSaftEosParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardChain {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for HardChain {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         // temperature dependent segment diameter
         let diameter = self.parameters.hs_diameter(state.temperature);
@@ -66,11 +66,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::new_scalar(volume, 1.0),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(
             pressure,
             -7.991735636207462e-1 * PASCAL,
@@ -92,11 +93,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -1.2831486124723626 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/eos/hard_chain.rs
+++ b/src/gc_pcsaft/eos/hard_chain.rs
@@ -66,12 +66,11 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::new_scalar(volume, 1.0),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(
             pressure,
             -7.991735636207462e-1 * PASCAL,
@@ -96,9 +95,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -1.2831486124723626 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/eos/mod.rs
+++ b/src/gc_pcsaft/eos/mod.rs
@@ -142,9 +142,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, 1.5285037907989527 * PASCAL, max_relative = 1e-10);
     }
 
@@ -163,9 +162,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, 2.3168212018200243 * PASCAL, max_relative = 1e-10);
     }
 
@@ -184,9 +182,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -206,9 +203,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -229,9 +225,8 @@ mod test {
             Dual64::from_re(volume).derivative(),
             moles.mapv(Dual64::from_re),
         );
-        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
-            * temperature
-            * EosUnit::reference_pressure();
+        let pressure =
+            -contrib.helmholtz_energy(&state).eps * temperature * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -26.105606376765632 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/eos/mod.rs
+++ b/src/gc_pcsaft/eos/mod.rs
@@ -139,11 +139,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, 1.5285037907989527 * PASCAL, max_relative = 1e-10);
     }
 
@@ -159,11 +160,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, 2.3168212018200243 * PASCAL, max_relative = 1e-10);
     }
 
@@ -179,11 +181,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -200,11 +203,12 @@ mod test {
         let moles = (1.5 * MOL).to_reduced(EosUnit::reference_moles()).unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             arr1(&[Dual64::from_re(moles)]),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -3.6819598891967344 * PASCAL, max_relative = 1e-10);
     }
 
@@ -222,11 +226,12 @@ mod test {
             .unwrap();
         let state = StateHD::new(
             Dual64::from_re(temperature),
-            Dual64::from_re(volume).derive(),
+            Dual64::from_re(volume).derivative(),
             moles.mapv(Dual64::from_re),
         );
-        let pressure =
-            -contrib.helmholtz_energy(&state).eps[0] * temperature * EosUnit::reference_pressure();
+        let pressure = -contrib.helmholtz_energy(&state).eps.unwrap()
+            * temperature
+            * EosUnit::reference_pressure();
         assert_relative_eq!(pressure, -26.105606376765632 * PASCAL, max_relative = 1e-10);
     }
 }

--- a/src/gc_pcsaft/eos/parameter.rs
+++ b/src/gc_pcsaft/eos/parameter.rs
@@ -277,7 +277,7 @@ impl HardSphereProperties for GcPcSaftEosParameters {
         MonomerShape::Heterosegmented([m.clone(), m.clone(), m.clone(), m], &self.component_index)
     }
 
-    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         let ti = temperature.recip() * -3.0;
         Array1::from_shape_fn(self.sigma.len(), |i| {
             -((ti * self.epsilon_k[i]).exp() * 0.12 - 1.0) * self.sigma[i]

--- a/src/gc_pcsaft/eos/polar.rs
+++ b/src/gc_pcsaft/eos/polar.rs
@@ -33,7 +33,7 @@ pub const CD: [[f64; 3]; 4] = [
 
 pub const PI_SQ_43: f64 = 4.0 * PI * FRAC_PI_3;
 
-fn pair_integral_ij<D: DualNum<f64>>(mij1: f64, mij2: f64, eta: D, eps_ij_t: D) -> D {
+fn pair_integral_ij<D: DualNum<f64> + Copy>(mij1: f64, mij2: f64, eta: D, eps_ij_t: D) -> D {
     let eta2 = eta * eta;
     let etas = [D::one(), eta, eta2, eta2 * eta, eta2 * eta2];
     (0..AD.len())
@@ -45,7 +45,7 @@ fn pair_integral_ij<D: DualNum<f64>>(mij1: f64, mij2: f64, eta: D, eps_ij_t: D) 
         .sum()
 }
 
-fn triplet_integral_ijk<D: DualNum<f64>>(mijk1: f64, mijk2: f64, eta: D) -> D {
+fn triplet_integral_ijk<D: DualNum<f64> + Copy>(mijk1: f64, mijk2: f64, eta: D) -> D {
     let eta2 = eta * eta;
     let etas = [D::one(), eta, eta2, eta2 * eta];
     (0..CD.len())
@@ -118,7 +118,7 @@ impl Dipole {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dipole {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Dipole {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
         let ndipole = p.dipole_comp.len();

--- a/src/hard_sphere/dft.rs
+++ b/src/hard_sphere/dft.rs
@@ -84,7 +84,7 @@ impl<P> FMTContribution<P> {
     }
 }
 
-impl<P: HardSphereProperties, N: DualNum<f64>> FunctionalContributionDual<N>
+impl<P: HardSphereProperties, N: DualNum<f64> + Copy> FunctionalContributionDual<N>
     for FMTContribution<P>
 {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {

--- a/src/hard_sphere/mod.rs
+++ b/src/hard_sphere/mod.rs
@@ -31,7 +31,7 @@ pub trait HardSphereProperties {
     fn monomer_shape<D: DualNum<f64>>(&self, temperature: D) -> MonomerShape<D>;
 
     /// The temperature dependent hard-sphere diameters of every segment.
-    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D>;
+    fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D>;
 
     /// For every segment, the index of the component that it is on.
     fn component_index(&self) -> Cow<Array1<usize>> {
@@ -55,7 +55,7 @@ pub trait HardSphereProperties {
     }
 
     /// The packing fractions $\zeta_k$.
-    fn zeta<D: DualNum<f64>, const N: usize>(
+    fn zeta<D: DualNum<f64> + Copy, const N: usize>(
         &self,
         temperature: D,
         partial_density: &Array1<D>,
@@ -77,7 +77,7 @@ pub trait HardSphereProperties {
     }
 
     /// The fraction $\frac{\zeta_2}{\zeta_3}$ evaluated in a way to avoid a division by 0 when the density is 0.
-    fn zeta_23<D: DualNum<f64>>(&self, temperature: D, molefracs: &Array1<D>) -> D {
+    fn zeta_23<D: DualNum<f64> + Copy>(&self, temperature: D, molefracs: &Array1<D>) -> D {
         let component_index = self.component_index();
         let geometry_coefficients = self.geometry_coefficients(temperature);
         let diameter = self.hs_diameter(temperature);
@@ -116,7 +116,7 @@ impl<P> HardSphere<P> {
     }
 }
 
-impl<D: DualNum<f64>, P: HardSphereProperties> HelmholtzEnergyDual<D> for HardSphere<P> {
+impl<D: DualNum<f64> + Copy, P: HardSphereProperties> HelmholtzEnergyDual<D> for HardSphere<P> {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
         let zeta = p.zeta(state.temperature, &state.partial_density, [0, 1, 2, 3]);

--- a/src/pcsaft/dft/dispersion.rs
+++ b/src/pcsaft/dft/dispersion.rs
@@ -28,7 +28,7 @@ impl AttractiveFunctional {
     }
 }
 
-fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
+fn att_weight_functions<N: DualNum<f64> + Copy + ScalarOperand>(
     p: &PcSaftParameters,
     psi: f64,
     temperature: N,
@@ -40,7 +40,9 @@ fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
     )
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for AttractiveFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N>
+    for AttractiveFunctional
+{
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         att_weight_functions(&self.parameters, PSI_DFT, temperature)
     }

--- a/src/pcsaft/dft/hard_chain.rs
+++ b/src/pcsaft/dft/hard_chain.rs
@@ -20,7 +20,7 @@ impl ChainFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for ChainFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N> for ChainFunctional {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let p = &self.parameters;
         let d = p.hs_diameter(temperature);

--- a/src/pcsaft/dft/polar.rs
+++ b/src/pcsaft/dft/polar.rs
@@ -8,7 +8,7 @@ use ndarray::*;
 use num_dual::DualNum;
 use std::f64::consts::{FRAC_PI_3, PI};
 
-pub(super) fn calculate_helmholtz_energy_density_polar<N: DualNum<f64> + ScalarOperand>(
+pub(super) fn calculate_helmholtz_energy_density_polar<N: DualNum<f64> + Copy + ScalarOperand>(
     parameters: &PcSaftParameters,
     temperature: N,
     density: ArrayView2<N>,
@@ -38,7 +38,7 @@ pub(super) fn calculate_helmholtz_energy_density_polar<N: DualNum<f64> + ScalarO
     Ok(phi)
 }
 
-pub fn pair_integral_ij<N: DualNum<f64> + ScalarOperand>(
+pub fn pair_integral_ij<N: DualNum<f64> + Copy + ScalarOperand>(
     mij1: f64,
     mij2: f64,
     eta: &Array1<N>,
@@ -93,7 +93,7 @@ fn triplet_integral_ijk_dq<N: DualNum<f64> + ScalarOperand>(
     integral
 }
 
-fn phi_polar_dipole<N: DualNum<f64> + ScalarOperand>(
+fn phi_polar_dipole<N: DualNum<f64> + Copy + ScalarOperand>(
     p: &PcSaftParameters,
     temperature: N,
     density: ArrayView2<N>,
@@ -181,7 +181,7 @@ fn phi_polar_dipole<N: DualNum<f64> + ScalarOperand>(
     Ok(result)
 }
 
-fn phi_polar_quadrupole<N: DualNum<f64> + ScalarOperand>(
+fn phi_polar_quadrupole<N: DualNum<f64> + Copy + ScalarOperand>(
     p: &PcSaftParameters,
     temperature: N,
     density: ArrayView2<N>,
@@ -269,7 +269,7 @@ fn phi_polar_quadrupole<N: DualNum<f64> + ScalarOperand>(
     Ok(result)
 }
 
-fn phi_polar_dipole_quadrupole<N: DualNum<f64> + ScalarOperand>(
+fn phi_polar_dipole_quadrupole<N: DualNum<f64> + Copy + ScalarOperand>(
     p: &PcSaftParameters,
     temperature: N,
     density: ArrayView2<N>,

--- a/src/pcsaft/dft/pure_saft_functional.rs
+++ b/src/pcsaft/dft/pure_saft_functional.rs
@@ -35,7 +35,9 @@ impl PureFMTAssocFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureFMTAssocFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N>
+    for PureFMTAssocFunctional
+{
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let r = self.parameters.hs_diameter(temperature) * 0.5;
         WeightFunctionInfo::new(arr1(&[0]), false).extend(
@@ -154,7 +156,7 @@ impl PureChainFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureChainFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N> for PureChainFunctional {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let d = self.parameters.hs_diameter(temperature);
         WeightFunctionInfo::new(arr1(&[0]), true)
@@ -206,7 +208,7 @@ impl PureAttFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureAttFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N> for PureAttFunctional {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let d = self.parameters.hs_diameter(temperature);
         const PSI: f64 = 1.3862; // Homosegmented DFT (Sauer2017)

--- a/src/pcsaft/eos/dispersion.rs
+++ b/src/pcsaft/eos/dispersion.rs
@@ -65,7 +65,7 @@ pub struct Dispersion {
     pub parameters: Arc<PcSaftParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dispersion {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Dispersion {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         // auxiliary variables
         let n = self.parameters.m.len();

--- a/src/pcsaft/eos/hard_chain.rs
+++ b/src/pcsaft/eos/hard_chain.rs
@@ -10,7 +10,7 @@ pub struct HardChain {
     pub parameters: Arc<PcSaftParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardChain {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for HardChain {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
         let d = self.parameters.hs_diameter(state.temperature);

--- a/src/pcsaft/eos/polar.rs
+++ b/src/pcsaft/eos/polar.rs
@@ -127,7 +127,7 @@ impl MeanSegmentNumbers {
     }
 }
 
-fn pair_integral_ij<D: DualNum<f64>>(
+fn pair_integral_ij<D: DualNum<f64> + Copy>(
     mij1: f64,
     mij2: f64,
     etas: &[D],
@@ -144,13 +144,18 @@ fn pair_integral_ij<D: DualNum<f64>>(
         .sum()
 }
 
-fn triplet_integral_ijk<D: DualNum<f64>>(mijk1: f64, mijk2: f64, etas: &[D], c: &[[f64; 3]]) -> D {
+fn triplet_integral_ijk<D: DualNum<f64> + Copy>(
+    mijk1: f64,
+    mijk2: f64,
+    etas: &[D],
+    c: &[[f64; 3]],
+) -> D {
     (0..c.len())
         .map(|i| etas[i] * (c[i][0] + mijk1 * c[i][1] + mijk2 * c[i][2]))
         .sum()
 }
 
-fn triplet_integral_ijk_dq<D: DualNum<f64>>(mijk: f64, etas: &[D], c: &[[f64; 2]]) -> D {
+fn triplet_integral_ijk_dq<D: DualNum<f64> + Copy>(mijk: f64, etas: &[D], c: &[[f64; 2]]) -> D {
     (0..c.len())
         .map(|i| etas[i] * (c[i][0] + mijk * c[i][1]))
         .sum()
@@ -160,7 +165,7 @@ pub struct Dipole {
     pub parameters: Arc<PcSaftParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dipole {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Dipole {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let m = MeanSegmentNumbers::new(&self.parameters, Multipole::Dipole);
         let p = &self.parameters;
@@ -237,7 +242,7 @@ pub struct Quadrupole {
     pub parameters: Arc<PcSaftParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Quadrupole {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Quadrupole {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let m = MeanSegmentNumbers::new(&self.parameters, Multipole::Quadrupole);
         let p = &self.parameters;
@@ -324,7 +329,7 @@ pub struct DipoleQuadrupole {
     pub variant: DQVariants,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for DipoleQuadrupole {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for DipoleQuadrupole {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
 

--- a/src/pcsaft/eos/qspr.rs
+++ b/src/pcsaft/eos/qspr.rs
@@ -68,7 +68,7 @@ pub struct QSPR {
     pub parameters: Arc<PcSaftParameters>,
 }
 
-impl<D: DualNum<f64>> IdealGasContributionDual<D> for QSPR {
+impl<D: DualNum<f64> + Copy> IdealGasContributionDual<D> for QSPR {
     fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D> {
         let (c_300, c_400) = if self.parameters.association.is_empty() {
             match self.parameters.ndipole + self.parameters.nquadpole {

--- a/src/pcsaft/parameters.rs
+++ b/src/pcsaft/parameters.rs
@@ -469,7 +469,7 @@ impl HardSphereProperties for PcSaftParameters {
         MonomerShape::NonSpherical(self.m.mapv(N::from))
     }
 
-    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         let ti = temperature.recip() * -3.0;
         Array::from_shape_fn(self.sigma.len(), |i| {
             -((ti * self.epsilon_k[i]).exp() * 0.12 - 1.0) * self.sigma[i]

--- a/src/pets/dft/dispersion.rs
+++ b/src/pets/dft/dispersion.rs
@@ -27,7 +27,7 @@ impl AttractiveFunctional {
     }
 }
 
-fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
+fn att_weight_functions<N: DualNum<f64> + Copy + ScalarOperand>(
     p: &PetsParameters,
     psi: f64,
     temperature: N,
@@ -39,7 +39,9 @@ fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
     )
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for AttractiveFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N>
+    for AttractiveFunctional
+{
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         att_weight_functions(&self.parameters, PSI_DFT, temperature)
     }

--- a/src/pets/dft/pure_pets_functional.rs
+++ b/src/pets/dft/pure_pets_functional.rs
@@ -29,7 +29,7 @@ impl PureFMTFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureFMTFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N> for PureFMTFunctional {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let r = self.parameters.hs_diameter(temperature) * 0.5;
         WeightFunctionInfo::new(arr1(&[0]), false).extend(
@@ -125,7 +125,7 @@ impl PureAttFunctional {
     }
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for PureAttFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N> for PureAttFunctional {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let d = self.parameters.hs_diameter(temperature);
         const PSI: f64 = 1.21; // Homosegmented DFT (Heier2018)

--- a/src/pets/eos/dispersion.rs
+++ b/src/pets/eos/dispersion.rs
@@ -30,7 +30,7 @@ pub struct Dispersion {
     pub parameters: Arc<PetsParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dispersion {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Dispersion {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         // auxiliary variables
         let n = self.parameters.sigma.len();

--- a/src/pets/eos/qspr.rs
+++ b/src/pets/eos/qspr.rs
@@ -68,7 +68,7 @@ pub struct QSPR {
     pub parameters: Arc<PetsParameters>,
 }
 
-impl<D: DualNum<f64>> IdealGasContributionDual<D> for QSPR {
+impl<D: DualNum<f64> + Copy> IdealGasContributionDual<D> for QSPR {
     fn de_broglie_wavelength(&self, temperature: D, components: usize) -> Array1<D> {
         let (c_300, c_400) = (NA_NP_300, NA_NP_400);
 

--- a/src/pets/parameters.rs
+++ b/src/pets/parameters.rs
@@ -237,7 +237,7 @@ impl HardSphereProperties for PetsParameters {
         MonomerShape::Spherical(self.sigma.len())
     }
 
-    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         let ti = temperature.recip() * -3.052785558;
         Array::from_shape_fn(self.sigma.len(), |i| {
             -((ti * self.epsilon_k[i]).exp() * 0.127112544 - 1.0) * self.sigma[i]

--- a/src/saftvrqmie/dft/dispersion.rs
+++ b/src/saftvrqmie/dft/dispersion.rs
@@ -26,7 +26,7 @@ impl AttractiveFunctional {
     }
 }
 
-fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
+fn att_weight_functions<N: DualNum<f64> + Copy + ScalarOperand>(
     p: &SaftVRQMieParameters,
     psi: f64,
     temperature: N,
@@ -38,7 +38,9 @@ fn att_weight_functions<N: DualNum<f64> + ScalarOperand>(
     )
 }
 
-impl<N: DualNum<f64> + ScalarOperand> FunctionalContributionDual<N> for AttractiveFunctional {
+impl<N: DualNum<f64> + Copy + ScalarOperand> FunctionalContributionDual<N>
+    for AttractiveFunctional
+{
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         att_weight_functions(&self.parameters, PSI_DFT, temperature)
     }

--- a/src/saftvrqmie/dft/mod.rs
+++ b/src/saftvrqmie/dft/mod.rs
@@ -116,7 +116,7 @@ impl HardSphereProperties for SaftVRQMieParameters {
         MonomerShape::Spherical(self.m.len())
     }
 
-    fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         self.hs_diameter(temperature)
     }
 }

--- a/src/saftvrqmie/dft/non_additive_hs.rs
+++ b/src/saftvrqmie/dft/non_additive_hs.rs
@@ -24,7 +24,7 @@ impl NonAddHardSphereFunctional {
 
 impl<N> FunctionalContributionDual<N> for NonAddHardSphereFunctional
 where
-    N: DualNum<f64> + ScalarOperand,
+    N: DualNum<f64> + Copy + ScalarOperand,
 {
     fn weight_functions(&self, temperature: N) -> WeightFunctionInfo<N> {
         let p = &self.parameters;
@@ -146,7 +146,7 @@ where
     }
 }
 
-pub fn non_additive_hs_energy_density<S, N: DualNum<f64> + ScalarOperand>(
+pub fn non_additive_hs_energy_density<S, N: DualNum<f64> + Copy + ScalarOperand>(
     parameters: &SaftVRQMieParameters,
     d_hs_ij: &Array2<N>,
     d_hs_add_ij: &Array2<N>,

--- a/src/saftvrqmie/eos/dispersion.rs
+++ b/src/saftvrqmie/eos/dispersion.rs
@@ -34,7 +34,7 @@ pub struct Alpha<D: DualNum<f64>> {
     alpha_ij: Array2<D>,
 }
 
-impl<D: DualNum<f64>> Alpha<D> {
+impl<D: DualNum<f64> + Copy> Alpha<D> {
     pub fn new(
         parameters: &SaftVRQMieParameters,
         sigma_eff_ij: &Array2<D>,
@@ -76,7 +76,7 @@ pub struct Dispersion {
     pub parameters: Arc<SaftVRQMieParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dispersion {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for Dispersion {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         // auxiliary variables
         let n = self.parameters.m.len();
@@ -136,7 +136,7 @@ impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for Dispersion {
 }
 
 #[cfg(feature = "dft")]
-pub fn dispersion_energy_density<D: DualNum<f64>>(
+pub fn dispersion_energy_density<D: DualNum<f64> + Copy>(
     parameters: &SaftVRQMieParameters,
     d_hs_ij: &Array2<D>,
     s_eff_ij: &Array2<D>,
@@ -172,7 +172,7 @@ pub fn dispersion_energy_density<D: DualNum<f64>>(
     rho_s * (a1 * inv_t + a2 * inv_t.powi(2) + a3 * inv_t.powi(3))
 }
 
-fn zeta_saft_vrq_mie<D: DualNum<f64>>(
+fn zeta_saft_vrq_mie<D: DualNum<f64> + Copy>(
     m: &Array1<f64>,
     x_s: &Array1<D>,
     diameter: &Array2<D>,
@@ -187,7 +187,7 @@ fn zeta_saft_vrq_mie<D: DualNum<f64>>(
     zeta * FRAC_PI_6 * rho_s
 }
 
-fn first_order_perturbation<D: DualNum<f64>>(
+fn first_order_perturbation<D: DualNum<f64> + Copy>(
     parameters: &SaftVRQMieParameters,
     x_s: &Array1<D>,
     zeta: D,
@@ -223,7 +223,7 @@ fn first_order_perturbation<D: DualNum<f64>>(
     a1
 }
 
-fn first_order_perturbation_ij<D: DualNum<f64>>(
+fn first_order_perturbation_ij<D: DualNum<f64> + Copy>(
     lambda_a: f64,
     lambda_r: f64,
     epsilon_k: f64,
@@ -244,7 +244,7 @@ fn first_order_perturbation_ij<D: DualNum<f64>>(
     (int_qa * qa1 - int_qr * qr1 + int_a - int_r) * c
 }
 
-fn eta_eff<D: DualNum<f64>>(lambda: f64, zeta: D) -> D {
+fn eta_eff<D: DualNum<f64> + Copy>(lambda: f64, zeta: D) -> D {
     let inv_lambda = Array1::from(vec![
         1.0,
         1.0 / lambda,
@@ -260,7 +260,7 @@ fn eta_eff<D: DualNum<f64>>(lambda: f64, zeta: D) -> D {
     zeta * (zeta * (zeta * (zeta * c[3] + c[2]) + c[1]) + c[0])
 }
 
-fn sutherland<D: DualNum<f64>>(lambda: f64, epsilon_k: f64, zeta: D, x0: D) -> D {
+fn sutherland<D: DualNum<f64> + Copy>(lambda: f64, epsilon_k: f64, zeta: D, x0: D) -> D {
     let ef = eta_eff(lambda, zeta);
     (-ef * 0.5 + 1.0) * -12.0 * x0.powf(lambda) * epsilon_k / (lambda - 3.0) / (-ef + 1.0).powi(3)
 }
@@ -278,7 +278,7 @@ fn jlambda<D: DualNum<f64>>(lambda: f64, x0: D) -> D {
 /// B is divided by the packing fraction
 ///
 /// \author Morten Hammer, February 2018
-fn b<D: DualNum<f64>>(lambda: f64, epsilon_k: f64, zeta: D, x0: D, x0_eff: D) -> D {
+fn b<D: DualNum<f64> + Copy>(lambda: f64, epsilon_k: f64, zeta: D, x0: D, x0_eff: D) -> D {
     let ilambda = ilambda(lambda, x0_eff);
     let jlambda = jlambda(lambda, x0_eff);
     let denum = (-zeta + 1.0).powi(3);
@@ -289,7 +289,7 @@ fn b<D: DualNum<f64>>(lambda: f64, epsilon_k: f64, zeta: D, x0: D, x0_eff: D) ->
 }
 
 #[inline]
-fn combine_sutherland_and_b<D: DualNum<f64>>(
+fn combine_sutherland_and_b<D: DualNum<f64> + Copy>(
     lambda: f64,
     epsilon_k: f64,
     zeta: D,
@@ -301,7 +301,7 @@ fn combine_sutherland_and_b<D: DualNum<f64>>(
     int_as + int_b
 }
 
-fn second_order_perturbation<D: DualNum<f64>>(
+fn second_order_perturbation<D: DualNum<f64> + Copy>(
     parameters: &SaftVRQMieParameters,
     alpha: &Alpha<D>,
     x_s: &Array1<D>,
@@ -353,7 +353,7 @@ fn quantum_prefactor(lambda: f64) -> f64 {
     lambda * (lambda - 1.0)
 }
 
-fn second_order_perturbation_ij<D: DualNum<f64>>(
+fn second_order_perturbation_ij<D: DualNum<f64> + Copy>(
     lambda_a: f64,
     lambda_r: f64,
     epsilon_k: f64,
@@ -398,7 +398,7 @@ fn second_order_perturbation_ij<D: DualNum<f64>>(
     a2_ij * 0.5 * epsilon_k * c.powi(2)
 }
 
-fn third_order_perturbation<D: DualNum<f64>>(
+fn third_order_perturbation<D: DualNum<f64> + Copy>(
     parameters: &SaftVRQMieParameters,
     alpha: &Alpha<D>,
     x_s: &Array1<D>,
@@ -417,7 +417,7 @@ fn third_order_perturbation<D: DualNum<f64>>(
     a3
 }
 
-fn third_order_perturbation_ij<D: DualNum<f64>>(
+fn third_order_perturbation_ij<D: DualNum<f64> + Copy>(
     i: usize,
     j: usize,
     epsilon_k_eff: D,
@@ -444,9 +444,6 @@ mod tests {
     use crate::saftvrqmie::parameters::utils::hydrogen_fh1;
     use approx::assert_relative_eq;
     use ndarray::arr1;
-    use num_dual::Dual2;
-    use num_dual::DualNum;
-    use num_traits::Zero;
 
     #[test]
     fn test_eta_eff() {
@@ -466,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_alpha() {
-        let temperature = Dual2::from_re(26.7060).derive();
+        let temperature = 26.7060;
         let parameters = hydrogen_fh1();
         let n = 1;
         let s_eff_ij = Array2::from_shape_fn((n, n), |(i, j)| {
@@ -476,46 +473,42 @@ mod tests {
             parameters.calc_epsilon_k_eff_ij(i, j, temperature)
         });
         let alpha = Alpha::new(&parameters, &s_eff_ij, &epsilon_k_eff_ij, temperature);
-        assert_relative_eq!(
-            alpha.alpha_ij[[0, 0]].re(),
-            1.0239374984636636,
-            epsilon = 5e-8
-        );
+        assert_relative_eq!(alpha.alpha_ij[[0, 0]], 1.0239374984636636, epsilon = 5e-8);
     }
 
     #[test]
     fn test_sutherland() {
-        let x0 = Dual2::from_re(1.1).derive();
-        let zeta = Dual2::from_re(0.333).derive();
+        let x0 = 1.1;
+        let zeta = 0.333;
         let lambda = 13.77;
         let eps_div_k = 13.88;
         let asa = sutherland(lambda, eps_div_k, zeta, x0);
-        assert_relative_eq!(asa.re(), -122.12017536923423, epsilon = 1e-12);
+        assert_relative_eq!(asa, -122.12017536923423, epsilon = 1e-12);
     }
 
     #[test]
     fn test_b() {
-        let x0 = Dual2::from_re(1.1).derive();
-        let zeta = Dual2::from_re(0.333).derive();
+        let x0 = 1.1;
+        let zeta = 0.333;
         let lambda = 13.77;
         let eps_div_k = 13.88;
         let ba = b(lambda, eps_div_k, zeta, x0, x0);
-        assert_relative_eq!(ba.re(), 93.436438943866293, epsilon = 1e-12);
+        assert_relative_eq!(ba, 93.436438943866293, epsilon = 1e-12);
     }
 
     #[test]
     fn test_quantum_d_ij() {
         let p = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
+        let temperature = 26.7060;
         let dq_ij = p.quantum_d_ij(0, 0, temperature);
-        assert_relative_eq!(dq_ij.re(), 7.5092605940987542e-2, epsilon = 5e-8);
+        assert_relative_eq!(dq_ij, 7.5092605940987542e-2, epsilon = 5e-8);
     }
 
     #[test]
     fn test_first_order_perturbation_ij() {
         let p = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
-        let zeta = Dual2::from_re(0.333).derive();
+        let temperature = 26.7060;
+        let zeta = 0.333;
         let dq_div_s2 = p.quantum_d_ij(0, 0, temperature) / p.sigma_ij[[0, 0]].powi(2);
         let s_eff = p.calc_sigma_eff_ij(0, 0, temperature);
         let d_hs = p.hs_diameter_ij(0, 0, temperature, s_eff);
@@ -532,15 +525,15 @@ mod tests {
             p.c_ij[[0, 0]],
             dq_div_s2,
         );
-        let rel_err = (a1_ij.re() + 332.00915966785539) / 332.00915966785539;
+        let rel_err = (a1_ij + 332.00915966785539) / 332.00915966785539;
         assert_relative_eq!(rel_err, 0.0, epsilon = 1e-7);
     }
 
     #[test]
     fn test_second_order_perturbation_ij() {
         let p = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
-        let zeta = Dual2::from_re(0.333).derive();
+        let temperature = 26.7060;
+        let zeta = 0.333;
         let dq_div_s2 = p.quantum_d_ij(0, 0, temperature) / p.sigma_ij[[0, 0]].powi(2);
         let s_eff = p.calc_sigma_eff_ij(0, 0, temperature);
         let d_hs = p.hs_diameter_ij(0, 0, temperature, s_eff);
@@ -557,15 +550,15 @@ mod tests {
             p.c_ij[[0, 0]],
             dq_div_s2,
         );
-        let rel_err = (a2_ij.re() + 1907.5055256805874) / 1907.5055256805874;
+        let rel_err = (a2_ij + 1907.5055256805874) / 1907.5055256805874;
         assert_relative_eq!(rel_err, 0.0, epsilon = 1e-7);
     }
 
     #[test]
     fn test_third_order_perturbation_ij() {
         let p = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
-        let zeta_bar = Dual2::from_re(0.333).derive();
+        let temperature = 26.7060;
+        let zeta_bar = 0.333;
         let n = 1;
         let s_eff_ij =
             Array2::from_shape_fn((n, n), |(i, j)| p.calc_sigma_eff_ij(i, j, temperature));
@@ -575,16 +568,16 @@ mod tests {
 
         let a3_ij = third_order_perturbation_ij(0, 0, epsilon_k_eff_ij[[0, 0]], &alpha, zeta_bar);
 
-        let rel_err = (a3_ij.re() + 25.807966819127916) / 25.807966819127916;
+        let rel_err = (a3_ij + 25.807966819127916) / 25.807966819127916;
         assert_relative_eq!(rel_err, 0.0, epsilon = 5e-7);
     }
 
     #[test]
     fn test_zeta_saft_vrq_mie() {
         let p = hydrogen_fh1();
-        let t = Dual2::from_re(26.7060).derive();
-        let v = Dual2::from_re(1.0e26).derive();
-        let n = Dual2::from_re(6.02214076e23).derive();
+        let t = 26.7060;
+        let v = 1.0e26;
+        let n = 6.02214076e23;
         let state = StateHD::new(t, v, arr1(&[n]));
         let nc = 1;
         // temperature dependent sigma
@@ -603,23 +596,23 @@ mod tests {
             x_s[i] *= inv_x_s_sum;
         }
         // Segment density
-        let mut rho_s = Dual2::zero();
+        let mut rho_s = 0.0;
         for i in 0..nc {
             rho_s += state.partial_density[i] * p.m[i];
         }
         // packing fractions
         let zeta = zeta_saft_vrq_mie(&p.m, &x_s, &d_hs_ij, rho_s);
         let zeta_bar = zeta_saft_vrq_mie(&p.m, &x_s, &s_eff_ij, rho_s);
-        assert_relative_eq!(zeta.re(), 9.7717457994590765E-002, epsilon = 5e-9);
-        assert_relative_eq!(zeta_bar.re(), 0.10864364645845238, epsilon = 5e-9);
+        assert_relative_eq!(zeta, 9.7717457994590765E-002, epsilon = 5e-9);
+        assert_relative_eq!(zeta_bar, 0.10864364645845238, epsilon = 5e-9);
     }
 
     #[test]
     fn test_perturbation_terms() {
         let p = hydrogen_fh1();
-        let t = Dual2::from_re(26.7060).derive();
-        let v = Dual2::from_re(1.0e26).derive();
-        let n = Dual2::from_re(6.02214076e23).derive();
+        let t = 26.7060;
+        let v = 1.0e26;
+        let n = 6.02214076e23;
         let state = StateHD::new(t, v, arr1(&[n]));
         let nc = 1;
         // temperature dependent sigma
@@ -639,7 +632,7 @@ mod tests {
         }
 
         // Segment density
-        let mut rho_s = Dual2::zero();
+        let mut rho_s = 0.0;
         for i in 0..nc {
             rho_s += state.partial_density[i] * p.m[i];
         }
@@ -666,12 +659,12 @@ mod tests {
         );
         let a3 = third_order_perturbation(&p, &alpha, &x_s, zeta_bar, &epsilon_k_eff_ij);
 
-        let rel_err_a1 = (a1.re() + 30.702499892515764) / 30.702499892515764;
-        let rel_err_a2 = (a2.re() + 67.046957636607587) / 67.046957636607587;
-        let rel_err_a3 = (a3.re() + 470.96241656623727) / 470.96241656623727;
-        assert_relative_eq!(rel_err_a1.re(), 0.0, epsilon = 5e-7);
-        assert_relative_eq!(rel_err_a2.re(), 0.0, epsilon = 5e-7);
-        assert_relative_eq!(rel_err_a3.re(), 0.0, epsilon = 5e-7);
+        let rel_err_a1 = (a1 + 30.702499892515764) / 30.702499892515764;
+        let rel_err_a2 = (a2 + 67.046957636607587) / 67.046957636607587;
+        let rel_err_a3 = (a3 + 470.96241656623727) / 470.96241656623727;
+        assert_relative_eq!(rel_err_a1, 0.0, epsilon = 5e-7);
+        assert_relative_eq!(rel_err_a2, 0.0, epsilon = 5e-7);
+        assert_relative_eq!(rel_err_a3, 0.0, epsilon = 5e-7);
     }
 
     #[test]
@@ -688,19 +681,18 @@ mod tests {
         ];
         let na = 6.02214076e23;
         for (it, &a) in a_ref.iter().enumerate() {
-            let t = Dual2::from_re(26.7060 * (it + 1) as f64).derive();
-            let v = Dual2::from_re(1.0e26).derive();
-            let n = Dual2::from_re(na).derive();
-            let state = StateHD::new(t, v, arr1(&[n]));
+            let t = 26.7060 * (it + 1) as f64;
+            let v = 1.0e26;
+            let state = StateHD::new(t, v, arr1(&[na]));
             let a_disp = disp.helmholtz_energy(&state) / na;
-            assert_relative_eq!(a_disp.re(), a, epsilon = 1e-7);
+            assert_relative_eq!(a_disp, a, epsilon = 1e-7);
         }
-        let t = Dual2::from_re(26.7060).derive();
-        let v = Dual2::from_re(1.0e26 * 2.0).derive();
-        let n = Dual2::from_re(na * 2.0).derive();
+        let t = 26.7060;
+        let v = 1.0e26 * 2.0;
+        let n = na * 2.0;
         let state = StateHD::new(t, v, arr1(&[n]));
         let a_disp = disp.helmholtz_energy(&state) / na;
-        assert_relative_eq!(a_disp.re(), a_ref[0] * 2.0, epsilon = 1e-7);
+        assert_relative_eq!(a_disp, a_ref[0] * 2.0, epsilon = 1e-7);
     }
 
     #[test]
@@ -728,21 +720,21 @@ mod tests {
             -0.84210863940206726,
         ];
         let na = 6.02214076e23;
-        let n = [Dual2::from_re(1.1 * na), Dual2::from_re(1.0 * na)];
-        let v = Dual2::from_re(1.0e26).derive();
+        let n = [1.1 * na, 1.0 * na];
+        let v = 1.0e26;
         for (it, &a) in a_ref.iter().enumerate() {
-            let t = Dual2::from_re(30.0 * (it + 1) as f64).derive();
+            let t = 30.0 * (it + 1) as f64;
             let state = StateHD::new(t, v, arr1(&n));
             let a_disp = disp.helmholtz_energy(&state) / na;
             dbg!(it);
-            assert_relative_eq!(a_disp.re(), a, epsilon = 1e-7);
+            assert_relative_eq!(a_disp, a, epsilon = 1e-7);
         }
-        let t = Dual2::from_re(30.0).derive();
-        let v = Dual2::from_re(1.0e26 * 2.0).derive();
-        let n = [Dual2::from_re(2.2 * na), Dual2::from_re(2.0 * na)];
+        let t = 30.0;
+        let v = 1.0e26 * 2.0;
+        let n = [2.2 * na, 2.0 * na];
         let state = StateHD::new(t, v, arr1(&n));
         let a_disp = disp.helmholtz_energy(&state) / na;
-        assert_relative_eq!(a_disp.re(), a_ref[0] * 2.0, epsilon = 1e-7);
+        assert_relative_eq!(a_disp, a_ref[0] * 2.0, epsilon = 1e-7);
     }
 
     #[cfg(feature = "dft")]
@@ -753,8 +745,8 @@ mod tests {
         };
         let p = &disp.parameters;
         let n = p.m.len();
-        let rho = Array1::from_shape_fn(n, |_i| Dual2::from_re(0.01));
-        let t = Dual2::from_re(25.0).derive();
+        let rho = Array1::from_shape_fn(n, |_i| 0.01);
+        let t = 25.0;
         // temperature dependent segment radius // calc & store this in struct
         let s_eff_ij = Array2::from_shape_fn((n, n), |(i, j)| p.calc_sigma_eff_ij(i, j, t));
 
@@ -783,7 +775,7 @@ mod tests {
         );
 
         dbg!(rho);
-        dbg!(a_disp.re());
-        assert_relative_eq!(a_disp.re(), -0.022349175545184223, epsilon = 1e-7);
+        dbg!(a_disp);
+        assert_relative_eq!(a_disp, -0.022349175545184223, epsilon = 1e-7);
     }
 }

--- a/src/saftvrqmie/eos/hard_sphere.rs
+++ b/src/saftvrqmie/eos/hard_sphere.rs
@@ -62,7 +62,7 @@ const W_K21: [f64; 21] = [
 
 impl SaftVRQMieParameters {
     #[inline]
-    pub fn hs_diameter<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    pub fn hs_diameter<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         Array1::from_shape_fn(self.m.len(), |i| -> D {
             let sigma_eff = self.calc_sigma_eff_ij(i, i, temperature);
             self.hs_diameter_ij(i, i, temperature, sigma_eff)
@@ -70,7 +70,7 @@ impl SaftVRQMieParameters {
     }
 
     #[inline]
-    pub fn hs_diameter_ij<D: DualNum<f64>>(
+    pub fn hs_diameter_ij<D: DualNum<f64> + Copy>(
         &self,
         i: usize,
         j: usize,
@@ -89,7 +89,7 @@ impl SaftVRQMieParameters {
         d_hs
     }
 
-    pub fn zero_integrand<D: DualNum<f64>>(
+    pub fn zero_integrand<D: DualNum<f64> + Copy>(
         &self,
         i: usize,
         j: usize,
@@ -118,13 +118,18 @@ impl SaftVRQMieParameters {
     }
 
     #[inline]
-    pub fn epsilon_k_eff<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    pub fn epsilon_k_eff<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         Array1::from_shape_fn(self.m.len(), |i| -> D {
             self.calc_epsilon_k_eff_ij(i, i, temperature)
         })
     }
 
-    pub fn calc_epsilon_k_eff_ij<D: DualNum<f64>>(&self, i: usize, j: usize, temperature: D) -> D {
+    pub fn calc_epsilon_k_eff_ij<D: DualNum<f64> + Copy>(
+        &self,
+        i: usize,
+        j: usize,
+        temperature: D,
+    ) -> D {
         let mut r = D::one() * self.sigma_ij[[i, j]];
         let mut u_vec = [D::zero(), D::zero(), D::zero()];
         for _k in 1..20 {
@@ -141,13 +146,18 @@ impl SaftVRQMieParameters {
     }
 
     #[inline]
-    pub fn sigma_eff<D: DualNum<f64>>(&self, temperature: D) -> Array1<D> {
+    pub fn sigma_eff<D: DualNum<f64> + Copy>(&self, temperature: D) -> Array1<D> {
         Array1::from_shape_fn(self.m.len(), |i| -> D {
             self.calc_sigma_eff_ij(i, i, temperature)
         })
     }
 
-    pub fn calc_sigma_eff_ij<D: DualNum<f64>>(&self, i: usize, j: usize, temperature: D) -> D {
+    pub fn calc_sigma_eff_ij<D: DualNum<f64> + Copy>(
+        &self,
+        i: usize,
+        j: usize,
+        temperature: D,
+    ) -> D {
         let mut r = D::one() * self.sigma_ij[[i, j]];
         let mut u_vec = [D::zero(), D::zero(), D::zero()];
         for _k in 1..20 {
@@ -169,7 +179,7 @@ impl SaftVRQMieParameters {
     }
 
     /// Feynman-Hibbs corrected potential
-    pub fn qmie_potential_ij<D: DualNum<f64>>(
+    pub fn qmie_potential_ij<D: DualNum<f64> + Copy>(
         &self,
         i: usize,
         j: usize,
@@ -219,7 +229,7 @@ pub struct HardSphere {
     pub parameters: Arc<SaftVRQMieParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardSphere {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for HardSphere {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let d = self.parameters.hs_diameter(state.temperature);
         let zeta = zeta(&self.parameters.m, &state.partial_density, &d);
@@ -238,7 +248,7 @@ impl fmt::Display for HardSphere {
     }
 }
 
-pub fn zeta<D: DualNum<f64>>(
+pub fn zeta<D: DualNum<f64> + Copy>(
     m: &Array1<f64>,
     partial_density: &Array1<D>,
     diameter: &Array1<D>,
@@ -254,7 +264,11 @@ pub fn zeta<D: DualNum<f64>>(
     zeta
 }
 
-pub fn zeta_23<D: DualNum<f64>>(m: &Array1<f64>, molefracs: &Array1<D>, diameter: &Array1<D>) -> D {
+pub fn zeta_23<D: DualNum<f64> + Copy>(
+    m: &Array1<f64>,
+    molefracs: &Array1<D>,
+    diameter: &Array1<D>,
+) -> D {
     let mut zeta: [D; 2] = [D::zero(), D::zero()];
     for i in 0..m.len() {
         for (k, z) in zeta.iter_mut().enumerate() {
@@ -271,59 +285,59 @@ mod tests {
     use crate::saftvrqmie::parameters::utils::hydrogen_fh1;
     use approx::assert_relative_eq;
     use ndarray::arr1;
-    use num_dual::Dual2;
+    use num_dual::Dual64;
 
     #[test]
     fn test_quantum_d_mass() {
         let parameters = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
-        let r = Dual2::from_re(3.5);
+        let temperature = 26.7060;
+        let r = 3.5;
         let u0 = parameters.qmie_potential_ij(0, 0, r, temperature);
         let eps = 1.0e-5;
         let u2 = parameters.qmie_potential_ij(0, 0, r + eps, temperature);
         let u1 = parameters.qmie_potential_ij(0, 0, r - eps, temperature);
-        let dudr_num = (u2[0].re() - u1[0].re()) / eps / 2.0;
-        let d2udr2_num = (u2[1].re() - u1[1].re()) / eps / 2.0;
-        assert!(((dudr_num - u0[1].re()) / u0[1].re()).abs() < 1.0e-9);
-        assert!(((d2udr2_num - u0[2].re()) / u0[2].re()).abs() < 1.0e-9);
+        let dudr_num = (u2[0] - u1[0]) / eps / 2.0;
+        let d2udr2_num = (u2[1] - u1[1]) / eps / 2.0;
+        assert!(((dudr_num - u0[1]) / u0[1]).abs() < 1.0e-9);
+        assert!(((d2udr2_num - u0[2]) / u0[2]).abs() < 1.0e-9);
     }
 
     #[test]
     fn test_sigma_effective() {
         let parameters = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
+        let temperature = 26.7060;
         let sigma_eff = parameters.calc_sigma_eff_ij(0, 0, temperature);
-        println!("{}", sigma_eff.re() - 3.2540054024660556);
-        assert!((sigma_eff.re() - 3.2540054024660556).abs() < 5.0e-7)
+        println!("{}", sigma_eff - 3.2540054024660556);
+        assert!((sigma_eff - 3.2540054024660556).abs() < 5.0e-7)
     }
 
     #[test]
     fn test_eps_div_k_effective() {
         let parameters = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
+        let temperature = 26.7060;
         let epsilon_k_eff = parameters.calc_epsilon_k_eff_ij(0, 0, temperature);
-        println!("{}", epsilon_k_eff.re() - 21.654396207986697);
-        assert!((epsilon_k_eff.re() - 21.654396207986697).abs() < 1.0e-6)
+        println!("{}", epsilon_k_eff - 21.654396207986697);
+        assert!((epsilon_k_eff - 21.654396207986697).abs() < 1.0e-6)
     }
 
     #[test]
     fn test_zero_integrand() {
         let parameters = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.706).derive();
+        let temperature = 26.706;
         let sigma_eff = parameters.calc_sigma_eff_ij(0, 0, temperature);
         let r0 = parameters.zero_integrand(0, 0, temperature, sigma_eff);
-        println!("{}", r0.re() - 2.5265031901173732);
-        assert!((r0.re() - 2.5265031901173732).abs() < 5.0e-7)
+        println!("{}", r0 - 2.5265031901173732);
+        assert!((r0 - 2.5265031901173732).abs() < 5.0e-7)
     }
 
     #[test]
     fn test_hs_diameter() {
         let parameters = hydrogen_fh1();
-        let temperature = Dual2::from_re(26.7060).derive();
+        let temperature = Dual64::from(26.7060).derivative();
         let sigma_eff = parameters.calc_sigma_eff_ij(0, 0, temperature);
         let d_hs = parameters.hs_diameter_ij(0, 0, temperature, sigma_eff);
         assert!((d_hs.re() - 3.1410453883283341).abs() < 5.0e-8);
-        assert!((d_hs.v1[0] + 8.4528823966252661e-3).abs() < 1.0e-9);
+        assert!((d_hs.eps.unwrap() + 8.4528823966252661e-3).abs() < 1.0e-9);
     }
 
     #[test]

--- a/src/saftvrqmie/eos/hard_sphere.rs
+++ b/src/saftvrqmie/eos/hard_sphere.rs
@@ -337,7 +337,7 @@ mod tests {
         let sigma_eff = parameters.calc_sigma_eff_ij(0, 0, temperature);
         let d_hs = parameters.hs_diameter_ij(0, 0, temperature, sigma_eff);
         assert!((d_hs.re() - 3.1410453883283341).abs() < 5.0e-8);
-        assert!((d_hs.eps.unwrap() + 8.4528823966252661e-3).abs() < 1.0e-9);
+        assert!((d_hs.eps + 8.4528823966252661e-3).abs() < 1.0e-9);
     }
 
     #[test]

--- a/src/saftvrqmie/eos/non_additive_hs.rs
+++ b/src/saftvrqmie/eos/non_additive_hs.rs
@@ -11,7 +11,7 @@ pub struct NonAddHardSphere {
     pub parameters: Arc<SaftVRQMieParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for NonAddHardSphere {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for NonAddHardSphere {
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
         let n = p.m.len();
@@ -40,7 +40,7 @@ impl fmt::Display for NonAddHardSphere {
     }
 }
 
-pub fn reduced_non_additive_hs_energy<D: DualNum<f64>>(
+pub fn reduced_non_additive_hs_energy<D: DualNum<f64> + Copy>(
     parameters: &SaftVRQMieParameters,
     d_hs_ij: &Array2<D>,
     d_hs_add_ij: &Array2<D>,

--- a/src/uvtheory/eos/attractive_perturbation_bh.rs
+++ b/src/uvtheory/eos/attractive_perturbation_bh.rs
@@ -51,7 +51,7 @@ impl fmt::Display for AttractivePerturbationBH {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for AttractivePerturbationBH {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for AttractivePerturbationBH {
     /// Helmholtz energy for attractive perturbation, eq. 52
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
@@ -87,7 +87,7 @@ fn delta_b12u<D: DualNum<f64>>(t_x: D, mean_field_constant_x: D, weighted_sigma3
     -mean_field_constant_x / t_x * 2.0 * PI * weighted_sigma3_ij
 }
 
-fn residual_virial_coefficient<D: DualNum<f64>>(p: &UVParameters, x: &Array1<D>, t: D) -> D {
+fn residual_virial_coefficient<D: DualNum<f64> + Copy>(p: &UVParameters, x: &Array1<D>, t: D) -> D {
     let mut delta_b2bar = D::zero();
     for i in 0..p.ncomponents {
         let xi = x[i];
@@ -101,7 +101,7 @@ fn residual_virial_coefficient<D: DualNum<f64>>(p: &UVParameters, x: &Array1<D>,
     delta_b2bar
 }
 
-fn correlation_integral_bh<D: DualNum<f64>>(
+fn correlation_integral_bh<D: DualNum<f64> + Copy>(
     rho_x: D,
     mean_field_constant_x: D,
     rep_x: D,
@@ -116,7 +116,7 @@ fn correlation_integral_bh<D: DualNum<f64>>(
 
 /// U-fraction according to Barker-Henderson division.
 /// Eq. 15
-fn u_fraction_bh<D: DualNum<f64>>(rep_x: D, reduced_density: D, one_fluid_beta: D) -> D {
+fn u_fraction_bh<D: DualNum<f64> + Copy>(rep_x: D, reduced_density: D, one_fluid_beta: D) -> D {
     let mut c = [D::zero(); 4];
     let inv_rep = rep_x.recip();
     for i in 0..4 {
@@ -130,11 +130,11 @@ fn u_fraction_bh<D: DualNum<f64>>(rep_x: D, reduced_density: D, one_fluid_beta: 
 
 /// Activation function used for u-fraction according to Barker-Henderson division.
 /// Eq. 16
-fn activation<D: DualNum<f64>>(c: D, one_fluid_beta: D) -> D {
+fn activation<D: DualNum<f64> + Copy>(c: D, one_fluid_beta: D) -> D {
     one_fluid_beta * c.sqrt() / (one_fluid_beta.powi(2) * c + 1.0).sqrt()
 }
 
-fn one_fluid_properties<D: DualNum<f64>>(
+fn one_fluid_properties<D: DualNum<f64> + Copy>(
     p: &UVParameters,
     x: &Array1<D>,
     t: D,
@@ -172,7 +172,7 @@ fn one_fluid_properties<D: DualNum<f64>>(
     )
 }
 
-fn coefficients_bh<D: DualNum<f64>>(rep: D, att: D, d: D) -> [D; 3] {
+fn coefficients_bh<D: DualNum<f64> + Copy>(rep: D, att: D, d: D) -> [D; 3] {
     let c11 = d.powd(-rep + 6.0) * ((D::one() * 2.0f64).powd(-rep + 3.0) - d.powd(rep - 3.0))
         / (-rep + 3.0)
         + (-d.powi(3) * 8.0 + 1.0) / 24.0;
@@ -190,14 +190,14 @@ fn coefficients_bh<D: DualNum<f64>>(rep: D, att: D, d: D) -> [D; 3] {
     [c1, c2, c3]
 }
 
-fn delta_b2<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64) -> D {
+fn delta_b2<D: DualNum<f64> + Copy>(reduced_temperature: D, rep: f64, att: f64) -> D {
     let rc = 5.0;
     let alpha = mean_field_constant(rep, att, rc);
     let yeff = y_eff(reduced_temperature, rep, att);
     -(yeff * (rc.powi(3) - 1.0) / 3.0 + reduced_temperature.recip() * alpha) * 2.0 * PI
 }
 
-fn y_eff<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64) -> D {
+fn y_eff<D: DualNum<f64> + Copy>(reduced_temperature: D, rep: f64, att: f64) -> D {
     // optimize: move this part to parameter initialization
     let rc = 5.0;
     let rs = 1.0;

--- a/src/uvtheory/eos/attractive_perturbation_uvb3.rs
+++ b/src/uvtheory/eos/attractive_perturbation_uvb3.rs
@@ -90,7 +90,7 @@ impl fmt::Display for AttractivePerturbationUVB3 {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for AttractivePerturbationUVB3 {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for AttractivePerturbationUVB3 {
     /// Helmholtz energy for attractive perturbation
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
@@ -131,7 +131,7 @@ impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for AttractivePerturbationUVB3 {
     }
 }
 
-fn delta_b12u<D: DualNum<f64>>(
+fn delta_b12u<D: DualNum<f64> + Copy>(
     t_x: D,
     mean_field_constant_x: D,
     weighted_sigma3_ij: D,
@@ -144,7 +144,7 @@ fn delta_b12u<D: DualNum<f64>>(
         * weighted_sigma3_ij
 }
 
-fn residual_virial_coefficient<D: DualNum<f64>>(p: &UVParameters, x: &Array1<D>, t: D) -> D {
+fn residual_virial_coefficient<D: DualNum<f64> + Copy>(p: &UVParameters, x: &Array1<D>, t: D) -> D {
     let mut delta_b2bar = D::zero();
 
     for i in 0..p.ncomponents {
@@ -163,7 +163,7 @@ fn residual_virial_coefficient<D: DualNum<f64>>(p: &UVParameters, x: &Array1<D>,
     }
     delta_b2bar
 }
-fn residual_third_virial_coefficient<D: DualNum<f64>>(
+fn residual_third_virial_coefficient<D: DualNum<f64> + Copy>(
     p: &UVParameters,
     x: &Array1<D>,
     t: D,
@@ -192,7 +192,7 @@ fn residual_third_virial_coefficient<D: DualNum<f64>>(
     }
     delta_b3bar
 }
-fn correlation_integral_wca<D: DualNum<f64>>(
+fn correlation_integral_wca<D: DualNum<f64> + Copy>(
     rho_x: D,
     mean_field_constant_x: D,
     rep_x: D,
@@ -209,7 +209,7 @@ fn correlation_integral_wca<D: DualNum<f64>>(
 }
 
 /// U-fraction with low temperature correction omega
-fn u_fraction_wca<D: DualNum<f64>>(rep_x: D, reduced_density: D, t_x: D) -> D {
+fn u_fraction_wca<D: DualNum<f64> + Copy>(rep_x: D, reduced_density: D, t_x: D) -> D {
     let omega = if t_x.re() < 175.0 {
         (-t_x * CU_WCA[5] * (reduced_density - CU_WCA[6]).powi(2)).exp()
             * ((t_x * CU_WCA[7]).tanh().recip() - 1.0).powi(2)
@@ -223,7 +223,7 @@ fn u_fraction_wca<D: DualNum<f64>>(rep_x: D, reduced_density: D, t_x: D) -> D {
 }
 
 // Coefficients for IWCA
-fn coefficients_wca<D: DualNum<f64>>(rep: D, att: D, d: D) -> [D; 6] {
+fn coefficients_wca<D: DualNum<f64> + Copy>(rep: D, att: D, d: D) -> [D; 6] {
     let rep_inv = rep.recip();
     let rs_x = (rep / att).powd((rep - att).recip());
     let tau_x = -d + rs_x;
@@ -261,7 +261,7 @@ fn factorial(num: u64) -> u64 {
     (1..=num).product()
 }
 
-fn delta_b2<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64, q: D) -> D {
+fn delta_b2<D: DualNum<f64> + Copy>(reduced_temperature: D, rep: f64, att: f64, q: D) -> D {
     let rm = (rep / att).powd((rep - att).recip());
     let beta = reduced_temperature.recip();
     let b20 = q.powi(3) * 2.0 / 3.0 * PI;
@@ -289,13 +289,13 @@ fn delta_b2<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64, q: D) -
 
     for i in 2..16 {
         let k = factorial(i as u64) as f64 * i as f64;
-        sum_beta += beta.powi(i as i32) / k
+        sum_beta += beta.powi(i) / k
     }
 
     (b20 - rm.powi(3) * 2.0 / 3.0 * PI - c1) * y - sum_beta * c2 - beta * c3 - beta.powi(2) * c4
 }
 
-fn delta_b31u<D: DualNum<f64>>(
+fn delta_b31u<D: DualNum<f64> + Copy>(
     t_x: D,
     weighted_sigma3_ij: D,
     rm_x: D,
@@ -313,7 +313,14 @@ fn delta_b31u<D: DualNum<f64>>(
     t_x.recip() * 4.0 * mie_prefactor(rep_x, att_x) * PI * k1 * weighted_sigma3_ij.powi(2)
 }
 
-fn delta_b3<D: DualNum<f64>>(t_x: D, rm_x: f64, rep_x: f64, _att_x: f64, d_x: D, q_x: D) -> D {
+fn delta_b3<D: DualNum<f64> + Copy>(
+    t_x: D,
+    rm_x: f64,
+    rep_x: f64,
+    _att_x: f64,
+    d_x: D,
+    q_x: D,
+) -> D {
     let beta = t_x.recip();
     let b30 = (q_x.powi(3) * PI / 6.0).powi(2) * 10.0;
 

--- a/src/uvtheory/eos/attractive_perturbation_wca.rs
+++ b/src/uvtheory/eos/attractive_perturbation_wca.rs
@@ -77,7 +77,7 @@ impl fmt::Display for AttractivePerturbationWCA {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for AttractivePerturbationWCA {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for AttractivePerturbationWCA {
     /// Helmholtz energy for attractive perturbation, eq. 52
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;
@@ -110,7 +110,7 @@ impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for AttractivePerturbationWCA {
 }
 
 // (S43) & (S53)
-fn delta_b12u<D: DualNum<f64>>(
+fn delta_b12u<D: DualNum<f64> + Copy>(
     t_x: D,
     mean_field_constant_x: D,
     weighted_sigma3_ij: D,
@@ -123,7 +123,7 @@ fn delta_b12u<D: DualNum<f64>>(
         * weighted_sigma3_ij
 }
 
-fn residual_virial_coefficient<D: DualNum<f64>>(p: &UVParameters, x: &Array1<D>, t: D) -> D {
+fn residual_virial_coefficient<D: DualNum<f64> + Copy>(p: &UVParameters, x: &Array1<D>, t: D) -> D {
     let mut delta_b2bar = D::zero();
 
     for i in 0..p.ncomponents {
@@ -145,7 +145,7 @@ fn residual_virial_coefficient<D: DualNum<f64>>(p: &UVParameters, x: &Array1<D>,
     delta_b2bar
 }
 
-fn correlation_integral_wca<D: DualNum<f64>>(
+fn correlation_integral_wca<D: DualNum<f64> + Copy>(
     rho_x: D,
     mean_field_constant_x: D,
     rep_x: D,
@@ -163,13 +163,13 @@ fn correlation_integral_wca<D: DualNum<f64>>(
 
 /// U-fraction according to Barker-Henderson division.
 /// Eq. 15
-fn u_fraction_wca<D: DualNum<f64>>(rep_x: D, reduced_density: D) -> D {
+fn u_fraction_wca<D: DualNum<f64> + Copy>(rep_x: D, reduced_density: D) -> D {
     (reduced_density * CU_WCA[0]
         + reduced_density.powi(2) * (rep_x.recip() * CU_WCA[2] + CU_WCA[1]))
         .tanh()
 }
 
-pub(super) fn one_fluid_properties<D: DualNum<f64>>(
+pub(super) fn one_fluid_properties<D: DualNum<f64> + Copy>(
     p: &UVParameters,
     x: &Array1<D>,
     t: D,
@@ -212,7 +212,7 @@ pub(super) fn one_fluid_properties<D: DualNum<f64>>(
 }
 
 // Coefficients for IWCA from eq. (S55)
-fn coefficients_wca<D: DualNum<f64>>(rep: D, att: D, d: D) -> [D; 6] {
+fn coefficients_wca<D: DualNum<f64> + Copy>(rep: D, att: D, d: D) -> [D; 6] {
     let rep_inv = rep.recip();
     let rs_x = (rep / att).powd((rep - att).recip());
     let tau_x = -d + rs_x;
@@ -244,7 +244,7 @@ fn coefficients_wca<D: DualNum<f64>>(rep: D, att: D, d: D) -> [D; 6] {
     [c1, c2, c3, c4, c5, c6]
 }
 
-fn delta_b2<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64, q: D) -> D {
+fn delta_b2<D: DualNum<f64> + Copy>(reduced_temperature: D, rep: f64, att: f64, q: D) -> D {
     let rm = (rep / att).powf(1.0 / (rep - att)); // Check mixing rule!!
     let rc = 5.0;
     let alpha = mean_field_constant(rep, att, rc);
@@ -256,7 +256,7 @@ fn delta_b2<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64, q: D) -
         * PI
 }
 
-fn y_eff<D: DualNum<f64>>(reduced_temperature: D, rep: f64, att: f64) -> D {
+fn y_eff<D: DualNum<f64> + Copy>(reduced_temperature: D, rep: f64, att: f64) -> D {
     // optimize: move this part to parameter initialization
     let rc = 5.0;
     let rs = (rep / att).powf(1.0 / (rep - att));

--- a/src/uvtheory/eos/hard_sphere_bh.rs
+++ b/src/uvtheory/eos/hard_sphere_bh.rs
@@ -23,7 +23,7 @@ pub struct HardSphereBH {
     pub parameters: Arc<UVParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardSphereBH {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for HardSphereBH {
     /// Helmholtz energy for hard spheres, eq. 19 (check Volume)
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let d = diameter_bh(&self.parameters, state.temperature);
@@ -46,7 +46,10 @@ impl fmt::Display for HardSphereBH {
 /// Dimensionless Hard-sphere diameter according to Barker-Henderson division.
 /// Eq. S23 and S24.
 ///
-pub(super) fn diameter_bh<D: DualNum<f64>>(parameters: &UVParameters, temperature: D) -> Array1<D> {
+pub(super) fn diameter_bh<D: DualNum<f64> + Copy>(
+    parameters: &UVParameters,
+    temperature: D,
+) -> Array1<D> {
     parameters
         .cd_bh_pure
         .iter()
@@ -54,14 +57,16 @@ pub(super) fn diameter_bh<D: DualNum<f64>>(parameters: &UVParameters, temperatur
         .map(|(i, c)| {
             let t = temperature / parameters.epsilon_k[i];
             let d = t.powf(0.25) * c[1] + t.powf(0.75) * c[2] + t.powf(1.25) * c[3];
-            (t * c[0] + d * (t + 1.0).ln() + t.powi(2) * c[4] + 1.0)
-                .powf(-0.5 / parameters.rep[i] as f64)
+            (t * c[0] + d * (t + 1.0).ln() + t.powi(2) * c[4] + 1.0).powf(-0.5 / parameters.rep[i])
                 * parameters.sigma[i]
         })
         .collect()
 }
 
-pub(super) fn zeta<D: DualNum<f64>>(partial_density: &Array1<D>, diameter: &Array1<D>) -> [D; 4] {
+pub(super) fn zeta<D: DualNum<f64> + Copy>(
+    partial_density: &Array1<D>,
+    diameter: &Array1<D>,
+) -> [D; 4] {
     let mut zeta: [D; 4] = [D::zero(), D::zero(), D::zero(), D::zero()];
     for i in 0..partial_density.len() {
         for k in 0..4 {
@@ -72,7 +77,7 @@ pub(super) fn zeta<D: DualNum<f64>>(partial_density: &Array1<D>, diameter: &Arra
     zeta
 }
 
-pub(super) fn packing_fraction<D: DualNum<f64>>(
+pub(super) fn packing_fraction<D: DualNum<f64> + Copy>(
     partial_density: &Array1<D>,
     diameter: &Array1<D>,
 ) -> D {
@@ -81,7 +86,7 @@ pub(super) fn packing_fraction<D: DualNum<f64>>(
     })
 }
 
-pub(super) fn zeta_23<D: DualNum<f64>>(molefracs: &Array1<D>, diameter: &Array1<D>) -> D {
+pub(super) fn zeta_23<D: DualNum<f64> + Copy>(molefracs: &Array1<D>, diameter: &Array1<D>) -> D {
     let mut zeta: [D; 2] = [D::zero(), D::zero()];
     for i in 0..molefracs.len() {
         for k in 0..2 {
@@ -91,7 +96,7 @@ pub(super) fn zeta_23<D: DualNum<f64>>(molefracs: &Array1<D>, diameter: &Array1<
     zeta[0] / zeta[1]
 }
 
-pub(super) fn packing_fraction_b<D: DualNum<f64>>(
+pub(super) fn packing_fraction_b<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     diameter: &Array1<D>,
     eta: D,
@@ -111,7 +116,7 @@ pub(super) fn packing_fraction_b<D: DualNum<f64>>(
     })
 }
 
-pub(super) fn packing_fraction_a<D: DualNum<f64>>(
+pub(super) fn packing_fraction_a<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     diameter: &Array1<D>,
     eta: D,

--- a/src/uvtheory/eos/hard_sphere_wca.rs
+++ b/src/uvtheory/eos/hard_sphere_wca.rs
@@ -53,7 +53,7 @@ pub struct HardSphereWCA {
     pub parameters: Arc<UVParameters>,
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for HardSphereWCA {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for HardSphereWCA {
     /// Helmholtz energy for hard spheres, eq. 19 (check Volume)
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let d = diameter_wca(&self.parameters, state.temperature);
@@ -74,7 +74,7 @@ impl fmt::Display for HardSphereWCA {
 }
 
 /// Dimensionless Hard-sphere diameter according to Weeks-Chandler-Andersen division.
-pub(super) fn diameter_wca<D: DualNum<f64>>(
+pub(super) fn diameter_wca<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     temperature: D,
 ) -> Array1<D> {
@@ -96,7 +96,11 @@ pub(super) fn diameter_wca<D: DualNum<f64>>(
         .collect()
 }
 
-pub(super) fn dimensionless_diameter_q_wca<D: DualNum<f64>>(t_x: D, rep_x: D, att_x: D) -> D {
+pub(super) fn dimensionless_diameter_q_wca<D: DualNum<f64> + Copy>(
+    t_x: D,
+    rep_x: D,
+    att_x: D,
+) -> D {
     let nu = rep_x;
     let n = att_x;
     let rs = (nu / n).powd((nu - n).recip());
@@ -122,7 +126,10 @@ pub(super) fn dimensionless_diameter_q_wca<D: DualNum<f64>>(t_x: D, rep_x: D, at
         * rs
 }
 
-pub(super) fn zeta<D: DualNum<f64>>(partial_density: &Array1<D>, diameter: &Array1<D>) -> [D; 4] {
+pub(super) fn zeta<D: DualNum<f64> + Copy>(
+    partial_density: &Array1<D>,
+    diameter: &Array1<D>,
+) -> [D; 4] {
     let mut zeta: [D; 4] = [D::zero(), D::zero(), D::zero(), D::zero()];
     for i in 0..partial_density.len() {
         for k in 0..4 {
@@ -133,7 +140,7 @@ pub(super) fn zeta<D: DualNum<f64>>(partial_density: &Array1<D>, diameter: &Arra
     zeta
 }
 
-pub(super) fn packing_fraction<D: DualNum<f64>>(
+pub(super) fn packing_fraction<D: DualNum<f64> + Copy>(
     partial_density: &Array1<D>,
     diameter: &Array1<D>,
 ) -> D {
@@ -142,7 +149,7 @@ pub(super) fn packing_fraction<D: DualNum<f64>>(
     })
 }
 
-pub(super) fn zeta_23<D: DualNum<f64>>(molefracs: &Array1<D>, diameter: &Array1<D>) -> D {
+pub(super) fn zeta_23<D: DualNum<f64> + Copy>(molefracs: &Array1<D>, diameter: &Array1<D>) -> D {
     let mut zeta: [D; 2] = [D::zero(), D::zero()];
     for i in 0..molefracs.len() {
         for k in 0..2 {
@@ -153,7 +160,7 @@ pub(super) fn zeta_23<D: DualNum<f64>>(molefracs: &Array1<D>, diameter: &Array1<
 }
 
 #[inline]
-pub(super) fn dimensionless_length_scale<D: DualNum<f64>>(
+pub(super) fn dimensionless_length_scale<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     temperature: D,
 ) -> Array1<D> {
@@ -172,7 +179,7 @@ pub(super) fn dimensionless_length_scale<D: DualNum<f64>>(
 
 #[inline]
 
-pub(super) fn packing_fraction_b<D: DualNum<f64>>(
+pub(super) fn packing_fraction_b<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     eta: D,
     temperature: D,
@@ -194,7 +201,7 @@ pub(super) fn packing_fraction_b<D: DualNum<f64>>(
     })
 }
 
-pub(super) fn packing_fraction_b_uvb3<D: DualNum<f64>>(
+pub(super) fn packing_fraction_b_uvb3<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     eta: D,
     temperature: D,
@@ -216,7 +223,7 @@ pub(super) fn packing_fraction_b_uvb3<D: DualNum<f64>>(
     })
 }
 
-pub(super) fn packing_fraction_a<D: DualNum<f64>>(
+pub(super) fn packing_fraction_a<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     eta: D,
     temperature: D,
@@ -245,7 +252,7 @@ pub(super) fn packing_fraction_a<D: DualNum<f64>>(
     })
 }
 
-pub(super) fn packing_fraction_a_uvb3<D: DualNum<f64>>(
+pub(super) fn packing_fraction_a_uvb3<D: DualNum<f64> + Copy>(
     parameters: &UVParameters,
     eta: D,
     temperature: D,

--- a/src/uvtheory/eos/reference_perturbation_bh.rs
+++ b/src/uvtheory/eos/reference_perturbation_bh.rs
@@ -18,7 +18,7 @@ impl fmt::Display for ReferencePerturbationBH {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for ReferencePerturbationBH {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for ReferencePerturbationBH {
     /// Helmholtz energy for perturbation reference (Mayer-f), eq. 29
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;

--- a/src/uvtheory/eos/reference_perturbation_uvb3.rs
+++ b/src/uvtheory/eos/reference_perturbation_uvb3.rs
@@ -19,7 +19,7 @@ impl fmt::Display for ReferencePerturbationUVB3 {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for ReferencePerturbationUVB3 {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for ReferencePerturbationUVB3 {
     /// Helmholtz energy for perturbation reference (Mayer-f), eq. 29
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;

--- a/src/uvtheory/eos/reference_perturbation_wca.rs
+++ b/src/uvtheory/eos/reference_perturbation_wca.rs
@@ -19,7 +19,7 @@ impl fmt::Display for ReferencePerturbationWCA {
     }
 }
 
-impl<D: DualNum<f64>> HelmholtzEnergyDual<D> for ReferencePerturbationWCA {
+impl<D: DualNum<f64> + Copy> HelmholtzEnergyDual<D> for ReferencePerturbationWCA {
     /// Helmholtz energy for perturbation reference (Mayer-f), eq. 29
     fn helmholtz_energy(&self, state: &StateHD<D>) -> D {
         let p = &self.parameters;

--- a/src/uvtheory/parameters.rs
+++ b/src/uvtheory/parameters.rs
@@ -93,12 +93,12 @@ lazy_static! {
 }
 
 #[inline]
-pub fn mie_prefactor<D: DualNum<f64>>(rep: D, att: D) -> D {
+pub fn mie_prefactor<D: DualNum<f64> + Copy>(rep: D, att: D) -> D {
     rep / (rep - att) * (rep / att).powd(att / (rep - att))
 }
 
 #[inline]
-pub fn mean_field_constant<D: DualNum<f64>>(rep: D, att: D, x: D) -> D {
+pub fn mean_field_constant<D: DualNum<f64> + Copy>(rep: D, att: D, x: D) -> D {
     mie_prefactor(rep, att) * (x.powd(-att + 3.0) / (att - 3.0) - x.powd(-rep + 3.0) / (rep - 3.0))
 }
 


### PR DESCRIPTION
The PR tracks the necessary changes introduced in https://github.com/itt-ustutt/num-dual/pull/52 and following pull requests so that there are no surprises once num-dual `0.7.0` is released.