### PR TITLE
PC-SAFT diffusion references according to erratum.

### DIFF
--- a/src/pcsaft/eos/mod.rs
+++ b/src/pcsaft/eos/mod.rs
@@ -222,7 +222,7 @@ impl EntropyScaling for PcSaft {
             .map(|i| {
                 let tr = (temperature / p.epsilon_k[i] / KELVIN).into_value();
                 3.0 / 8.0 / (p.sigma[i] * ANGSTROM).powi::<P2>() / omega11(tr) / (density * NAV)
-                    * (temperature * RGAS / PI / (p.molarweight[i] * GRAM / MOL)).sqrt()
+                    * (temperature * RGAS / PI / (p.molarweight[i] * GRAM / MOL) / p.m[i]).sqrt()
             })
             .collect();
         Ok(res[0])


### PR DESCRIPTION
Missing segment number added according to Erratum to _M. Hopp, J. Mele, and J. Gross: “Self-Diffusion Coefficients from Entropy Scaling Using the PCP-SAFT Equation of State”_ [https://doi.org/10.1021/acs.iecr.9b05731](https://doi.org/10.1021/acs.iecr.9b05731).