### PR TITLE
Convergence improvement for tp_flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-01-11
+- Python only: Release the changes introduced in `feos-core` 0.6.1.
+
 ## [0.6.0] - 2023-12-19
 ### Added
 - Added `EquationOfState.ideal_gas()` to initialize an equation of state that only consists of an ideal gas contribution. [#204](https://github.com/feos-org/feos/pull/204)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feos"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>", "Philipp Rehner <prehner@ethz.ch>"]
 edition = "2021"
 readme = "README.md"

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.6.1] 2024-01-11
+### Fixed
+- Improved convergence of `tp_flash` for certain edge cases. [#219](https://github.com/feos-org/feos/pull/219)
+
 ## [0.6.0] 2023-12-19
 ### Added
 - Added `EquationOfState::ideal_gas` to initialize an equation of state that only consists of an ideal gas contribution. [#204](https://github.com/feos-org/feos/pull/204)

--- a/feos-core/Cargo.toml
+++ b/feos-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feos-core"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
            "Philipp Rehner <prehner@ethz.ch"]
 edition = "2021"

--- a/feos-core/src/phase_equilibria/tp_flash.rs
+++ b/feos-core/src/phase_equilibria/tp_flash.rs
@@ -60,7 +60,15 @@ impl<E: Residual> State<E> {
             Some(init) => init
                 .clone()
                 .update_pressure(self.temperature, self.pressure(Contributions::Total))?,
-            None => PhaseEquilibrium::vle_init_stability(self)?,
+            None => {
+                let (init1, init2) = PhaseEquilibrium::vle_init_stability(self)?;
+                let vle1 = self.tp_flash(Some(&init1), options, non_volatile_components.clone());
+                return if vle1.is_err() && init2.is_some() {
+                    self.tp_flash(init2.as_ref(), options, non_volatile_components)
+                } else {
+                    vle1
+                };
+            }
         };
 
         log_iter!(
@@ -297,14 +305,19 @@ impl<E: Residual> PhaseEquilibrium<E, 2> {
         Ok(())
     }
 
-    fn vle_init_stability(feed_state: &State<E>) -> EosResult<Self> {
+    fn vle_init_stability(feed_state: &State<E>) -> EosResult<(Self, Option<Self>)> {
         let mut stable_states = feed_state.stability_analysis(SolverOptions::default())?;
         let state1 = stable_states.pop();
         let state2 = stable_states.pop();
-        match (state1, state2) {
-            (Some(s1), Some(s2)) => Ok(Self::from_states(s1, s2)),
-            (Some(s1), None) => Ok(Self::from_states(s1, feed_state.clone())),
-            _ => Err(EosError::NoPhaseSplit),
+        if let Some(s1) = state1 {
+            let init1 = Self::from_states(s1.clone(), feed_state.clone());
+            if let Some(s2) = state2 {
+                Ok((Self::from_states(s1, s2), Some(init1)))
+            } else {
+                Ok((init1, None))
+            }
+        } else {
+            Err(EosError::NoPhaseSplit)
         }
     }
 }


### PR DESCRIPTION
In some cases, when the different solutions found by a stability analysis are right above the equality threshold, an almost trivial solution is used to initialize the tp flash for cases that could otherwise be solved very robustly.

MRE:
```python
from feos.si import *
from feos.pcsaft import *
from feos.eos import *
import numpy as np

pcsaft = PcSaftParameters.from_json(['cyclopentane', 'propylene'], '../input/esper2023.json')
eos = EquationOfState.pcsaft(pcsaft)

state = State(eos, 343.7964273175933*KELVIN, partial_density=np.array([78.77667866249813, 423.48238669680353])*MOL/METER**3)
state.tp_flash()
```