### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2023-03-20
+- Python only: Release the changes introduced in `feos-core` 0.4.1 and `feos-dft` 0.4.1.
+
 ## [0.4.1] - 2023-01-28
 ### Changed
 - Replaced some slow array operations to make calculations with multiple associating molecules significantly faster. [#129](https://github.com/feos-org/feos/pull/129)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feos"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>", "Philipp Rehner <prehner@ethz.ch>"]
 edition = "2018"
 readme = "README.md"

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.4.1] - 2023-03-20
 ### Fixed
 - Fixed a bug that caused the bubble and dew point solvers to ignore the initial values for the opposing phase given by the user if no initial value for temperature/pressure was also given. [#138](https://github.com/feos-org/feos/pull/138)
 

--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feos-core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
            "Philipp Rehner <prehner@ethz.ch"]
 edition = "2018"

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.1] - 2023-03-20
 ### Added
 - Added new methods `drho_dmu`, `drho_dp` and `drho_dt` that calculate partial derivatives of density profiles to every DFT profile. Also includes direct access to the integrated derivatives `dn_dmu`, `dn_dp` and `dn_dt`. [#134](https://github.com/feos-org/feos/pull/134)
 - Added `enthalpy_of_adsoprtion` and `partial_molar_enthalpy_of_adsorption` getters to pores and adsorption isotherms. [#135](https://github.com/feos-org/feos/pull/135)

--- a/feos-dft/Cargo.toml
+++ b/feos-dft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feos-dft"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Philipp Rehner <prehner@ethz.ch>", "Gernot Bauer <bauer@itt.uni-stuttgart.de>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This includes the necessary changes for the release of
- `feos-core` 0.4.1
- `feos-dft` 0.4.1
- `feos` 0.4.2

For the Rust crate itself, the release of `feos` is meaningless. However, the current system uses the same semver version for both the `feos` crate and Python package (which is good). Therefore, the new release is necessary.