### PR TITLE
QoL improvements for working with ideal gas models

### DIFF
--- a/feos-core/src/cubic.rs
+++ b/feos-core/src/cubic.rs
@@ -26,15 +26,18 @@ pub struct PengRobinsonRecord {
     pc: f64,
     /// acentric factor
     acentric_factor: f64,
+    /// molar weight
+    molarweight: f64,
 }
 
 impl PengRobinsonRecord {
     /// Create a new pure substance record for the Peng-Robinson equation of state.
-    pub fn new(tc: f64, pc: f64, acentric_factor: f64) -> Self {
+    pub fn new(tc: f64, pc: f64, acentric_factor: f64, molarweight: f64) -> Self {
         Self {
             tc,
             pc,
             acentric_factor,
+            molarweight,
         }
     }
 }
@@ -43,7 +46,8 @@ impl std::fmt::Display for PengRobinsonRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "PengRobinsonRecord(tc={} K", self.tc)?;
         write!(f, ", pc={} Pa", self.pc)?;
-        write!(f, ", acentric factor={}", self.acentric_factor)
+        write!(f, ", acentric factor={}", self.acentric_factor)?;
+        write!(f, ", molar weight={})", self.molarweight)
     }
 }
 
@@ -93,9 +97,10 @@ impl PengRobinsonParameters {
                     tc: tc[i],
                     pc: pc[i],
                     acentric_factor: acentric_factor[i],
+                    molarweight: molarweight[i],
                 };
                 let id = Identifier::default();
-                PureRecord::new(id, molarweight[i], record)
+                PureRecord::new(id, record)
             })
             .collect();
         PengRobinsonParameters::from_records(records, None)
