### PR TITLE
Make constructors in Parameter trait fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Adjusted all model's implementation of `Parameter` which now requires `Result`s in some methods. [#161](https://github.com/feos-org/feos/pull/161)
+
 ## [0.4.3] - 2023-03-20
 - Python only: Release the changes introduced in `feos-core` 0.4.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Adjusted all model's implementation of `Parameter` which now requires `Result`s in some methods. [#161](https://github.com/feos-org/feos/pull/161)
+- Adjusted all models' implementation of the `Parameter` trait which now requires `Result`s in some methods. [#161](https://github.com/feos-org/feos/pull/161)
 
 ## [0.4.3] - 2023-03-20
 - Python only: Release the changes introduced in `feos-core` 0.4.2.

--- a/benches/contributions.rs
+++ b/benches/contributions.rs
@@ -70,7 +70,8 @@ fn pcsaft(c: &mut Criterion) {
     let moles = arr1(&[1.0, 1.0]) * MOL;
     for comp1 in &[hexane, acetone, co2, ethanol] {
         for comp2 in [&heptane, &dme, &acetylene, &propanol] {
-            let params = PcSaftParameters::new_binary(vec![comp1.clone(), comp2.clone()], None);
+            let params =
+                PcSaftParameters::new_binary(vec![comp1.clone(), comp2.clone()], None).unwrap();
             let eos = Arc::new(PcSaft::new(Arc::new(params)));
             let state = State::new_npt(&eos, t, p, &moles, DensityInitialization::Liquid).unwrap();
             let state_hd = state.derive1(Derivative::DT);

--- a/benches/dual_numbers.rs
+++ b/benches/dual_numbers.rs
@@ -117,7 +117,8 @@ fn methane_co2_pcsaft(c: &mut Criterion) {
     )
     .unwrap();
     let k_ij = -0.0192211646;
-    let parameters = PcSaftParameters::new_binary(parameters.pure_records, Some(k_ij.into()));
+    let parameters =
+        PcSaftParameters::new_binary(parameters.pure_records, Some(k_ij.into())).unwrap();
     let eos = Arc::new(PcSaft::new(Arc::new(parameters)));
 
     // 230 K, 50 bar, x0 = 0.15

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new functions `isenthalpic_compressibility`, `thermal_expansivity` and `grueneisen_parameter` to `State`. [#154](https://github.com/feos-org/feos/pull/154)
 
+### Changed
+- Changed constructors of `Parameter` trait to return `Result`s. [#161](https://github.com/feos-org/feos/pull/161)
+
 ## [0.4.2] - 2023-04-03
 ### Fixed
 - Fixed a wrong reference state in the implementation of the Peng-Robinson equation of state. [#151](https://github.com/feos-org/feos/pull/151)

--- a/feos-core/src/python/parameter.rs
+++ b/feos-core/src/python/parameter.rs
@@ -602,7 +602,7 @@ macro_rules! impl_parameter {
                             &prs,
                             &brs,
                             search_option,
-                        ))
+                        )?)
                     } else {
                         Err(PyErr::new::<PyTypeError, _>(format!(
                             "Could not parse binary input!"
@@ -611,13 +611,13 @@ macro_rules! impl_parameter {
                     Ok(Self(Arc::new(<$parameter>::from_records(
                         prs,
                         brs.unwrap(),
-                    ))))
+                    )?)))
                 } else {
                     let n = prs.len();
                     Ok(Self(Arc::new(<$parameter>::from_records(
                         prs,
                         Array2::from_elem([n, n], <$parameter as Parameter>::Binary::default()),
-                    ))))
+                    )?)))
                 }
             }
 
