### PR TITLE
Optional binary records and new parameter constructor

### DIFF
--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `Components`, `Residual`, `IdealGas` and `DeBroglieWavelength` traits to decouple ideal gas models from residual models. [#158](https://github.com/feos-org/feos/pull/158)
 - Added `JobackParameters` struct that implements `Parameters` including Python bindings. [#158](https://github.com/feos-org/feos/pull/158)
+- Added `Parameter::from_model_records` as a simpler interface to generate parameters.  [#169](https://github.com/feos-org/feos/pull/169)
 
 ### Changed
 - Changed `EquationOfState` from a trait to a `struct` that is generic over `Residual` and `IdealGas` and implements all necessary traits to be used as equation of state including the ideal gas contribution. [#158](https://github.com/feos-org/feos/pull/158)
@@ -19,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `StateVec` into own file and module. [#158](https://github.com/feos-org/feos/pull/158)
 - Ideal gas and residual Helmholtz energy models can now be separately implemented in Python via the `PyIdealGas` and `PyResidual` structs. [#158](https://github.com/feos-org/feos/pull/158)
 - Bubble and dew point iterations will not attempt a second iteration if no solution is found for the given initial pressure. [#166](https://github.com/feos-org/feos/pull/166)
+- Made the binary records in the constructions and getters of the `Parameter` trait optional. [#169](https://github.com/feos-org/feos/pull/169)
+- Changed the second argument of `new_binary` in Python from a `BinaryRecord` to the corresponding binary model record (analogous to the Rust implementation). [#169](https://github.com/feos-org/feos/pull/169)
 
 ### Removed
 - Removed `EquationOfState` trait. [#158](https://github.com/feos-org/feos/pull/158)

--- a/feos-core/src/joback.rs
+++ b/feos-core/src/joback.rs
@@ -72,7 +72,6 @@ pub struct JobackParameters {
     d: Array1<f64>,
     e: Array1<f64>,
     pure_records: Vec<PureRecord<JobackRecord>>,
-    binary_records: Array2<JobackBinaryRecord>,
 }
 
 impl Parameter for JobackParameters {
@@ -81,11 +80,10 @@ impl Parameter for JobackParameters {
 
     fn from_records(
         pure_records: Vec<PureRecord<Self::Pure>>,
-        _binary_records: Array2<Self::Binary>,
+        _binary_records: Option<Array2<Self::Binary>>,
     ) -> Self {
         let n = pure_records.len();
 
-        let binary_records = Array::from_elem((n, n), JobackBinaryRecord);
         let mut a = Array::zeros(n);
         let mut b = Array::zeros(n);
         let mut c = Array::zeros(n);
@@ -108,12 +106,11 @@ impl Parameter for JobackParameters {
             d,
             e,
             pure_records,
-            binary_records,
         }
     }
 
-    fn records(&self) -> (&[PureRecord<Self::Pure>], &Array2<Self::Binary>) {
-        (&self.pure_records, &self.binary_records)
+    fn records(&self) -> (&[PureRecord<Self::Pure>], Option<&Array2<Self::Binary>>) {
+        (&self.pure_records, None)
     }
 }
 
@@ -188,11 +185,7 @@ impl Components for Joback {
         component_list
             .iter()
             .for_each(|&i| records.push(self.parameters.pure_records[i].clone()));
-        let n = component_list.len();
-        Self::new(Arc::new(JobackParameters::from_records(
-            records,
-            Array::from_elem((n, n), JobackBinaryRecord),
-        )))
+        Self::new(Arc::new(JobackParameters::from_records(records, None)))
     }
 }
 

--- a/feos-core/src/lib.rs
+++ b/feos-core/src/lib.rs
@@ -202,7 +202,6 @@ mod tests {
     use crate::EosResult;
     use crate::StateBuilder;
     use approx::*;
-    use ndarray::Array2;
     use quantity::si::*;
     use std::sync::Arc;
 
@@ -248,7 +247,7 @@ mod tests {
     fn validate_residual_properties() -> EosResult<()> {
         let mixture = pure_record_vec();
         let propane = mixture[0].clone();
-        let parameters = PengRobinsonParameters::from_records(vec![propane], Array2::zeros((1, 1)));
+        let parameters = PengRobinsonParameters::new_pure(propane);
         let residual = Arc::new(PengRobinson::new(Arc::new(parameters)));
         let joback_parameters = Arc::new(JobackParameters::new_pure(PureRecord::new(
             Identifier::default(),

--- a/feos-core/src/python/cubic.rs
+++ b/feos-core/src/python/cubic.rs
@@ -58,7 +58,8 @@ pub struct PyPengRobinsonParameters(pub Arc<PengRobinsonParameters>);
 impl_parameter!(
     PengRobinsonParameters,
     PyPengRobinsonParameters,
-    PyPengRobinsonRecord
+    PyPengRobinsonRecord,
+    f64
 );
 
 #[pymethods]

--- a/feos-core/src/python/cubic.rs
+++ b/feos-core/src/python/cubic.rs
@@ -4,7 +4,6 @@ use crate::parameter::{
 };
 use crate::python::parameter::PyIdentifier;
 use crate::*;
-use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -56,7 +55,11 @@ impl_binary_record!();
 #[derive(Clone)]
 pub struct PyPengRobinsonParameters(pub Arc<PengRobinsonParameters>);
 
-impl_parameter!(PengRobinsonParameters, PyPengRobinsonParameters);
+impl_parameter!(
+    PengRobinsonParameters,
+    PyPengRobinsonParameters,
+    PyPengRobinsonRecord
+);
 
 #[pymethods]
 impl PyPengRobinsonParameters {

--- a/feos-core/src/python/joback.rs
+++ b/feos-core/src/python/joback.rs
@@ -7,7 +7,6 @@ use crate::{
     impl_binary_record, impl_json_handling, impl_parameter, impl_parameter_from_segments,
     impl_pure_record, impl_segment_record,
 };
-use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -62,6 +61,7 @@ impl_segment_record!(JobackRecord, PyJobackRecord);
 pub struct PyJobackBinaryRecord(pub JobackBinaryRecord);
 
 impl_binary_record!(JobackBinaryRecord, PyJobackBinaryRecord);
+
 /// Create a set of Joback parameters from records.
 ///
 /// Parameters
@@ -83,7 +83,7 @@ impl_binary_record!(JobackBinaryRecord, PyJobackBinaryRecord);
 #[derive(Clone)]
 pub struct PyJobackParameters(pub Arc<JobackParameters>);
 
-impl_parameter!(JobackParameters, PyJobackParameters);
+impl_parameter!(JobackParameters, PyJobackParameters, PyJobackRecord);
 impl_parameter_from_segments!(JobackParameters, PyJobackParameters);
 
 #[pymethods]

--- a/feos-core/src/python/joback.rs
+++ b/feos-core/src/python/joback.rs
@@ -83,7 +83,12 @@ impl_binary_record!(JobackBinaryRecord, PyJobackBinaryRecord);
 #[derive(Clone)]
 pub struct PyJobackParameters(pub Arc<JobackParameters>);
 
-impl_parameter!(JobackParameters, PyJobackParameters, PyJobackRecord);
+impl_parameter!(
+    JobackParameters,
+    PyJobackParameters,
+    PyJobackRecord,
+    PyJobackBinaryRecord
+);
 impl_parameter_from_segments!(JobackParameters, PyJobackParameters);
 
 #[pymethods]

--- a/feos-core/src/python/parameter.rs
+++ b/feos-core/src/python/parameter.rs
@@ -201,6 +201,12 @@ macro_rules! impl_binary_record {
         #[derive(Clone)]
         pub struct PyBinaryRecord(pub BinaryRecord<Identifier, $model_record>);
 
+        impl From<$py_model_record> for $model_record {
+            fn from(record: $py_model_record) -> Self {
+                record.0
+            }
+        }
+
         #[pymethods]
         impl PyBinaryRecord {
             #[new]
@@ -540,7 +546,7 @@ macro_rules! impl_segment_record {
 
 #[macro_export]
 macro_rules! impl_parameter {
-    ($parameter:ty, $py_parameter:ty, $py_model_record:ty) => {
+    ($parameter:ty, $py_parameter:ty, $py_model_record:ty, $py_binary_model_record:ty) => {
         #[pymethods]
         impl $py_parameter {
             /// Creates parameters from records.
@@ -618,8 +624,8 @@ macro_rules! impl_parameter {
                     .map(|br| {
                         if let Ok(r) = br.extract::<f64>() {
                             Ok(r.try_into()?)
-                        } else if let Ok(r) = br.extract::<PyBinaryRecord>() {
-                            Ok(r.0.model_record)
+                        } else if let Ok(r) = br.extract::<$py_binary_model_record>() {
+                            Ok(r.into())
                         } else {
                             Err(PyErr::new::<PyTypeError, _>(format!(
                                 "Could not parse binary input!"

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -176,7 +176,12 @@ impl_binary_record!(PcSaftBinaryRecord, PyPcSaftBinaryRecord);
 #[derive(Clone)]
 pub struct PyPcSaftParameters(pub Arc<PcSaftParameters>);
 
-impl_parameter!(PcSaftParameters, PyPcSaftParameters, PyPcSaftRecord);
+impl_parameter!(
+    PcSaftParameters,
+    PyPcSaftParameters,
+    PyPcSaftRecord,
+    PyPcSaftBinaryRecord
+);
 impl_parameter_from_segments!(PcSaftParameters, PyPcSaftParameters);
 
 #[pymethods]

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -6,7 +6,6 @@ use feos_core::parameter::{
 };
 use feos_core::python::parameter::*;
 use feos_core::*;
-use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -177,14 +176,17 @@ impl_binary_record!(PcSaftBinaryRecord, PyPcSaftBinaryRecord);
 #[derive(Clone)]
 pub struct PyPcSaftParameters(pub Arc<PcSaftParameters>);
 
-impl_parameter!(PcSaftParameters, PyPcSaftParameters);
+impl_parameter!(PcSaftParameters, PyPcSaftParameters, PyPcSaftRecord);
 impl_parameter_from_segments!(PcSaftParameters, PyPcSaftParameters);
 
 #[pymethods]
 impl PyPcSaftParameters {
     #[getter]
-    fn get_k_ij<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
-        self.0.k_ij.view().to_pyarray(py)
+    fn get_k_ij<'py>(&self, py: Python<'py>) -> Option<&'py PyArray2<f64>> {
+        self.0
+            .binary_records
+            .as_ref()
+            .map(|br| br.map(|br| br.k_ij).view().to_pyarray(py))
     }
 
     fn _repr_markdown_(&self) -> String {

--- a/src/pets/parameters.rs
+++ b/src/pets/parameters.rs
@@ -2,7 +2,6 @@ use crate::hard_sphere::{HardSphereProperties, MonomerShape};
 use feos_core::parameter::{Parameter, PureRecord};
 use ndarray::{Array, Array1, Array2};
 use num_dual::DualNum;
-use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -104,7 +103,7 @@ pub struct PetsParameters {
     /// Lennard-Jones energy parameter in Kelvin
     pub epsilon_k: Array1<f64>,
     /// binary interaction parameter
-    pub k_ij: Array2<f64>,
+    pub k_ij: Option<Array2<f64>>,
     /// diameter matrix
     pub sigma_ij: Array2<f64>,
     /// energy parameter matrix including k_ij
@@ -120,7 +119,7 @@ pub struct PetsParameters {
     /// records of all pure substances of the system
     pub pure_records: Vec<PureRecord<PetsRecord>>,
     /// records of all binary interaction parameters
-    pub binary_records: Array2<PetsBinaryRecord>,
+    pub binary_records: Option<Array2<PetsBinaryRecord>>,
 }
 
 impl Parameter for PetsParameters {
@@ -129,7 +128,7 @@ impl Parameter for PetsParameters {
 
     fn from_records(
         pure_records: Vec<PureRecord<Self::Pure>>,
-        binary_records: Array2<PetsBinaryRecord>,
+        binary_records: Option<Array2<PetsBinaryRecord>>,
     ) -> Self {
         let n = pure_records.len();
 
@@ -153,16 +152,18 @@ impl Parameter for PetsParameters {
             molarweight[i] = record.molarweight;
         }
 
-        let k_ij = binary_records.map(|br| br.k_ij);
-        let mut epsilon_k_ij = Array::zeros((n, n));
+        let k_ij = binary_records.as_ref().map(|br| br.map(|br| br.k_ij));
         let mut sigma_ij = Array::zeros((n, n));
         let mut e_k_ij = Array::zeros((n, n));
         for i in 0..n {
             for j in 0..n {
                 e_k_ij[[i, j]] = (epsilon_k[i] * epsilon_k[j]).sqrt();
-                epsilon_k_ij[[i, j]] = (1.0 - k_ij[[i, j]]) * e_k_ij[[i, j]];
                 sigma_ij[[i, j]] = 0.5 * (sigma[i] + sigma[j]);
             }
+        }
+        let mut epsilon_k_ij = e_k_ij.clone();
+        if let Some(k_ij) = k_ij.as_ref() {
+            epsilon_k_ij *= &(1.0 - k_ij);
         }
 
         let viscosity_coefficients = if viscosity.iter().any(|v| v.is_none()) {
@@ -212,8 +213,8 @@ impl Parameter for PetsParameters {
         }
     }
 
-    fn records(&self) -> (&[PureRecord<PetsRecord>], &Array2<PetsBinaryRecord>) {
-        (&self.pure_records, &self.binary_records)
+    fn records(&self) -> (&[PureRecord<PetsRecord>], Option<&Array2<PetsBinaryRecord>>) {
+        (&self.pure_records, self.binary_records.as_ref())
     }
 }
 
@@ -260,8 +261,8 @@ impl std::fmt::Display for PetsParameters {
         write!(f, "\n\tmolarweight={}", self.molarweight)?;
         write!(f, "\n\tsigma={}", self.sigma)?;
         write!(f, "\n\tepsilon_k={}", self.epsilon_k)?;
-        if !self.k_ij.iter().all(|k| k.is_zero()) {
-            write!(f, "\n\tk_ij=\n{}", self.k_ij)?;
+        if let Some(k_ij) = self.k_ij.as_ref() {
+            write!(f, "\n\tk_ij=\n{}", k_ij)?;
         }
         write!(f, "\n)")
     }

--- a/src/pets/python.rs
+++ b/src/pets/python.rs
@@ -250,7 +250,12 @@ impl PyPetsParameters {
     }
 }
 
-impl_parameter!(PetsParameters, PyPetsParameters, PyPetsRecord);
+impl_parameter!(
+    PetsParameters,
+    PyPetsParameters,
+    PyPetsRecord,
+    PyPetsBinaryRecord
+);
 
 #[pymodule]
 pub fn pets(_py: Python<'_>, m: &PyModule) -> PyResult<()> {

--- a/src/pets/python.rs
+++ b/src/pets/python.rs
@@ -2,7 +2,6 @@ use super::parameters::*;
 use feos_core::parameter::*;
 use feos_core::python::parameter::*;
 use feos_core::{impl_binary_record, impl_json_handling, impl_parameter, impl_pure_record};
-use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
@@ -183,10 +182,7 @@ impl PyPetsParameters {
             })
             .collect();
 
-        let binary = match k_ij {
-            Some(v) => v.to_owned_array().mapv(f64::into),
-            None => Array2::from_shape_fn((n, n), |(_, _)| PetsBinaryRecord::from(0.0)),
-        };
+        let binary = k_ij.map(|v| v.to_owned_array().mapv(f64::into));
 
         Ok(Self(Arc::new(PetsParameters::from_records(
             pure_records,
@@ -241,8 +237,8 @@ impl PyPetsParameters {
     }
 
     #[getter]
-    fn get_k_ij<'py>(&self, py: Python<'py>) -> &'py PyArray2<f64> {
-        self.0.k_ij.view().to_pyarray(py)
+    fn get_k_ij<'py>(&self, py: Python<'py>) -> Option<&'py PyArray2<f64>> {
+        self.0.k_ij.as_ref().map(|k| k.view().to_pyarray(py))
     }
 
     fn _repr_markdown_(&self) -> String {
@@ -254,7 +250,7 @@ impl PyPetsParameters {
     }
 }
 
-impl_parameter!(PetsParameters, PyPetsParameters);
+impl_parameter!(PetsParameters, PyPetsParameters, PyPetsRecord);
 
 #[pymodule]
 pub fn pets(_py: Python<'_>, m: &PyModule) -> PyResult<()> {

--- a/src/saftvrqmie/python.rs
+++ b/src/saftvrqmie/python.rs
@@ -8,7 +8,6 @@ use feos_core::parameter::{
 };
 use feos_core::python::parameter::PyIdentifier;
 use feos_core::*;
-use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::{PyIOError, PyTypeError};
 use pyo3::prelude::*;
@@ -147,7 +146,11 @@ pub struct PySaftVRQMieParameters(pub Arc<SaftVRQMieParameters>);
 impl_json_handling!(PySaftVRQMieRecord);
 impl_pure_record!(SaftVRQMieRecord, PySaftVRQMieRecord);
 impl_binary_record!(SaftVRQMieBinaryRecord, PySaftVRQMieBinaryRecord);
-impl_parameter!(SaftVRQMieParameters, PySaftVRQMieParameters);
+impl_parameter!(
+    SaftVRQMieParameters,
+    PySaftVRQMieParameters,
+    PySaftVRQMieRecord
+);
 
 #[pymethods]
 impl PySaftVRQMieParameters {
@@ -206,7 +209,7 @@ impl PySaftVRQMieParameters {
     ) -> PyResult<()> {
         self.0
             .lammps_tables(temperature.into(), n, r_min.into(), r_max.into())
-            .map_err(|e| PyIOError::new_err(e))
+            .map_err(PyIOError::new_err)
     }
 
     fn _repr_markdown_(&self) -> String {

--- a/src/saftvrqmie/python.rs
+++ b/src/saftvrqmie/python.rs
@@ -149,7 +149,8 @@ impl_binary_record!(SaftVRQMieBinaryRecord, PySaftVRQMieBinaryRecord);
 impl_parameter!(
     SaftVRQMieParameters,
     PySaftVRQMieParameters,
-    PySaftVRQMieRecord
+    PySaftVRQMieRecord,
+    PySaftVRQMieBinaryRecord
 );
 
 #[pymethods]

--- a/src/uvtheory/parameters.rs
+++ b/src/uvtheory/parameters.rs
@@ -111,7 +111,7 @@ pub struct UVParameters {
     pub sigma: Array1<f64>,
     pub epsilon_k: Array1<f64>,
     pub molarweight: Array1<f64>,
-    pub k_ij: Array2<f64>,
+    pub k_ij: Option<Array2<f64>>,
     pub rep_ij: Array2<f64>,
     pub att_ij: Array2<f64>,
     pub sigma_ij: Array2<f64>,
@@ -119,7 +119,7 @@ pub struct UVParameters {
     pub cd_bh_pure: Vec<Array1<f64>>,
     pub cd_bh_binary: Array2<Array1<f64>>,
     pub pure_records: Vec<PureRecord<UVRecord>>,
-    pub binary_records: Array2<UVBinaryRecord>,
+    pub binary_records: Option<Array2<UVBinaryRecord>>,
 }
 
 impl Parameter for UVParameters {
@@ -128,7 +128,7 @@ impl Parameter for UVParameters {
 
     fn from_records(
         pure_records: Vec<PureRecord<Self::Pure>>,
-        binary_records: Array2<Self::Binary>,
+        binary_records: Option<Array2<Self::Binary>>,
     ) -> Self {
         let n = pure_records.len();
 
@@ -154,7 +154,7 @@ impl Parameter for UVParameters {
         let mut att_ij = Array2::zeros((n, n));
         let mut sigma_ij = Array2::zeros((n, n));
         let mut eps_k_ij = Array2::zeros((n, n));
-        let k_ij = binary_records.map(|br| br.k_ij);
+        let k_ij = binary_records.as_ref().map(|br| br.map(|br| br.k_ij));
 
         for i in 0..n {
             rep_ij[[i, i]] = rep[i];
@@ -168,7 +168,8 @@ impl Parameter for UVParameters {
                 att_ij[[j, i]] = att_ij[[i, j]];
                 sigma_ij[[i, j]] = 0.5 * (sigma[i] + sigma[j]);
                 sigma_ij[[j, i]] = sigma_ij[[i, j]];
-                eps_k_ij[[i, j]] = (1.0 - k_ij[[i, j]]) * (epsilon_k[i] * epsilon_k[j]).sqrt();
+                eps_k_ij[[i, j]] = (1.0 - k_ij.as_ref().map_or(0.0, |k_ij| k_ij[[i, j]]))
+                    * (epsilon_k[i] * epsilon_k[j]).sqrt();
                 eps_k_ij[[j, i]] = eps_k_ij[[i, j]];
             }
         }
@@ -197,8 +198,8 @@ impl Parameter for UVParameters {
         }
     }
 
-    fn records(&self) -> (&[PureRecord<UVRecord>], &Array2<UVBinaryRecord>) {
-        (&self.pure_records, &self.binary_records)
+    fn records(&self) -> (&[PureRecord<UVRecord>], Option<&Array2<UVBinaryRecord>>) {
+        (&self.pure_records, self.binary_records.as_ref())
     }
 }
 

--- a/src/uvtheory/python.rs
+++ b/src/uvtheory/python.rs
@@ -5,7 +5,6 @@ use feos_core::parameter::{
 };
 use feos_core::python::parameter::*;
 use feos_core::*;
-use ndarray::Array2;
 use numpy::{PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -97,8 +96,7 @@ impl PyUVParameters {
                 PureRecord::new(identifier, 1.0, model_record)
             })
             .collect();
-        let binary = Array2::from_shape_fn((n, n), |(_, _)| UVBinaryRecord { k_ij: 0.0 });
-        Self(Arc::new(UVParameters::from_records(pure_records, binary)))
+        Self(Arc::new(UVParameters::from_records(pure_records, None)))
     }
 
     /// Create UV Theory parameters for pure substance.
@@ -131,7 +129,7 @@ impl PyUVParameters {
 }
 
 impl_pure_record!(UVRecord, PyUVRecord);
-impl_parameter!(UVParameters, PyUVParameters);
+impl_parameter!(UVParameters, PyUVParameters, PyUVRecord);
 
 #[pymodule]
 pub fn uvtheory(_py: Python<'_>, m: &PyModule) -> PyResult<()> {

--- a/src/uvtheory/python.rs
+++ b/src/uvtheory/python.rs
@@ -129,7 +129,7 @@ impl PyUVParameters {
 }
 
 impl_pure_record!(UVRecord, PyUVRecord);
-impl_parameter!(UVParameters, PyUVParameters, PyUVRecord);
+impl_parameter!(UVParameters, PyUVParameters, PyUVRecord, PyUVBinaryRecord);
 
 #[pymodule]
 pub fn uvtheory(_py: Python<'_>, m: &PyModule) -> PyResult<()> {


### PR DESCRIPTION
This PR comprises of two changes:

- The `binary_records` in `Parameter::from_records` is made optional. This removes some boilerplate from models that do not use binary interaction parameters at all (ideal gas models and pure component models). If the models have a GC method, they still need a custom struct for binary records to implement all necessary traits.
- A new constructor `Parameter::from_model_records` is added that internally creates the `PureRecord`s using defaults for molarweight and identifier, and does not use binary records. This is necessary, because at the moment, it is not possible to create `JobackParameters` from records in Python, since there is no appropriate `PureRecord` around.