### PR TITLE
Revive phi in hetero gc PC-SAFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed the internal implementation of the association contribution to accomodate more general association schemes. [#150](https://github.com/feos-org/feos/pull/150)
 - To comply with the new association implementation, the default values of `na` and `nb` are now `0` rather than `1`. Parameter files have been adapted accordingly. [#150](https://github.com/feos-org/feos/pull/150)
+- Added the possibility to specify a pure component correction parameter `phi` for the heterosegmented gc PC-SAFT equation of state. [#157](https://github.com/feos-org/feos/pull/157)
 
 ## [0.4.3] - 2023-03-20
 - Python only: Release the changes introduced in `feos-core` 0.4.2.

--- a/src/gc_pcsaft/python/mod.rs
+++ b/src/gc_pcsaft/python/mod.rs
@@ -95,6 +95,10 @@ impl_parameter_from_segments!(GcPcSaftEosParameters, PyGcPcSaftEosParameters);
 
 #[pymethods]
 impl PyGcPcSaftEosParameters {
+    fn phi(&self, phi: Vec<f64>) -> PyResult<Self> {
+        Ok(Self(Arc::new((*self.0).clone().phi(&phi)?)))
+    }
+
     fn _repr_markdown_(&self) -> String {
         self.0.to_markdown()
     }


### PR DESCRIPTION
The $\varphi_i$ parameter in gc PC-SAFT corrects the model to obtain accurate pure component vapor pressures.