@@ -628,8 +628,8 @@ macro_rules! impl_parameter {
             /// pure_record : PureRecord
             ///     The pure component parameters.
             #[staticmethod]
-            fn new_pure(pure_record: PyPureRecord) -> Self {
-                Self(Arc::new(<$parameter>::new_pure(pure_record.0)))
+            fn new_pure(pure_record: PyPureRecord) -> PyResult<Self> {
+                Ok(Self(Arc::new(<$parameter>::new_pure(pure_record.0)?)))
             }
 
             /// Creates parameters for a binary system from pure records and an optional
@@ -661,7 +661,7 @@ macro_rules! impl_parameter {
                         }
                     })
                     .transpose()?;
-                Ok(Self(Arc::new(<$parameter>::new_binary(prs, br))))
+                Ok(Self(Arc::new(<$parameter>::new_binary(prs, br)?)))
             }
 
             /// Creates parameters from json files.

--- a/feos-core/src/python/user_defined.rs
+++ b/feos-core/src/python/user_defined.rs
@@ -2,11 +2,11 @@ use crate::{EquationOfState, HelmholtzEnergy, HelmholtzEnergyDual, MolarWeight, 
 use ndarray::Array1;
 use num_dual::*;
 use numpy::convert::IntoPyArray;
-use numpy::{PyReadonlyArrayDyn, PyArray};
+use numpy::{PyArray, PyReadonlyArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use quantity::python::PySIArray1;
-use quantity::si::{SIArray1};
+use quantity::si::SIArray1;
 use std::fmt;
 
 struct PyHelmholtzEnergy(Py<PyAny>);
@@ -212,12 +212,7 @@ impl_dual_state_helmholtz_energy!(
     Dual<DualVec64<3>, f64>,
     PyDualVec3
 );
-impl_dual_state_helmholtz_energy!(
-    PyStateHD,
-    PyHyperDual64,
-    HyperDual64,
-    f64
-);
+impl_dual_state_helmholtz_energy!(PyStateHD, PyHyperDual64, HyperDual64, f64);
 impl_dual_state_helmholtz_energy!(PyStateD2, PyDual2_64, Dual2_64, f64);
 impl_dual_state_helmholtz_energy!(PyStateD3, PyDual3_64, Dual3_64, f64);
 impl_dual_state_helmholtz_energy!(PyStateHDD, PyHyperDualDual64, HyperDual<Dual64, f64>, PyDual64);

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -376,7 +376,7 @@ mod tests_pcsaft {
     use crate::pcsaft::parameters::utils::water_parameters;
     use crate::pcsaft::PcSaftParameters;
     use approx::assert_relative_eq;
-    use feos_core::parameter::Parameter;
+    use feos_core::parameter::{Parameter, ParameterError};
 
     #[test]
     fn helmholtz_energy() {
@@ -403,13 +403,13 @@ mod tests_pcsaft {
     }
 
     #[test]
-    fn helmholtz_energy_cross_3b() {
+    fn helmholtz_energy_cross_3b() -> Result<(), ParameterError> {
         let mut params = water_parameters();
         let mut record = params.pure_records.pop().unwrap();
         let mut association_record = record.model_record.association_record.unwrap();
         association_record.na = Some(2.0);
         record.model_record.association_record = Some(association_record);
-        let params = Arc::new(PcSaftParameters::new_pure(record));
+        let params = Arc::new(PcSaftParameters::new_pure(record)?);
         let assoc = Association::new(&params, &params.association, 50, 1e-10);
         let cross_assoc =
             Association::new_cross_association(&params, &params.association, 50, 1e-10);
@@ -420,6 +420,7 @@ mod tests_pcsaft {
         let a_assoc = assoc.helmholtz_energy(&s) / n;
         let a_cross_assoc = cross_assoc.helmholtz_energy(&s) / n;
         assert_relative_eq!(a_assoc, a_cross_assoc, epsilon = 1e-10);
+        Ok(())
     }
 }
 

--- a/src/pcsaft/parameters.rs
+++ b/src/pcsaft/parameters.rs
@@ -304,7 +304,7 @@ impl Parameter for PcSaftParameters {
     fn from_records(
         pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
         binary_records: Array2<PcSaftBinaryRecord>,
-    ) -> Self {
+    ) -> Result<Self, ParameterError> {
         let n = pure_records.len();
 
         let mut molarweight = Array::zeros(n);
@@ -404,7 +404,7 @@ impl Parameter for PcSaftParameters {
             .map(|r| r.ideal_gas_record.clone())
             .collect();
 
-        Self {
+        Ok(Self {
             molarweight,
             m,
             sigma,
@@ -428,7 +428,7 @@ impl Parameter for PcSaftParameters {
             pure_records,
             binary_records,
             joback_records,
-        }
+        })
     }
 
     fn records(
@@ -549,7 +549,7 @@ pub mod utils {
             }"#;
         let propane_record: PureRecord<PcSaftRecord, JobackRecord> =
             serde_json::from_str(propane_json).expect("Unable to parse json.");
-        Arc::new(PcSaftParameters::new_pure(propane_record))
+        Arc::new(PcSaftParameters::new_pure(propane_record).unwrap())
     }
 
     pub fn carbon_dioxide_parameters() -> PcSaftParameters {
@@ -573,7 +573,7 @@ pub mod utils {
         }"#;
         let co2_record: PureRecord<PcSaftRecord, JobackRecord> =
             serde_json::from_str(co2_json).expect("Unable to parse json.");
-        PcSaftParameters::new_pure(co2_record)
+        PcSaftParameters::new_pure(co2_record).unwrap()
     }
 
     pub fn butane_parameters() -> Arc<PcSaftParameters> {
@@ -596,7 +596,7 @@ pub mod utils {
             }"#;
         let butane_record: PureRecord<PcSaftRecord, JobackRecord> =
             serde_json::from_str(butane_json).expect("Unable to parse json.");
-        Arc::new(PcSaftParameters::new_pure(butane_record))
+        Arc::new(PcSaftParameters::new_pure(butane_record).unwrap())
     }
 
     pub fn dme_parameters() -> PcSaftParameters {
@@ -620,7 +620,7 @@ pub mod utils {
             }"#;
         let dme_record: PureRecord<PcSaftRecord, JobackRecord> =
             serde_json::from_str(dme_json).expect("Unable to parse json.");
-        PcSaftParameters::new_pure(dme_record)
+        PcSaftParameters::new_pure(dme_record).unwrap()
     }
 
     pub fn water_parameters() -> PcSaftParameters {
@@ -645,7 +645,7 @@ pub mod utils {
             }"#;
         let water_record: PureRecord<PcSaftRecord, JobackRecord> =
             serde_json::from_str(water_json).expect("Unable to parse json.");
-        PcSaftParameters::new_pure(water_record)
+        PcSaftParameters::new_pure(water_record).unwrap()
     }
 
     pub fn dme_co2_parameters() -> PcSaftParameters {
@@ -687,7 +687,7 @@ pub mod utils {
         ]"#;
         let binary_record: Vec<PureRecord<PcSaftRecord, JobackRecord>> =
             serde_json::from_str(binary_json).expect("Unable to parse json.");
-        PcSaftParameters::new_binary(binary_record, None)
+        PcSaftParameters::new_binary(binary_record, None).unwrap()
     }
 
     pub fn propane_butane_parameters() -> Arc<PcSaftParameters> {
@@ -732,7 +732,7 @@ pub mod utils {
         ]"#;
         let binary_record: Vec<PureRecord<PcSaftRecord, JobackRecord>> =
             serde_json::from_str(binary_json).expect("Unable to parse json.");
-        Arc::new(PcSaftParameters::new_binary(binary_record, None))
+        Arc::new(PcSaftParameters::new_binary(binary_record, None).unwrap())
     }
 
     #[test]

--- a/src/pets/parameters.rs
+++ b/src/pets/parameters.rs
@@ -1,6 +1,6 @@
 use crate::hard_sphere::{HardSphereProperties, MonomerShape};
 use feos_core::joback::JobackRecord;
-use feos_core::parameter::{Parameter, PureRecord};
+use feos_core::parameter::{Parameter, ParameterError, PureRecord};
 use ndarray::{Array, Array1, Array2};
 use num_dual::DualNum;
 use num_traits::Zero;
@@ -134,7 +134,7 @@ impl Parameter for PetsParameters {
     fn from_records(
         pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
         binary_records: Array2<PetsBinaryRecord>,
-    ) -> Self {
+    ) -> Result<Self, ParameterError> {
         let n = pure_records.len();
 
         let mut molarweight = Array::zeros(n);
@@ -205,7 +205,7 @@ impl Parameter for PetsParameters {
             .map(|r| r.ideal_gas_record.clone())
             .collect();
 
-        Self {
+        Ok(Self {
             molarweight,
             sigma,
             epsilon_k,
@@ -219,7 +219,7 @@ impl Parameter for PetsParameters {
             pure_records,
             joback_records,
             binary_records,
-        }
+        })
     }
 
     fn records(
@@ -310,7 +310,7 @@ pub mod utils {
             }"#;
         let argon_record: PureRecord<PetsRecord, JobackRecord> =
             serde_json::from_str(argon_json).expect("Unable to parse json.");
-        Arc::new(PetsParameters::new_pure(argon_record))
+        Arc::new(PetsParameters::new_pure(argon_record).unwrap())
     }
 
     pub fn krypton_parameters() -> Arc<PetsParameters> {
@@ -332,7 +332,7 @@ pub mod utils {
             }"#;
         let krypton_record: PureRecord<PetsRecord, JobackRecord> =
             serde_json::from_str(krypton_json).expect("Unable to parse json.");
-        Arc::new(PetsParameters::new_pure(krypton_record))
+        Arc::new(PetsParameters::new_pure(krypton_record).unwrap())
     }
 
     pub fn argon_krypton_parameters() -> Arc<PetsParameters> {
@@ -376,6 +376,6 @@ pub mod utils {
         ]"#;
         let binary_record: Vec<PureRecord<PetsRecord, JobackRecord>> =
             serde_json::from_str(binary_json).expect("Unable to parse json.");
-        Arc::new(PetsParameters::new_binary(binary_record, None))
+        Arc::new(PetsParameters::new_binary(binary_record, None).unwrap())
     }
 }

--- a/src/pets/python.rs
+++ b/src/pets/python.rs
@@ -194,7 +194,7 @@ impl PyPetsParameters {
         Ok(Self(Arc::new(PetsParameters::from_records(
             pure_records,
             binary,
-        ))))
+        )?)))
     }
 
     // Create a set of PeTS parameters from values.
@@ -227,7 +227,7 @@ impl PyPetsParameters {
         viscosity: Option<[f64; 4]>,
         diffusion: Option<[f64; 5]>,
         thermal_conductivity: Option<[f64; 4]>,
-    ) -> Self {
+    ) -> PyResult<Self> {
         let pure_record = PureRecord::new(
             Identifier::new(
                 Some(format!("{}", 1).as_str()),
@@ -241,7 +241,7 @@ impl PyPetsParameters {
             PetsRecord::new(sigma, epsilon_k, viscosity, diffusion, thermal_conductivity),
             None,
         );
-        Self(Arc::new(PetsParameters::new_pure(pure_record)))
+        Ok(Self(Arc::new(PetsParameters::new_pure(pure_record)?)))
     }
 
     #[getter]

--- a/src/python/dft.rs
+++ b/src/python/dft.rs
@@ -33,7 +33,7 @@ use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
 #[cfg(feature = "estimator")]
 use pyo3::wrap_pymodule;
-use quantity::python::{PySINumber, PySIArray1, PySIArray2, PySIArray3, PySIArray4};
+use quantity::python::{PySIArray1, PySIArray2, PySIArray3, PySIArray4, PySINumber};
 use quantity::si::*;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/python/eos.rs
+++ b/src/python/eos.rs
@@ -36,7 +36,7 @@ use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
 #[cfg(feature = "estimator")]
 use pyo3::wrap_pymodule;
-use quantity::python::{PySINumber, PySIArray1, PySIArray2};
+use quantity::python::{PySIArray1, PySIArray2, PySINumber};
 use quantity::si::*;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/saftvrqmie/parameters.rs
+++ b/src/saftvrqmie/parameters.rs
@@ -147,7 +147,7 @@ impl Parameter for SaftVRQMieParameters {
     fn from_records(
         pure_records: Vec<PureRecord<Self::Pure, Self::IdealGas>>,
         binary_records: Array2<SaftVRQMieBinaryRecord>,
-    ) -> Self {
+    ) -> Result<Self, ParameterError> {
         let n = pure_records.len();
 
         let mut molarweight = Array::zeros(n);
@@ -240,7 +240,7 @@ impl Parameter for SaftVRQMieParameters {
             .map(|r| r.ideal_gas_record.clone())
             .collect();
 
-        Self {
+        Ok(Self {
             molarweight,
             m,
             sigma,
@@ -262,7 +262,7 @@ impl Parameter for SaftVRQMieParameters {
             pure_records,
             binary_records,
             joback_records,
-        }
+        })
     }
 
     fn records(
@@ -433,7 +433,7 @@ pub mod utils {
             }"#;
         let hydrogen_record: PureRecord<SaftVRQMieRecord, JobackRecord> =
             serde_json::from_str(hydrogen_json).expect("Unable to parse json.");
-        Arc::new(SaftVRQMieParameters::new_pure(hydrogen_record))
+        Arc::new(SaftVRQMieParameters::new_pure(hydrogen_record).unwrap())
     }
 
     #[allow(dead_code)]
@@ -459,7 +459,7 @@ pub mod utils {
             }"#;
         let helium_record: PureRecord<SaftVRQMieRecord, JobackRecord> =
             serde_json::from_str(helium_json).expect("Unable to parse json.");
-        Arc::new(SaftVRQMieParameters::new_pure(helium_record))
+        Arc::new(SaftVRQMieParameters::new_pure(helium_record).unwrap())
     }
 
     #[allow(dead_code)]
@@ -485,7 +485,7 @@ pub mod utils {
             }"#;
         let neon_record: PureRecord<SaftVRQMieRecord, JobackRecord> =
             serde_json::from_str(neon_json).expect("Unable to parse json.");
-        Arc::new(SaftVRQMieParameters::new_pure(neon_record))
+        Arc::new(SaftVRQMieParameters::new_pure(neon_record).unwrap())
     }
 
     pub fn h2_ne_fh1() -> Arc<SaftVRQMieParameters> {
@@ -529,12 +529,15 @@ pub mod utils {
         ]"#;
         let binary_record: Vec<PureRecord<SaftVRQMieRecord, JobackRecord>> =
             serde_json::from_str(binary_json).expect("Unable to parse json.");
-        Arc::new(SaftVRQMieParameters::new_binary(
-            binary_record,
-            Some(SaftVRQMieBinaryRecord {
-                k_ij: 0.105,
-                l_ij: 0.0,
-            }),
-        ))
+        Arc::new(
+            SaftVRQMieParameters::new_binary(
+                binary_record,
+                Some(SaftVRQMieBinaryRecord {
+                    k_ij: 0.105,
+                    l_ij: 0.0,
+                }),
+            )
+            .unwrap(),
+        )
     }
 }

--- a/src/uvtheory/eos/mod.rs
+++ b/src/uvtheory/eos/mod.rs
@@ -183,7 +183,7 @@ mod test {
     fn helmholtz_energy_pure_wca() -> EosResult<()> {
         let sig = 3.7039;
         let eps_k = 150.03;
-        let parameters = UVParameters::new_simple(24.0, 6.0, sig, eps_k);
+        let parameters = UVParameters::new_simple(24.0, 6.0, sig, eps_k)?;
         let eos = Arc::new(UVTheory::new(Arc::new(parameters))?);
 
         let reduced_temperature = 4.0;
@@ -206,7 +206,7 @@ mod test {
         let sig = 3.7039;
         let rep = 24.0;
         let att = 6.0;
-        let parameters = UVParameters::new_simple(rep, att, sig, eps_k);
+        let parameters = UVParameters::new_simple(rep, att, sig, eps_k)?;
         let options = UVTheoryOptions {
             max_eta: 0.5,
             perturbation: Perturbation::BarkerHenderson,
@@ -236,7 +236,7 @@ mod test {
         let sig = 3.7039;
         let rep = 12.0;
         let att = 6.0;
-        let parameters = UVParameters::new_simple(rep, att, sig, eps_k);
+        let parameters = UVParameters::new_simple(rep, att, sig, eps_k)?;
         let options = UVTheoryOptions {
             max_eta: 0.5,
             perturbation: Perturbation::WeeksChandlerAndersen,
@@ -279,7 +279,7 @@ mod test {
         let pr1 = PureRecord::new(i, 1.0, r1, None);
         let pr2 = PureRecord::new(j, 1.0, r2, None);
         let pure_records = vec![pr1, pr2];
-        let uv_parameters = UVParameters::new_binary(pure_records, None);
+        let uv_parameters = UVParameters::new_binary(pure_records, None)?;
         // state
         let reduced_temperature = 4.0;
         let eps_k_x = (eps_k1 + eps_k2) / 2.0; // Check rule!!

--- a/src/uvtheory/python.rs
+++ b/src/uvtheory/python.rs
@@ -81,7 +81,12 @@ impl PyUVParameters {
     /// UVParameters
     #[pyo3(text_signature = "(rep, att, sigma, epsilon_k)")]
     #[staticmethod]
-    fn from_lists(rep: Vec<f64>, att: Vec<f64>, sigma: Vec<f64>, epsilon_k: Vec<f64>) -> Self {
+    fn from_lists(
+        rep: Vec<f64>,
+        att: Vec<f64>,
+        sigma: Vec<f64>,
+        epsilon_k: Vec<f64>,
+    ) -> PyResult<Self> {
         let n = rep.len();
         let pure_records = (0..n)
             .map(|i| {
@@ -98,7 +103,10 @@ impl PyUVParameters {
             })
             .collect();
         let binary = Array2::from_shape_fn((n, n), |(_, _)| UVBinaryRecord { k_ij: 0.0 });
-        Self(Arc::new(UVParameters::from_records(pure_records, binary)))
+        Ok(Self(Arc::new(UVParameters::from_records(
+            pure_records,
+            binary,
+        )?)))
     }
 
     /// Create UV Theory parameters for pure substance.
@@ -123,10 +131,10 @@ impl PyUVParameters {
     /// Molar weight is one. No ideal gas contribution is considered.
     #[pyo3(text_signature = "(rep, att, sigma, epsilon_k)")]
     #[staticmethod]
-    fn new_simple(rep: f64, att: f64, sigma: f64, epsilon_k: f64) -> Self {
-        Self(Arc::new(UVParameters::new_simple(
+    fn new_simple(rep: f64, att: f64, sigma: f64, epsilon_k: f64) -> PyResult<Self> {
+        Ok(Self(Arc::new(UVParameters::new_simple(
             rep, att, sigma, epsilon_k,
-        )))
+        )?)))
     }
 }
 


### PR DESCRIPTION
Changes return types for constructor methods of `Parameter` to results. This is useful for parameters that contain assertions or have multiple, incompatible variants. Existing assertions/unwraps in implemented parameters have not been changed in this PR.

Since `Parameter::subset` is called on parameters that are usually created via the (now fallible) constructors, the method still returns the parameters without a results to keep the interfaces for property calculations clean. Added `panic` section to the doc strings.