### PR TITLE
Non orthogonal dft

### DIFF
--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -35,6 +35,7 @@ typenum = "1.16"
 approx = "0.4"
 regex = "1.9"
 once_cell = "1.18"
+ang = "0.6"
 
 [features]
 default = []

--- a/feos-core/src/si/mod.rs
+++ b/feos-core/src/si/mod.rs
@@ -1,3 +1,4 @@
+use ang::{Angle, Degrees, Radians};
 use num_traits::Zero;
 use std::marker::PhantomData;
 use std::ops::{Div, Mul};
@@ -139,6 +140,11 @@ pub const GRAM: Mass<f64> = Quantity(1e-3, PhantomData);
 pub const HOUR: Time<f64> = Quantity(3600.0, PhantomData);
 pub const LITER: Volume<f64> = Quantity(1e-3, PhantomData);
 pub const MINUTE: Time<f64> = Quantity(60.0, PhantomData);
+
+/// Angle unit radian $\\left(\text{rad}\\right)$
+pub const RADIANS: Angle = Radians(1.0);
+/// Angle unit degree $\\left(1^\\circ=\frac{\pi}{180}\\,\text{rad}\\approx 0.0174532925\\,\text{rad}\\right)$
+pub const DEGREES: Angle = Degrees(1.0);
 
 /// Boltzmann constant $\\left(k_\text{B}=1.380649\times 10^{-23}\\,\\frac{\text{J}}{\text{K}}\\right)$
 pub const KB: Entropy<f64> = Quantity(1.380649e-23, PhantomData);

