### PR TITLE
Fix unexpected behavior in the initialization of bubble and dew point calculations

### DIFF
--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fixed a bug that caused the bubble and dew point solvers to ignore the initial values for the opposing phase given by the user if no initial value for temperature/pressure was also given. [#138](https://github.com/feos-org/feos/pull/138)
 
 ## [0.4.0] - 2023-01-27
 ### Added

--- a/feos-core/src/phase_equilibria/bubble_dew.rs
+++ b/feos-core/src/phase_equilibria/bubble_dew.rs
@@ -142,7 +142,7 @@ impl<E: EquationOfState> PhaseEquilibrium<E, 2> {
                         tp_spec,
                         p,
                         molefracs_spec,
-                        Some(&x),
+                        molefracs_init.or(Some(&x)),
                         bubble,
                         options,
                     )


### PR DESCRIPTION
Before this fix, the initial value for the composition of the opposing phase was ignored if no initial guess for the temperature or pressure was given. This behavior is confusing and should be changed. The value that was used to override the user-given initial values is remarkably robust for PC-SAFT but for other models (cubics...) this behavior is problematic.