### PR TITLE
`EquationOfState` without residual model

### DIFF
--- a/feos-core/src/equation_of_state/mod.rs
+++ b/feos-core/src/equation_of_state/mod.rs
@@ -11,6 +11,7 @@ mod residual;
 
 pub use helmholtz_energy::{HelmholtzEnergy, HelmholtzEnergyDual};
 pub use ideal_gas::{DeBroglieWavelength, DeBroglieWavelengthDual, IdealGas};
+use residual::NoResidual;
 pub use residual::{EntropyScaling, Residual};
 
 /// The number of components that the model is initialized for.
@@ -35,6 +36,18 @@ impl<I, R> EquationOfState<I, R> {
     /// Return a new [EquationOfState] with the given ideal gas
     /// and residual models.
     pub fn new(ideal_gas: Arc<I>, residual: Arc<R>) -> Self {
+        Self {
+            ideal_gas,
+            residual,
+        }
+    }
+}
+
+impl<I: IdealGas> EquationOfState<I, NoResidual> {
+    /// Return a new [EquationOfState] that only consists of
+    /// an ideal gas models.
+    pub fn ideal_gas(ideal_gas: Arc<I>) -> Self {
+        let residual = Arc::new(NoResidual(ideal_gas.components()));
         Self {
             ideal_gas,
             residual,

--- a/feos-core/src/equation_of_state/residual.rs
+++ b/feos-core/src/equation_of_state/residual.rs
@@ -178,3 +178,29 @@ pub trait EntropyScaling {
     ) -> EosResult<ThermalConductivity>;
     fn thermal_conductivity_correlation(&self, s_res: f64, x: &Array1<f64>) -> EosResult<f64>;
 }
+
+pub struct NoResidual(pub usize);
+
+impl Components for NoResidual {
+    fn components(&self) -> usize {
+        self.0
+    }
+
+    fn subset(&self, component_list: &[usize]) -> Self {
+        Self(component_list.len())
+    }
+}
+
+impl Residual for NoResidual {
+    fn compute_max_density(&self, _: &Array1<f64>) -> f64 {
+        1.0
+    }
+
+    fn contributions(&self) -> &[Box<dyn HelmholtzEnergy>] {
+        &[]
+    }
+
+    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
+        panic!("No mass specific properties are available for this model!")
+    }
+}

--- a/feos-derive/src/residual.rs
+++ b/feos-derive/src/residual.rs
@@ -24,20 +24,38 @@ fn impl_residual(
 ) -> proc_macro2::TokenStream {
     let compute_max_density = variants.iter().map(|v| {
         let name = &v.ident;
-        quote! {
-            Self::#name(residual) => residual.compute_max_density(moles)
+        if name == "NoModel" {
+            quote! {
+                Self::#name(_) => 0.0
+            }
+        } else {
+            quote! {
+                Self::#name(residual) => residual.compute_max_density(moles)
+            }
         }
     });
     let contributions = variants.iter().map(|v| {
         let name = &v.ident;
-        quote! {
-            Self::#name(residual) => residual.contributions()
+        if name == "NoModel" {
+            quote! {
+                Self::#name(_) => &[]
+            }
+        } else {
+            quote! {
+                Self::#name(residual) => residual.contributions()
+            }
         }
     });
     let molar_weight = variants.iter().map(|v| {
         let name = &v.ident;
-        quote! {
-            Self::#name(residual) => residual.molar_weight()
+        if name == "NoModel" {
+            quote! {
+                Self::#name(_) => panic!("OH NO")
+            }
+        } else {
+            quote! {
+                Self::#name(residual) => residual.molar_weight()
+            }
         }
     });
 

--- a/src/eos.rs
+++ b/src/eos.rs
@@ -23,6 +23,7 @@ use ndarray::Array1;
 /// are undesirable (e.g. FFI).
 #[derive(Components, Residual)]
 pub enum ResidualModel {
+    NoModel(usize),
     #[cfg(feature = "pcsaft")]
     #[implement(entropy_scaling)]
     PcSaft(PcSaft),


### PR DESCRIPTION
Enables constructing an `EquationOfState` object without providing a residual Helmholtz energy model in Rust
```rust
EquationOfState::ideal_gas(joback)
```
and Python
```python
EquationOfState.ideal_gas().joback(joback)
```