### PR TITLE
Add `PureRecord` and other Python classes to `feos.ideal_gas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `EquationOfState.ideal_gas()` to initialize an equation of state that only consists of an ideal gas contribution. [#204](https://github.com/feos-org/feos/pull/204)
+- Added `PureRecord`, `SegmentRecord`, `Identifier`, and `IdentifierOption` to `feos.ideal_gas`. [#205](https://github.com/feos-org/feos/pull/205)
 
 ## [0.5.1] - 2023-11-23
 - Python only: Release the changes introduced in `feos-core` 0.5.1.

--- a/src/python/ideal_gas.rs
+++ b/src/python/ideal_gas.rs
@@ -1,8 +1,14 @@
-use feos_core::python::joback::{PyJobackParameters, PyJobackRecord};
+use feos_core::parameter::IdentifierOption;
+use feos_core::python::joback::*;
+use feos_core::python::parameter::PyIdentifier;
 use pyo3::prelude::*;
 
 #[pymodule]
 pub fn ideal_gas(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyIdentifier>()?;
+    m.add_class::<IdentifierOption>()?;
     m.add_class::<PyJobackRecord>()?;
+    m.add_class::<PyPureRecord>()?;
+    m.add_class::<PySegmentRecord>()?;
     m.add_class::<PyJobackParameters>()
 }


### PR DESCRIPTION
This adds `Identifier`, `IdentifierOption`, `PureRecord`, and `SegmentRecord` to `feos.ideal_gas`.

In the short term this allows to handle ideal gas parameters like other models. For the future, there remain 3 issues:
1. In Python, we have a `PureRecord` for every model, which can lead to confusing errors or the requirement to rename imports.
2. The `PureRecord` in `feos.ideal_gas` refers to Joback specifically, so if we add more models, the naming will be awkward.
3. It might be more clear if non-generic Python classes (`Identifier` and `IdentifierOption`) are exported only once.