### PR TITLE
Enforce total_moles when providing molefracs that do not add up to 1

### DIFF
--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Added comparison for pressures of both phases in `PyPhaseDiagram.to_dict` to make the method work with `spinodal` constructor. [#224](https://github.com/feos-org/feos/pull/224)
+- Enforce the total moles when providing `State::new` with molefracs that do not add up to 1. [#227](https://github.com/feos-org/feos/pull/227)
 
 
 ## [0.6.1] 2024-01-11

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -392,7 +392,6 @@ impl<E: Residual> State<E> {
         }
 
         // Check if new state can be created using density iteration
-        println!("{:?} {:?} {:?}", pressure, temperature, n_i);
         if let (Some(p), Some(t), Some(n_i)) = (pressure, temperature, &n_i) {
             return Ok(Ok(State::new_npt(eos, t, p, n_i, density_initialization)?));
         }

--- a/feos-core/src/state/mod.rs
+++ b/feos-core/src/state/mod.rs
@@ -383,7 +383,7 @@ impl<E: Residual> State<E> {
         if let (None, None) = (volume, n) {
             n = Some(Moles::from_reduced(1.0))
         }
-        let n_i = n.map(|n| &x_u * n);
+        let n_i = n.map(|n| &x_u * n / x_u.sum());
         let v = volume.or_else(|| rho.and_then(|d| n.map(|n| n / d)));
 
         // check if new state can be created using default constructor
@@ -392,6 +392,7 @@ impl<E: Residual> State<E> {
         }
 
         // Check if new state can be created using density iteration
+        println!("{:?} {:?} {:?}", pressure, temperature, n_i);
         if let (Some(p), Some(t), Some(n_i)) = (pressure, temperature, &n_i) {
             return Ok(Ok(State::new_npt(eos, t, p, n_i, density_initialization)?));
         }


### PR DESCRIPTION
```python
State(eos, 300*KELVIN, molefracs=np.array([1.5,3.5]), total_moles=10*MOL, pressure=BAR).moles
```
would previously evaluate to 
```
[15, 35] MOL
```
with this change the output is
```
[3, 7] MOL
```
which conforms with the total moles provided by the call to `State::new`. In any case, this is only an issue, if the molefracs do not add up to 1. A different approach would be to return an Error if this condition is not met, however, I'm not much in favor of adding an == 1.0 check due to the implications on floating point arithmetic.