--- a/feos-dft/CHANGELOG.md
+++ b/feos-dft/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Implemented `HelmholtzEnergyFunctional` for `EquationOfState` to be able to use functionals as equations of state. [#158](https://github.com/feos-org/feos/pull/158) 
+- Implemented `HelmholtzEnergyFunctional` for `EquationOfState` to be able to use functionals as equations of state. [#158](https://github.com/feos-org/feos/pull/158)
+- Added the possibility to specify the angles of non-orthorombic unit cells. Currently, the external potential must be specified if non-orthorombic unit cells are calculated. [#176](https://github.com/feos-org/feos/pull/176)
 
 ### Changed
 - `HelmholtzEnergyFunctional`: added `Components` trait as trait bound and removed `ideal_gas` method. [#158](https://github.com/feos-org/feos/pull/158)
@@ -17,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed `DefaultIdealGasContribution` [#158](https://github.com/feos-org/feos/pull/158)
 - Removed getters for `chemical_potential` (for profiles) and `molar_gibbs_energy` (for `Adsorption1D` and `Adsorption3D`) from Python interface. [#158](https://github.com/feos-org/feos/pull/158)
+
+### Fixed
+- Added an error, if the unit cells in 3D DFT are too small and violate the minimum image convention. [#176](https://github.com/feos-org/feos/pull/176)
 
 ### Packaging
 - Updated `num-dual` dependency to 0.7. [#137](https://github.com/feos-org/feos/pull/137)

--- a/feos-dft/src/adsorption/mod.rs
+++ b/feos-dft/src/adsorption/mod.rs
@@ -14,8 +14,10 @@ mod external_potential;
 #[cfg(feature = "rayon")]
 mod fea_potential;
 mod pore;
+mod pore2d;
 pub use external_potential::{ExternalPotential, FluidParameters};
 pub use pore::{Pore1D, PoreProfile, PoreProfile1D, PoreSpecification};
+pub use pore2d::{Pore2D, PoreProfile2D};
 
 #[cfg(feature = "rayon")]
 mod pore3d;

--- a/feos-dft/src/adsorption/mod.rs
+++ b/feos-dft/src/adsorption/mod.rs
@@ -214,7 +214,7 @@ where
                 _ => unreachable!(),
             };
         }
-        let profile = pore.initialize(&bulk, None, None).solve(solver)?.profile;
+        let profile = pore.initialize(&bulk, None, None)?.solve(solver)?.profile;
         let external_potential = Some(&profile.external_potential);
         let mut old_density = Some(&profile.density);
 
@@ -231,8 +231,8 @@ where
                     .clone();
             }
 
-            let p = pore.initialize(&bulk, old_density, external_potential);
-            let p2 = pore.initialize(&bulk, None, external_potential);
+            let p = pore.initialize(&bulk, old_density, external_potential)?;
+            let p2 = pore.initialize(&bulk, None, external_potential)?;
             profiles.push(p.solve(solver).or_else(|_| p2.solve(solver)));
 
             old_density = if let Some(Ok(l)) = profiles.last() {
@@ -279,8 +279,8 @@ where
             .vapor()
             .build()?;
 
-        let mut vapor = pore.initialize(&vapor_bulk, None, None).solve(solver)?;
-        let mut liquid = pore.initialize(&bulk_init, None, None).solve(solver)?;
+        let mut vapor = pore.initialize(&vapor_bulk, None, None)?.solve(solver)?;
+        let mut liquid = pore.initialize(&bulk_init, None, None)?.solve(solver)?;
 
         // calculate initial value for bulk density
         let n_dp_drho_v = (vapor.profile.moles() * vapor_bulk.dp_drho(Contributions::Total)).sum();

--- a/feos-dft/src/adsorption/pore.rs
+++ b/feos-dft/src/adsorption/pore.rs
@@ -53,7 +53,7 @@ pub trait PoreSpecification<D: Dimension> {
         bulk: &State<DFT<F>>,
         density: Option<&Density<Array<f64, D::Larger>>>,
         external_potential: Option<&Array<f64, D::Larger>>,
-    ) -> PoreProfile<D, F>;
+    ) -> EosResult<PoreProfile<D, F>>;
 
     /// Return the pore volume using Helium at 298 K as reference.
     fn pore_volume(&self) -> EosResult<Volume<f64>>
@@ -64,7 +64,7 @@ pub trait PoreSpecification<D: Dimension> {
             .temperature(298.0 * KELVIN)
             .density(Density::from_reduced(1.0))
             .build()?;
-        let pore = self.initialize(&bulk, None, None);
+        let pore = self.initialize(&bulk, None, None)?;
         let pot = Dimensionless::from_reduced(
             pore.profile
                 .external_potential
@@ -151,7 +151,7 @@ impl PoreSpecification<Ix1> for Pore1D {
         bulk: &State<DFT<F>>,
         density: Option<&Density<Array2<f64>>>,
         external_potential: Option<&Array2<f64>>,
-    ) -> PoreProfile1D<F> {
+    ) -> EosResult<PoreProfile1D<F>> {
         let dft: &F = &bulk.eos;
         let n_grid = self.n_grid.unwrap_or(DEFAULT_GRID_POINTS);
 
@@ -191,11 +191,11 @@ impl PoreSpecification<Ix1> for Pore1D {
         let weight_functions = dft.weight_functions(t);
         let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
-        PoreProfile {
+        Ok(PoreProfile {
             profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), density),
             grand_potential: None,
             interfacial_tension: None,
-        }
+        })
     }
 }
 

--- a/feos-dft/src/adsorption/pore2d.rs
+++ b/feos-dft/src/adsorption/pore2d.rs
@@ -1,0 +1,53 @@
+use super::{FluidParameters, PoreProfile, PoreSpecification};
+use crate::{Axis, ConvolverFFT, DFTProfile, Grid, HelmholtzEnergyFunctional, DFT};
+use ang::Angle;
+use feos_core::si::{Density, Length};
+use feos_core::State;
+use ndarray::{Array3, Ix2};
+
+pub struct Pore2D {
+    system_size: [Length<f64>; 2],
+    angle: Angle,
+    n_grid: [usize; 2],
+}
+
+pub type PoreProfile2D<F> = PoreProfile<Ix2, F>;
+
+impl Pore2D {
+    pub fn new(system_size: [Length<f64>; 2], angle: Angle, n_grid: [usize; 2]) -> Self {
+        Self {
+            system_size,
+            angle,
+            n_grid,
+        }
+    }
+}
+
+impl PoreSpecification<Ix2> for Pore2D {
+    fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
+        &self,
+        bulk: &State<DFT<F>>,
+        density: Option<&Density<Array3<f64>>>,
+        external_potential: Option<&Array3<f64>>,
+    ) -> PoreProfile<Ix2, F> {
+        let dft: &F = &bulk.eos;
+
+        // generate grid
+        let x = Axis::new_cartesian(self.n_grid[0], self.system_size[0], None);
+        let y = Axis::new_cartesian(self.n_grid[1], self.system_size[1], None);
+
+        // temperature
+        let t = bulk.temperature.to_reduced();
+
+        // initialize convolver
+        let grid = Grid::Periodical2(x, y, self.angle);
+        let weight_functions = dft.weight_functions(t);
+        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
+
+        PoreProfile {
+            profile: DFTProfile::new(grid, convolver, bulk, external_potential.cloned(), density),
+            grand_potential: None,
+            interfacial_tension: None,
+        }
+    }
+}

--- a/feos-dft/src/adsorption/pore2d.rs
+++ b/feos-dft/src/adsorption/pore2d.rs
@@ -2,7 +2,7 @@ use super::{FluidParameters, PoreProfile, PoreSpecification};
 use crate::{Axis, ConvolverFFT, DFTProfile, Grid, HelmholtzEnergyFunctional, DFT};
 use ang::Angle;
 use feos_core::si::{Density, Length};
-use feos_core::State;
+use feos_core::{EosResult, State};
 use ndarray::{Array3, Ix2};
 
 pub struct Pore2D {
@@ -29,7 +29,7 @@ impl PoreSpecification<Ix2> for Pore2D {
         bulk: &State<DFT<F>>,
         density: Option<&Density<Array3<f64>>>,
         external_potential: Option<&Array3<f64>>,
-    ) -> PoreProfile<Ix2, F> {
+    ) -> EosResult<PoreProfile<Ix2, F>> {
         let dft: &F = &bulk.eos;
 
         // generate grid
@@ -44,10 +44,10 @@ impl PoreSpecification<Ix2> for Pore2D {
         let weight_functions = dft.weight_functions(t);
         let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
-        PoreProfile {
+        Ok(PoreProfile {
             profile: DFTProfile::new(grid, convolver, bulk, external_potential.cloned(), density),
             grand_potential: None,
             interfacial_tension: None,
-        }
+        })
     }
 }

--- a/feos-dft/src/adsorption/pore3d.rs
+++ b/feos-dft/src/adsorption/pore3d.rs
@@ -4,6 +4,7 @@ use crate::convolver::ConvolverFFT;
 use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::{Axis, Grid};
 use crate::profile::{DFTProfile, CUTOFF_RADIUS, MAX_POTENTIAL};
+use ang::Angle;
 use feos_core::si::{Density, Length};
 use feos_core::State;
 use ndarray::prelude::*;
@@ -12,6 +13,7 @@ use ndarray::Zip;
 /// Parameters required to specify a 3D pore.
 pub struct Pore3D {
     system_size: [Length<f64>; 3],
+    angles: [Angle; 3],
     n_grid: [usize; 3],
     coordinates: Length<Array2<f64>>,
     sigma_ss: Array1<f64>,
@@ -23,6 +25,7 @@ pub struct Pore3D {
 impl Pore3D {
     pub fn new(
         system_size: [Length<f64>; 3],
+        angles: [Angle; 3],
         n_grid: [usize; 3],
         coordinates: Length<Array2<f64>>,
         sigma_ss: Array1<f64>,
@@ -32,6 +35,7 @@ impl Pore3D {
     ) -> Self {
         Self {
             system_size,
+            angles,
             n_grid,
             coordinates,
             sigma_ss,
@@ -86,7 +90,7 @@ impl PoreSpecification<Ix3> for Pore3D {
         );
 
         // initialize convolver
-        let grid = Grid::Periodical3(x, y, z);
+        let grid = Grid::Periodical3(x, y, z, self.angles);
         let weight_functions = dft.weight_functions(t);
         let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 

--- a/feos-dft/src/adsorption/pore3d.rs
+++ b/feos-dft/src/adsorption/pore3d.rs
@@ -5,15 +5,15 @@ use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::{Axis, Grid};
 use crate::profile::{DFTProfile, CUTOFF_RADIUS, MAX_POTENTIAL};
 use ang::Angle;
-use feos_core::si::{Density, Length};
-use feos_core::State;
+use feos_core::si::{Density, Length, DEGREES};
+use feos_core::{EosError, EosResult, State};
 use ndarray::prelude::*;
 use ndarray::Zip;
 
 /// Parameters required to specify a 3D pore.
 pub struct Pore3D {
     system_size: [Length<f64>; 3],
-    angles: [Angle; 3],
+    angles: Option<[Angle; 3]>,
     n_grid: [usize; 3],
     coordinates: Length<Array2<f64>>,
     sigma_ss: Array1<f64>,
@@ -25,7 +25,7 @@ pub struct Pore3D {
 impl Pore3D {
     pub fn new(
         system_size: [Length<f64>; 3],
-        angles: [Angle; 3],
+        angles: Option<[Angle; 3]>,
         n_grid: [usize; 3],
         coordinates: Length<Array2<f64>>,
         sigma_ss: Array1<f64>,
@@ -55,7 +55,7 @@ impl PoreSpecification<Ix3> for Pore3D {
         bulk: &State<DFT<F>>,
         density: Option<&Density<Array4<f64>>>,
         external_potential: Option<&Array4<f64>>,
-    ) -> PoreProfile3D<F> {
+    ) -> EosResult<PoreProfile3D<F>> {
         let dft: &F = &bulk.eos;
 
         // generate grid
@@ -63,13 +63,18 @@ impl PoreSpecification<Ix3> for Pore3D {
         let y = Axis::new_cartesian(self.n_grid[1], self.system_size[1], None);
         let z = Axis::new_cartesian(self.n_grid[2], self.system_size[2], None);
 
-        // move center of geometry of solute to box center
-        let coordinates = Array2::from_shape_fn(self.coordinates.raw_dim(), |(i, j)| {
-            (self.coordinates.get((i, j))).to_reduced()
-        });
+        let coordinates = self.coordinates.to_reduced();
 
         // temperature
         let t = bulk.temperature.to_reduced();
+
+        // For non-orthorombic unit cells, the external potential has to be
+        // provided at the moment
+        if let (Some(_), None) = (self.angles, external_potential) {
+            return Err(EosError::UndeterminedState(
+                "For non-orthorombic unit cells, the external potential has to provided!".into(),
+            ));
+        }
 
         // calculate external potential
         let external_potential = external_potential.map_or_else(
@@ -86,19 +91,19 @@ impl PoreSpecification<Ix3> for Pore3D {
                     t,
                 )
             },
-            |e| e.clone(),
-        );
+            |e| Ok(e.clone()),
+        )?;
 
         // initialize convolver
-        let grid = Grid::Periodical3(x, y, z, self.angles);
+        let grid = Grid::Periodical3(x, y, z, self.angles.unwrap_or([90.0 * DEGREES; 3]));
         let weight_functions = dft.weight_functions(t);
         let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
-        PoreProfile {
+        Ok(PoreProfile {
             profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), density),
             grand_potential: None,
             interfacial_tension: None,
-        }
+        })
     }
 }
 
@@ -112,7 +117,7 @@ pub fn external_potential_3d<F: FluidParameters>(
     cutoff_radius: Option<Length<f64>>,
     potential_cutoff: Option<f64>,
     reduced_temperature: f64,
-) -> Array4<f64> {
+) -> EosResult<Array4<f64>> {
     // allocate external potential
     let m = functional.m();
     let mut external_potential = Array4::zeros((
@@ -131,6 +136,12 @@ pub fn external_potential_3d<F: FluidParameters>(
     let cutoff_radius = cutoff_radius
         .unwrap_or(Length::from_reduced(CUTOFF_RADIUS))
         .to_reduced();
+
+    if system_size.iter().any(|&s| s < 2.0 * cutoff_radius) {
+        return Err(EosError::UndeterminedState(
+            "The unit cell is smaller than 2*cutoff".into(),
+        ));
+    }
 
     // square cut-off radius
     let cutoff_radius2 = cutoff_radius.powi(2);
@@ -167,7 +178,7 @@ pub fn external_potential_3d<F: FluidParameters>(
         }
     });
 
-    external_potential
+    Ok(external_potential)
 }
 
 /// Evaluate LJ12-6 potential between solid site "alpha" and fluid segment

--- a/feos-dft/src/convolver/mod.rs
+++ b/feos-dft/src/convolver/mod.rs
@@ -146,10 +146,12 @@ where
                 CurvilinearConvolver::new(r, &[z], weight_functions, lanczos)
             }
             Grid::Cartesian2(x, y) => Self::new(Some(x), &[y], weight_functions, lanczos),
-            Grid::Periodical2(x, y) => PeriodicConvolver::new(&[x, y], weight_functions, lanczos),
+            Grid::Periodical2(x, y, alpha) => {
+                PeriodicConvolver::new_2d(&[x, y], *alpha, weight_functions, lanczos)
+            }
             Grid::Cartesian3(x, y, z) => Self::new(Some(x), &[y, z], weight_functions, lanczos),
-            Grid::Periodical3(x, y, z) => {
-                PeriodicConvolver::new(&[x, y, z], weight_functions, lanczos)
+            Grid::Periodical3(x, y, z, angles) => {
+                PeriodicConvolver::new_3d(&[x, y, z], *angles, weight_functions, lanczos)
             }
         }
     }

--- a/feos-dft/src/geometry.rs
+++ b/feos-dft/src/geometry.rs
@@ -63,7 +63,7 @@ impl Grid {
         match &self {
             Self::Periodical2(_, _, alpha) => alpha.sin(),
             Self::Periodical3(_, _, _, [alpha, beta, gamma]) => {
-                let xi = alpha.cos() - gamma.cos() * beta.cos() / gamma.sin();
+                let xi = (alpha.cos() - gamma.cos() * beta.cos()) / gamma.sin();
                 gamma.sin() * (1.0 - beta.cos().powi(2) - xi * xi).sqrt()
             }
             _ => 1.0,

--- a/feos-dft/src/interface/mod.rs
+++ b/feos-dft/src/interface/mod.rs
@@ -192,7 +192,7 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
     }
 
     /// Relative adsorption of component `i' with respect to `j': \Gamma_i^(j)
-    pub fn relative_adsorption(&self) -> EosResult<Moles<Array2<f64>>> {
+    pub fn relative_adsorption(&self) -> Moles<Array2<f64>> {
         let s = self.profile.density.shape();
         let mut rho_l = Density::zeros(s[0]);
         let mut rho_v = Density::zeros(s[0]);
@@ -204,7 +204,7 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
         }
 
         // Calculate \Gamma_i^(j)
-        let gamma = Moles::from_shape_fn((s[0], s[0]), |(i, j)| {
+        Moles::from_shape_fn((s[0], s[0]), |(i, j)| {
             if i == j {
                 Moles::from_reduced(0.0)
             } else {
@@ -216,28 +216,24 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
                                 / (rho_l.get(i) - rho_v.get(i)))),
                 )
             }
-        });
-
-        Ok(gamma)
+        })
     }
 
     /// Interfacial enrichment of component `i': E_i
-    pub fn interfacial_enrichment(&self) -> EosResult<Array1<f64>> {
+    pub fn interfacial_enrichment(&self) -> Array1<f64> {
         let s = self.profile.density.shape();
         let density = self.profile.density.to_reduced();
         let rho_l = density.index_axis(Axis_nd(1), 0);
         let rho_v = density.index_axis(Axis_nd(1), s[1] - 1);
 
-        let enrichment = Array1::from_shape_fn(s[0], |i| {
+        Array1::from_shape_fn(s[0], |i| {
             *(density
                 .index_axis(Axis_nd(0), i)
                 .iter()
                 .max_by(|&a, &b| a.total_cmp(b))
                 .unwrap())  // panics only of iterator is empty
                 / rho_l[i].max(rho_v[i])
-        });
-
-        Ok(enrichment)
+        })
     }
 
     /// Interface thickness (90-10 number density difference)

--- a/feos-dft/src/interface/surface_tension_diagram.rs
+++ b/feos-dft/src/interface/surface_tension_diagram.rs
@@ -84,14 +84,14 @@ impl<F: HelmholtzEnergyFunctional> SurfaceTensionDiagram<F> {
     pub fn relative_adsorption(&self) -> Vec<Moles<Array2<f64>>> {
         self.profiles
             .iter()
-            .map(|planar_interf| planar_interf.relative_adsorption().unwrap())
+            .map(|planar_interf| planar_interf.relative_adsorption())
             .collect()
     }
 
     pub fn interfacial_enrichment(&self) -> Vec<Array1<f64>> {
         self.profiles
             .iter()
-            .map(|planar_interf| planar_interf.interfacial_enrichment().unwrap())
+            .map(|planar_interf| planar_interf.interfacial_enrichment())
             .collect()
     }
 

--- a/feos-dft/src/profile/mod.rs
+++ b/feos-dft/src/profile/mod.rs
@@ -2,9 +2,11 @@ use crate::convolver::{BulkConvolver, Convolver};
 use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::Grid;
 use crate::solver::{DFTSolver, DFTSolverLog};
-use feos_core::si::{Density, Length, Moles, Quantity, Temperature, Volume, _Volume};
+use feos_core::si::{Density, Length, Moles, Quantity, Temperature, Volume, _Volume, DEGREES};
 use feos_core::{Components, EosError, EosResult, State};
-use ndarray::{Array, Array1, ArrayBase, Axis as Axis_nd, Data, Dimension, Ix1, Ix2, Ix3};
+use ndarray::{
+    Array, Array1, Array2, Array3, ArrayBase, Axis as Axis_nd, Data, Dimension, Ix1, Ix2, Ix3,
+};
 use std::ops::{Add, MulAssign};
 use std::sync::Arc;
 use typenum::Sum;
@@ -124,6 +126,19 @@ impl<F> DFTProfile<Ix2, F> {
         ]
     }
 
+    pub fn meshgrid(&self) -> [Length<Array2<f64>>; 2] {
+        let (u, v, alpha) = match &self.grid {
+            Grid::Cartesian2(u, v) => (u, v, 90.0 * DEGREES),
+            Grid::Periodical2(u, v, alpha) => (u, v, *alpha),
+            _ => unreachable!(),
+        };
+        let u_grid = Array::from_shape_fn([u.grid.len(), v.grid.len()], |(i, _)| u.grid[i]);
+        let v_grid = Array::from_shape_fn([u.grid.len(), v.grid.len()], |(_, j)| v.grid[j]);
+        let x = Length::from_reduced(u_grid + &v_grid * alpha.cos());
+        let y = Length::from_reduced(v_grid * alpha.sin());
+        [x, y]
+    }
+
     pub fn r(&self) -> Length<Array1<f64>> {
         Length::from_reduced(self.grid.grids()[0].to_owned())
     }
@@ -140,6 +155,24 @@ impl<F> DFTProfile<Ix3, F> {
             Length::from_reduced(self.grid.axes()[1].edges.to_owned()),
             Length::from_reduced(self.grid.axes()[2].edges.to_owned()),
         ]
+    }
+
+    pub fn meshgrid(&self) -> [Length<Array3<f64>>; 3] {
+        let (u, v, w, [alpha, beta, gamma]) = match &self.grid {
+            Grid::Cartesian3(u, v, w) => (u, v, w, [90.0 * DEGREES; 3]),
+            Grid::Periodical3(u, v, w, angles) => (u, v, w, *angles),
+            _ => unreachable!(),
+        };
+        let shape = [u.grid.len(), v.grid.len(), w.grid.len()];
+        let u_grid = Array::from_shape_fn(shape, |(i, _, _)| u.grid[i]);
+        let v_grid = Array::from_shape_fn(shape, |(_, j, _)| v.grid[j]);
+        let w_grid = Array::from_shape_fn(shape, |(_, _, k)| w.grid[k]);
+        let xi = (alpha.cos() - gamma.cos() * beta.cos()) / gamma.sin();
+        let zeta = (1.0 - beta.cos().powi(2) - xi * xi).sqrt();
+        let x = Length::from_reduced(u_grid + &v_grid * gamma.cos() + &w_grid * beta.cos());
+        let y = Length::from_reduced(v_grid * gamma.sin() + &w_grid * xi);
+        let z = Length::from_reduced(w_grid * zeta);
+        [x, y, z]
     }
 
     pub fn x(&self) -> Length<Array1<f64>> {
@@ -215,14 +248,14 @@ where
     }
 
     fn integrate_reduced(&self, mut profile: Array<f64, D>) -> f64 {
-        let integration_weights = self.grid.integration_weights();
+        let (integration_weights, functional_determinant) = self.grid.integration_weights();
 
         for (i, w) in integration_weights.into_iter().enumerate() {
             for mut l in profile.lanes_mut(Axis_nd(i)) {
                 l.mul_assign(w);
             }
         }
-        profile.sum()
+        profile.sum() * functional_determinant
     }
 
     fn integrate_reduced_comp(&self, profile: &Array<f64, D::Larger>) -> Array1<f64> {
@@ -233,9 +266,10 @@ where
 
     /// Return the volume of the profile.
     ///
-    /// Depending on the geometry, the result is in m, m² or m³.
+    /// In periodic directions, the length is assumed to be 1 Å.
     pub fn volume(&self) -> Volume<f64> {
-        Volume::from_reduced(self.grid.axes().iter().map(|ax| ax.volume()).product())
+        let volume: f64 = self.grid.axes().iter().map(|ax| ax.volume()).product();
+        Volume::from_reduced(volume * self.grid.functional_determinant())
     }
 
     /// Integrate a given profile over the iteration domain.
@@ -246,14 +280,14 @@ where
     where
         _Volume: Add<U>,
     {
-        let integration_weights = self.grid.integration_weights();
+        let (integration_weights, functional_determinant) = self.grid.integration_weights();
         let mut value = profile.to_owned();
         for (i, &w) in integration_weights.iter().enumerate() {
             for mut l in value.lanes_mut(Axis_nd(i)) {
                 l.assign(&(&l * w));
             }
         }
-        Volume::from_reduced(1.0) * value.sum()
+        Volume::from_reduced(functional_determinant) * value.sum()
     }
 
     /// Integrate each component individually.

--- a/feos-dft/src/python/adsorption/pore.rs
+++ b/feos-dft/src/python/adsorption/pore.rs
@@ -76,7 +76,7 @@ macro_rules! impl_pore {
                     &bulk.0,
                     density.map(|d| d.try_into()).transpose()?.as_ref(),
                     external_potential.map(|e| e.to_owned_array()).as_ref(),
-                )))
+                )?))
             }
 
             #[getter]
@@ -185,7 +185,7 @@ macro_rules! impl_pore {
                     &bulk.0,
                     density.map(|d| d.try_into()).transpose()?.as_ref(),
                     external_potential.map(|e| e.to_owned_array()).as_ref(),
-                )))
+                )?))
             }
 
             /// The pore volume using Helium at 298 K as reference.