@@ -120,8 +125,8 @@ impl Parameter for PengRobinsonParameters {
         let mut kappa = Array1::zeros(n);
 
         for (i, record) in pure_records.iter().enumerate() {
-            molarweight[i] = record.molarweight;
             let r = &record.model_record;
+            molarweight[i] = r.molarweight;
             tc[i] = r.tc;
             a[i] = 0.45724 * r.tc.powi(2) * KB_A3 / r.pc;
             b[i] = 0.07780 * r.tc * KB_A3 / r.pc;

--- a/feos-core/src/equation_of_state/mod.rs
+++ b/feos-core/src/equation_of_state/mod.rs
@@ -27,14 +27,14 @@ pub trait Components {
 /// and a residual Helmholtz energy model.
 #[derive(Clone)]
 pub struct EquationOfState<I, R> {
-    pub ideal_gas: Arc<I>,
+    pub ideal_gas: I,
     pub residual: Arc<R>,
 }
 
 impl<I, R> EquationOfState<I, R> {
     /// Return a new [EquationOfState] with the given ideal gas
     /// and residual models.
-    pub fn new(ideal_gas: Arc<I>, residual: Arc<R>) -> Self {
+    pub fn new(ideal_gas: I, residual: Arc<R>) -> Self {
         Self {
             ideal_gas,
             residual,
@@ -45,7 +45,7 @@ impl<I, R> EquationOfState<I, R> {
 impl<I: IdealGas> EquationOfState<I, NoResidual> {
     /// Return a new [EquationOfState] that only consists of
     /// an ideal gas models.
-    pub fn ideal_gas(ideal_gas: Arc<I>) -> Self {
+    pub fn ideal_gas(ideal_gas: I) -> Self {
         let residual = Arc::new(NoResidual(ideal_gas.components()));
         Self {
             ideal_gas,
@@ -66,7 +66,7 @@ impl<I: Components, R: Components> Components for EquationOfState<I, R> {
 
     fn subset(&self, component_list: &[usize]) -> Self {
         Self::new(
-            Arc::new(self.ideal_gas.subset(component_list)),
+            self.ideal_gas.subset(component_list),
             Arc::new(self.residual.subset(component_list)),
         )
     }

--- a/feos-core/src/joback.rs
+++ b/feos-core/src/joback.rs
@@ -333,8 +333,8 @@ mod tests {
         );
         assert_relative_eq!(jr.e, 0.0);
 
-        let pr = PureRecord::new(Identifier::default(), 1.0, jr);
-        let joback = Arc::new(Joback::new(Arc::new(JobackParameters::new_pure(pr)?)));
+        let pr = PureRecord::new(Identifier::default(), jr);
+        let joback = Joback::new(Arc::new(JobackParameters::new_pure(pr)?));
         let eos = Arc::new(EquationOfState::ideal_gas(joback));
         let state = State::new_nvt(
             &eos,
@@ -357,17 +357,16 @@ mod tests {
     fn c_p_comparison() -> EosResult<()> {
         let record1 = PureRecord::new(
             Identifier::default(),
-            1.0,
             JobackRecord::new(1.0, 0.2, 0.03, 0.004, 0.005),
         );
         let record2 = PureRecord::new(
             Identifier::default(),
-            1.0,
             JobackRecord::new(-5.0, 0.4, 0.03, 0.002, 0.001),
         );
         let parameters = Arc::new(JobackParameters::new_binary(vec![record1, record2], None)?);
-        let joback = Arc::new(Joback::new(parameters));
-        let eos = Arc::new(EquationOfState::ideal_gas(joback.clone()));
+        let joback = Joback::new(parameters.clone());
+        let ideal_gas = Joback::new(parameters);
+        let eos = Arc::new(EquationOfState::ideal_gas(ideal_gas));
         let temperature = 300.0 * KELVIN;
         let volume = METER.powi::<P3>();
         let moles = &arr1(&[1.0, 3.0]) * MOL;

--- a/feos-core/src/lib.rs
+++ b/feos-core/src/lib.rs
@@ -173,14 +173,13 @@ mod tests {
     fn validate_residual_properties() -> EosResult<()> {
         let mixture = pure_record_vec();
         let propane = mixture[0].clone();
-        let parameters = PengRobinsonParameters::new_pure(propane)?;
-        let residual = Arc::new(PengRobinson::new(Arc::new(parameters)));
+        let parameters = Arc::new(PengRobinsonParameters::new_pure(propane)?);
+        let residual = Arc::new(PengRobinson::new(parameters));
         let joback_parameters = Arc::new(JobackParameters::new_pure(PureRecord::new(
             Identifier::default(),
-            1.0,
             JobackRecord::new(0.0, 0.0, 0.0, 0.0, 0.0),
         ))?);
-        let ideal_gas = Arc::new(Joback::new(joback_parameters));
+        let ideal_gas = Joback::new(joback_parameters);
         let eos = Arc::new(EquationOfState::new(ideal_gas, residual.clone()));
 
         let sr = StateBuilder::new(&residual)

--- a/feos-core/src/parameter/mod.rs
+++ b/feos-core/src/parameter/mod.rs
@@ -66,7 +66,7 @@ where
     fn from_model_records(model_records: Vec<Self::Pure>) -> Result<Self, ParameterError> {
         let pure_records = model_records
             .into_iter()
-            .map(|r| PureRecord::new(Default::default(), Default::default(), r))
+            .map(|r| PureRecord::new(Default::default(), r))
             .collect();
         Self::from_records(pure_records, None)
     }

--- a/feos-core/src/python/cubic.rs
+++ b/feos-core/src/python/cubic.rs
@@ -18,8 +18,13 @@ pub struct PyPengRobinsonRecord(PengRobinsonRecord);
 #[pymethods]
 impl PyPengRobinsonRecord {
     #[new]
-    fn new(tc: f64, pc: f64, acentric_factor: f64) -> Self {
-        Self(PengRobinsonRecord::new(tc, pc, acentric_factor))
+    fn new(tc: f64, pc: f64, acentric_factor: f64, molarweight: f64) -> Self {
+        Self(PengRobinsonRecord::new(
+            tc,
+            pc,
+            acentric_factor,
+            molarweight,
+        ))
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/feos-core/src/python/parameter/mod.rs
+++ b/feos-core/src/python/parameter/mod.rs
@@ -399,16 +399,8 @@ macro_rules! impl_pure_record {
         impl PyPureRecord {
             #[new]
             #[pyo3(text_signature = "(identifier, molarweight, model_record)")]
-            fn new(
-                identifier: PyIdentifier,
-                molarweight: f64,
-                model_record: $py_model_record,
-            ) -> PyResult<Self> {
-                Ok(Self(PureRecord::new(
-                    identifier.0,
-                    molarweight,
-                    model_record.0,
-                )))
+            fn new(identifier: PyIdentifier, model_record: $py_model_record) -> PyResult<Self> {
+                Ok(Self(PureRecord::new(identifier.0, model_record.0)))
             }
 
             #[getter]
@@ -419,16 +411,6 @@ macro_rules! impl_pure_record {
             #[setter]
             fn set_identifier(&mut self, identifier: PyIdentifier) {
                 self.0.identifier = identifier.0;
-            }
-
-            #[getter]
-            fn get_molarweight(&self) -> f64 {
-                self.0.molarweight
-            }
-
-            #[setter]
-            fn set_molarweight(&mut self, molarweight: f64) {
-                self.0.molarweight = molarweight;
             }
 
             #[getter]

--- a/feos-derive/src/residual.rs
+++ b/feos-derive/src/residual.rs
@@ -24,20 +24,38 @@ fn impl_residual(
 ) -> proc_macro2::TokenStream {
     let compute_max_density = variants.iter().map(|v| {
         let name = &v.ident;
-        quote! {
-            Self::#name(residual) => residual.compute_max_density(moles)
+        if name == "NoModel" {
+            quote! {
+                Self::#name(_) => 0.0
+            }
+        } else {
+            quote! {
+                Self::#name(residual) => residual.compute_max_density(moles)
+            }
         }
     });
     let contributions = variants.iter().map(|v| {
         let name = &v.ident;
-        quote! {
-            Self::#name(residual) => residual.contributions()
+        if name == "NoModel" {
+            quote! {
+                Self::#name(_) => &[]
+            }
+        } else {
+            quote! {
+                Self::#name(residual) => residual.contributions()
+            }
         }
     });
     let molar_weight = variants.iter().map(|v| {
         let name = &v.ident;
-        quote! {
-            Self::#name(residual) => residual.molar_weight()
+        if name == "NoModel" {
+            quote! {
+                Self::#name(_) => panic!("OH NO")
+            }
+        } else {
+            quote! {
+                Self::#name(residual) => residual.molar_weight()
+            }
         }
     });
 

--- a/feos-derive/src/residual.rs
+++ b/feos-derive/src/residual.rs
@@ -24,38 +24,20 @@ fn impl_residual(
 ) -> proc_macro2::TokenStream {
     let compute_max_density = variants.iter().map(|v| {
         let name = &v.ident;
-        if name == "NoModel" {
-            quote! {
-                Self::#name(_) => 0.0
-            }
-        } else {
-            quote! {
-                Self::#name(residual) => residual.compute_max_density(moles)
-            }
+        quote! {
+            Self::#name(residual) => residual.compute_max_density(moles)
         }
     });
     let contributions = variants.iter().map(|v| {
         let name = &v.ident;
-        if name == "NoModel" {
-            quote! {
-                Self::#name(_) => &[]
-            }
-        } else {
-            quote! {
-                Self::#name(residual) => residual.contributions()
-            }
+        quote! {
+            Self::#name(residual) => residual.contributions()
         }
     });
     let molar_weight = variants.iter().map(|v| {
         let name = &v.ident;
-        if name == "NoModel" {
-            quote! {
-                Self::#name(_) => panic!("OH NO")
-            }
-        } else {
-            quote! {
-                Self::#name(residual) => residual.molar_weight()
-            }
+        quote! {
+            Self::#name(residual) => residual.molar_weight()
         }
     });
 

--- a/feos-dft/src/functional.rs
+++ b/feos-dft/src/functional.rs
@@ -80,7 +80,7 @@ impl<F> Deref for DFT<F> {
 
 impl<F> DFT<F> {
     pub fn ideal_gas<I>(self, ideal_gas: I) -> DFT<EquationOfState<I, F>> {
-        DFT(EquationOfState::new(Arc::new(ideal_gas), Arc::new(self.0)))
+        DFT(EquationOfState::new(ideal_gas, Arc::new(self.0)))
     }
 }
 

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -53,6 +53,7 @@ impl PyPcSaftRecord {
         text_signature = "(m, sigma, epsilon_k, mu=None, q=None, kappa_ab=None, epsilon_k_ab=None, na=None, nb=None, nc=None, viscosity=None, diffusion=None, thermal_conductivity=None)"
     )]
     fn new(
+        molarweight: f64,
         m: f64,
         sigma: f64,
         epsilon_k: f64,
@@ -68,6 +69,7 @@ impl PyPcSaftRecord {
         thermal_conductivity: Option<[f64; 4]>,
     ) -> Self {
         Self(PcSaftRecord::new(
+            molarweight,
             m,
             sigma,
             epsilon_k,
@@ -82,6 +84,11 @@ impl PyPcSaftRecord {
             diffusion,
             thermal_conductivity,
         ))
+    }
+
+    #[getter]
+    fn get_molarweight(&self) -> f64 {
+        self.0.molarweight
     }
 
     #[getter]

--- a/src/python/eos.rs
+++ b/src/python/eos.rs
@@ -95,7 +95,7 @@ impl PyEquationOfState {
             parameters.0,
             options,
         )));
-        let ideal_gas = Arc::new(IdealGasModel::NoModel(residual.components()));
+        let ideal_gas = IdealGasModel::NoModel(residual.components());
         Self(Arc::new(EquationOfState::new(ideal_gas, residual)))
     }
 
@@ -157,7 +157,7 @@ impl PyEquationOfState {
     #[staticmethod]
     pub fn peng_robinson(parameters: PyPengRobinsonParameters) -> Self {
         let residual = Arc::new(ResidualModel::PengRobinson(PengRobinson::new(parameters.0)));
-        let ideal_gas = Arc::new(IdealGasModel::NoModel(residual.components()));
+        let ideal_gas = IdealGasModel::NoModel(residual.components());
         Self(Arc::new(EquationOfState::new(ideal_gas, residual)))
     }
 
@@ -175,7 +175,7 @@ impl PyEquationOfState {
     #[staticmethod]
     fn python_residual(residual: Py<PyAny>) -> PyResult<Self> {
         let residual = Arc::new(ResidualModel::Python(PyResidual::new(residual)?));
-        let ideal_gas = Arc::new(IdealGasModel::NoModel(residual.components()));
+        let ideal_gas = IdealGasModel::NoModel(residual.components());
         Ok(Self(Arc::new(EquationOfState::new(ideal_gas, residual))))
     }
 
@@ -335,10 +335,7 @@ impl PyEquationOfState {
             ))),
             _ => self.0.residual.clone(),
         };
-        Self(Arc::new(EquationOfState::new(
-            Arc::new(ideal_gas),
-            residual,
-        )))
+        Self(Arc::new(EquationOfState::new(ideal_gas, residual)))
     }
 }
 

--- a/src/python/eos.rs
+++ b/src/python/eos.rs
@@ -293,7 +293,7 @@ impl PyEquationOfState {
     #[staticmethod]
     fn ideal_gas() -> Self {
         let residual = Arc::new(ResidualModel::NoResidual(NoResidual(0)));
-        let ideal_gas = Arc::new(IdealGasModel::NoModel(0));
+        let ideal_gas = IdealGasModel::NoModel(0);
         Self(Arc::new(EquationOfState::new(ideal_gas, residual)))
     }
 

--- a/tests/pcsaft/state_creation_mixture.rs
+++ b/tests/pcsaft/state_creation_mixture.rs
@@ -32,7 +32,7 @@ fn pressure_entropy_molefracs() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_butane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let pressure = BAR;
     let temperature = 300.0 * KELVIN;
     let x = arr1(&[0.3, 0.7]);

--- a/tests/pcsaft/state_creation_pure.rs
+++ b/tests/pcsaft/state_creation_pure.rs
@@ -148,7 +148,7 @@ fn pressure_enthalpy_vapor() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let pressure = 0.3 * BAR;
     let molar_enthalpy = 2000.0 * JOULE / MOL;
     let state = StateBuilder::new(&eos)
@@ -190,7 +190,7 @@ fn density_internal_energy() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let pressure = 5.0 * BAR;
     let temperature = 315.0 * KELVIN;
     let total_moles = 2.5 * MOL;
@@ -220,7 +220,7 @@ fn pressure_enthalpy_total_moles_vapor() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let pressure = 0.3 * BAR;
     let molar_enthalpy = 2000.0 * JOULE / MOL;
     let total_moles = 2.5 * MOL;
@@ -264,7 +264,7 @@ fn pressure_entropy_vapor() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let pressure = 0.3 * BAR;
     let molar_entropy = -2.0 * JOULE / MOL / KELVIN;
     let state = StateBuilder::new(&eos)
@@ -306,7 +306,7 @@ fn temperature_entropy_vapor() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let pressure = 3.0 * BAR;
     let temperature = 315.15 * KELVIN;
     let total_moles = 3.0 * MOL;
@@ -366,7 +366,7 @@ fn test_consistency() -> Result<(), Box<dyn Error>> {
     let (saft_params, joback_params) = propane_parameters()?;
     let saft = Arc::new(PcSaft::new(saft_params));
     let joback = Joback::new(joback_params);
-    let eos = Arc::new(EquationOfState::new(Arc::new(joback), saft));
+    let eos = Arc::new(EquationOfState::new(joback, saft));
     let temperatures = [350.0 * KELVIN, 400.0 * KELVIN, 450.0 * KELVIN];
     let pressures = [1.0 * BAR, 2.0 * BAR, 3.0 * BAR];
 


### PR DESCRIPTION
The PR contains four smaller proposed changes that are each open to discussion individually.

1. The `molarweight` field is removed from `PureRecord` and added to `PcSaftRecord` instead (the other eos would have to be updated as well)
2. ~~A new `NoResidual` struct is used (internally) to be able to construct an `EquationOfState` with only an ideal gas model, e.g.~~ #204 
```python
EquationOfState.ideal_gas().joback(joback)
```
3. The `Arc` around the ideal gas part in `EquationOfState` is removed. The corresponding `Arc` around the residual part is required exactly once for the "building" pattern for `EquationOfState` in Python. I would prefer to also get rid of that, because it is unnecessary for Rust and conceptually not required at that point. That would require a different constructor for `EquationOfState` in Python, though.
4. ~~`PureRecord`, `SegmentRecord`, `Identifier`, and `IdentifierOption` are added to `feos.ideal_gas`. This is related to a larger issue that there are multiple `PureRecord`s and `SegmentRecord`s in the Python package. `Identifier` and `IdentifierOption` could be exposed only once at a central location.~~ #205 


The changes in 1. and 3. are breaking changes, but 2. is a nice quality of life improvement that could be published as patch. 4. more of a fix, but does not really solve the root of the problem.