@@ -224,6 +224,9 @@ macro_rules! impl_pore {
         /// ----------
         /// system_size : [SINumber; 3]
         ///     The size of the unit cell.
+        /// angles : [Angle; 3]
+        ///     The angles of the unit cell or `None` if the unit cell
+        ///     is orthorombic
         /// n_grid : [int; 3]
         ///     The number of grid points in each direction.
         /// coordinates : numpy.ndarray[float]
@@ -242,7 +245,7 @@ macro_rules! impl_pore {
         /// Pore3D
         ///
         #[pyclass(name = "Pore3D")]
-        #[pyo3(text_signature = "(system_size, n_grid, coordinates, sigma_ss, epsilon_k_ss, potential_cutoff=None, cutoff_radius=None)")]
+        #[pyo3(text_signature = "(system_size, angles, n_grid, coordinates, sigma_ss, epsilon_k_ss, potential_cutoff=None, cutoff_radius=None)")]
         pub struct PyPore3D(Pore3D);
 
         #[pyclass(name = "PoreProfile3D")]
@@ -255,7 +258,7 @@ macro_rules! impl_pore {
             #[new]
             fn new(
                 system_size: [PySINumber; 3],
-                angles: [PyAngle; 3],
+                angles: Option<[PyAngle; 3]>,
                 n_grid: [usize; 3],
                 coordinates: PySIArray2,
                 sigma_ss: &PyArray1<f64>,
@@ -265,7 +268,7 @@ macro_rules! impl_pore {
             ) -> PyResult<Self> {
                 Ok(Self(Pore3D::new(
                     [system_size[0].try_into()?, system_size[1].try_into()?, system_size[2].try_into()?],
-                    [angles[0].into(), angles[1].into(), angles[2].into()],
+                    angles.map(|angles| [angles[0].into(), angles[1].into(), angles[2].into()]),
                     n_grid,
                     coordinates.try_into()?,
                     sigma_ss.to_owned_array(),
@@ -302,7 +305,7 @@ macro_rules! impl_pore {
                     &bulk.0,
                     density.map(|d| d.try_into()).transpose()?.as_ref(),
                     external_potential.map(|e| e.to_owned_array()).as_ref(),
-                )))
+                )?))
             }
 
             /// The pore volume using Helium at 298 K as reference.

--- a/feos-dft/src/python/adsorption/pore.rs
+++ b/feos-dft/src/python/adsorption/pore.rs
@@ -134,6 +134,90 @@ macro_rules! impl_pore {
             }
         }
 
+        #[pyclass(name = "Pore2D")]
+        #[pyo3(text_signature = "(geometry, pore_size, potential, n_grid=None, potential_cutoff=None)")]
+        pub struct PyPore2D(Pore2D);
+
+        #[pyclass(name = "PoreProfile2D")]
+        pub struct PyPoreProfile2D(PoreProfile2D<$func>);
+
+        impl_2d_profile!(PyPoreProfile2D, get_x, get_y);
+
+        #[pymethods]
+        impl PyPore2D {
+            #[new]
+            fn new(
+                system_size: [PySINumber; 2],
+                angle: PyAngle,
+                n_grid: [usize; 2],
+            ) -> PyResult<Self> {
+                Ok(Self(Pore2D::new(
+                    [system_size[0].try_into()?, system_size[1].try_into()?],
+                    angle.into(),
+                    n_grid,
+                )))
+            }
+
+            /// Initialize the pore for the given bulk state.
+            ///
+            /// Parameters
+            /// ----------
+            /// bulk : State
+            ///     The bulk state in equilibrium with the pore.
+            /// density : SIArray3, optional
+            ///     Initial values for the density profile.
+            /// external_potential : numpy.ndarray[float], optional
+            ///     The external potential in the pore. Used to
+            ///     save computation time in the case of costly
+            ///     evaluations of external potentials.
+            ///
+            /// Returns
+            /// -------
+            /// PoreProfile2D
+            #[pyo3(text_signature = "($self, bulk, density=None, external_potential=None)")]
+            fn initialize(
+                &self,
+                bulk: &PyState,
+                density: Option<PySIArray3>,
+                external_potential: Option<&PyArray3<f64>>,
+            ) -> PyResult<PyPoreProfile2D> {
+                Ok(PyPoreProfile2D(self.0.initialize(
+                    &bulk.0,
+                    density.map(|d| d.try_into()).transpose()?.as_ref(),
+                    external_potential.map(|e| e.to_owned_array()).as_ref(),
+                )))
+            }
+
+            /// The pore volume using Helium at 298 K as reference.
+            #[getter]
+            fn get_pore_volume(&self) -> PyResult<PySINumber> {
+                Ok(self.0.pore_volume()?.into())
+            }
+        }
+
+        #[pymethods]
+        impl PyPoreProfile2D {
+            #[getter]
+            fn get_grand_potential(&self) -> Option<PySINumber> {
+                self.0.grand_potential.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_interfacial_tension(&self) -> Option<PySINumber> {
+                self.0.interfacial_tension.map(PySINumber::from)
+            }
+
+            #[getter]
+            fn get_partial_molar_enthalpy_of_adsorption(&self) -> PyResult<PySIArray1> {
+                Ok(self.0.partial_molar_enthalpy_of_adsorption()?.into())
+            }
+
+            #[getter]
+            fn get_enthalpy_of_adsorption(&self) -> PyResult<PySINumber> {
+                Ok(self.0.enthalpy_of_adsorption()?.into())
+            }
+        }
+
         /// Parameters required to specify a 3D pore.
         ///
         /// Parameters
@@ -171,6 +255,7 @@ macro_rules! impl_pore {
             #[new]
             fn new(
                 system_size: [PySINumber; 3],
+                angles: [PyAngle; 3],
                 n_grid: [usize; 3],
                 coordinates: PySIArray2,
                 sigma_ss: &PyArray1<f64>,
@@ -180,6 +265,7 @@ macro_rules! impl_pore {
             ) -> PyResult<Self> {
                 Ok(Self(Pore3D::new(
                     [system_size[0].try_into()?, system_size[1].try_into()?, system_size[2].try_into()?],
+                    [angles[0].into(), angles[1].into(), angles[2].into()],
                     n_grid,
                     coordinates.try_into()?,
                     sigma_ss.to_owned_array(),

--- a/feos-dft/src/python/interface/mod.rs
+++ b/feos-dft/src/python/interface/mod.rs
@@ -133,8 +133,8 @@ macro_rules! impl_planar_interface {
             /// -------
             /// SIArray2
             ///
-            fn relative_adsorption(&self) -> PyResult<PySIArray2> {
-                Ok(self.0.relative_adsorption()?.into())
+            fn relative_adsorption(&self) -> PySIArray2 {
+                self.0.relative_adsorption().into()
             }
 
             /// Calculates the interfacial enrichment E_i.
@@ -143,8 +143,8 @@ macro_rules! impl_planar_interface {
             /// -------
             /// numpy.ndarray
             ///
-            fn interfacial_enrichment<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
-                Ok(self.0.interfacial_enrichment()?.to_pyarray(py))
+            fn interfacial_enrichment<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
+                self.0.interfacial_enrichment().to_pyarray(py)
             }
 
             /// Calculates the interfacial thickness (90-10 number density difference)

--- a/feos-dft/src/python/profile.rs
+++ b/feos-dft/src/python/profile.rs
@@ -240,9 +240,15 @@ macro_rules! impl_2d_profile {
         #[pymethods]
         impl $struct {
             #[getter]
-            fn get_edges(&self) -> (PySIArray1, PySIArray1) {
-                let (edge1, edge2) = self.0.profile.edges();
-                (edge1.into(), edge2.into())
+            fn get_edges(&self) -> [PySIArray1; 2] {
+                let [edge1, edge2] = self.0.profile.edges();
+                [edge1.into(), edge2.into()]
+            }
+
+            #[getter]
+            fn get_meshgrid(&self) -> [PySIArray2; 2] {
+                let [x, y] = self.0.profile.meshgrid();
+                [x.into(), y.into()]
             }
         }
     };
@@ -267,6 +273,12 @@ macro_rules! impl_3d_profile {
             fn get_edges(&self) -> [PySIArray1; 3] {
                 let [edge1, edge2, edge3] = self.0.profile.edges();
                 [edge1.into(), edge2.into(), edge3.into()]
+            }
+
+            #[getter]
+            fn get_meshgrid(&self) -> [PySIArray3; 3] {
+                let [x, y, z] = self.0.profile.meshgrid();
+                [x.into(), y.into(), z.into()]
             }
         }
     };

--- a/src/python/dft.rs
+++ b/src/python/dft.rs
@@ -30,12 +30,12 @@ use feos_dft::python::*;
 use feos_dft::solvation::*;
 use feos_dft::*;
 use numpy::convert::ToPyArray;
-use numpy::{PyArray1, PyArray2, PyArray4};
+use numpy::{PyArray1, PyArray2, PyArray3, PyArray4};
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
 #[cfg(feature = "estimator")]
 use pyo3::wrap_pymodule;
-use quantity::python::{PySIArray1, PySIArray2, PySIArray3, PySIArray4, PySINumber};
+use quantity::python::{PyAngle, PySIArray1, PySIArray2, PySIArray3, PySIArray4, PySINumber};
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
@@ -259,6 +259,7 @@ pub fn dft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyPlanarInterface>()?;
     m.add_class::<Geometry>()?;
     m.add_class::<PyPore1D>()?;
+    m.add_class::<PyPore2D>()?;
     m.add_class::<PyPore3D>()?;
     m.add_class::<PyPairCorrelation>()?;
     m.add_class::<PyExternalPotential>()?;

--- a/tests/gc_pcsaft/dft.rs
+++ b/tests/gc_pcsaft/dft.rs
@@ -240,6 +240,7 @@ fn test_dft_assoc() -> Result<(), Box<dyn Error>> {
         None,
     )
     .initialize(&bulk, None, None)
+    .unwrap()
     .solve(Some(&solver))?;
     Ok(())
 }


### PR DESCRIPTION
This is a MVSP for calculations of pores with non-orthorombic unit cells. Convolution integrals and integration is implemented, but to use non-orthorombic cells, the external potential has to be provided.