### PR TITLE
Added Henry's law constant

### DIFF
--- a/docs/theory/eos/properties.md
+++ b/docs/theory/eos/properties.md
@@ -80,6 +80,7 @@ Due to different language paradigms, $\text{FeO}_\text{s}$ handles the ideal gas
 | Logarithmic fugacity coefficient $\ln\varphi_i$ | $\beta\mu_i^\mathrm{res}\left(T,p,\lbrace n_i\rbrace\right)$ | no | no |
 | Pure component logarithmic fugacity coefficient $\ln\varphi_i^\mathrm{pure}$ | $\lim_{x_i\to 1}\ln\varphi_i$ | no | no |
 | Logarithmic (symmetric) activity coefficient $\ln\gamma_i$ | $\ln\left(\frac{\varphi_i}{\varphi_i^\mathrm{pure}}\right)$ | no | no |
+| Henry's law constant $H_{i,s}$ | $\lim_{x_i\to 0}\frac{y_ip}{x_i}=p_s^\mathrm{sat}\frac{\varphi_i^{\infty,\mathrm{L}}}{\varphi_i^{\infty,\mathrm{V}}}$ | no | no |
 | Partial derivative of the logarithmic fugacity coefficient w.r.t. temperature | $\left(\frac{\partial\ln\varphi_i}{\partial T}\right)_{p,n_i}$ | no | no |
 | Partial derivative of the logarithmic fugacity coefficient w.r.t. pressure | $\left(\frac{\partial\ln\varphi_i}{\partial p}\right)_{T,n_i}=\frac{v_i^\mathrm{res,p}}{RT}$ | no | no |
 | Partial derivative of the logarithmic fugacity coefficient w.r.t. moles |  $\left(\frac{\partial\ln\varphi_i}{\partial n_j}\right)_{T,p,n_k}$ | no | no |

--- a/feos-core/CHANGELOG.md
+++ b/feos-core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added specific isochoric and isobaric heat capacities to the Python interface. [#223](https://github.com/feos-org/feos/pull/223))
 - Added `to_dict` method for `PyStateVec`. [#224](https://github.com/feos-org/feos/pull/224)
+- Added `State::henrys_law_constant` to calculate Henry's law constants for arbitrary mixtures. [#234](https://github.com/feos-org/feos/pull/234)
 
 ### Changed
 - Changed the interface for Helmholtz energy calculation in `Residual` and `IdealGas` which removes the need for the `HelmholtzEnergy` and `HelmholtzEnergyDual` traits and trait objects. [#226](https://github.com/feos-org/feos/pull/226)

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -579,6 +579,15 @@ macro_rules! impl_state {
                 Ok(self.0.ln_symmetric_activity_coefficient()?.view().to_pyarray(py))
             }
 
+            /// Return Henry's law constant of every solute (x_i=0) for a given solvent (x_i>0).
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            fn henrys_law_constant(&self) -> PyResult<PySIArray1> {
+                Ok(self.0.henrys_law_constant()?.into())
+            }
+
             /// Return derivative of logarithmic fugacity coefficient w.r.t. temperature.
             ///
             /// Returns

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -581,11 +581,21 @@ macro_rules! impl_state {
 
             /// Return Henry's law constant of every solute (x_i=0) for a given solvent (x_i>0).
             ///
+            /// Parameters
+            /// ----------
+            /// eos : Eos
+            ///     The equation of state to use.
+            /// temperature : SINumber
+            ///     Temperature.
+            /// molefracs : np.ndarray[float]
+            ///     Composition of the solvent including x_i=0 for solutes.
+            ///
             /// Returns
             /// -------
             /// SIArray1
-            fn henrys_law_constant(&self) -> PyResult<PySIArray1> {
-                Ok(self.0.henrys_law_constant()?.into())
+            #[staticmethod]
+            fn henrys_law_constant(eos: $py_eos, temperature: PySINumber, molefracs: &PyArray1<f64>) -> PyResult<PySIArray1> {
+                Ok(State::henrys_law_constant(&eos.0, temperature.try_into()?, &molefracs.to_owned_array())?.into())
             }
 
             /// Return derivative of logarithmic fugacity coefficient w.r.t. temperature.

--- a/feos-core/src/python/state.rs
+++ b/feos-core/src/python/state.rs
@@ -598,6 +598,24 @@ macro_rules! impl_state {
                 Ok(State::henrys_law_constant(&eos.0, temperature.try_into()?, &molefracs.to_owned_array())?.into())
             }
 
+            /// Return Henry's law constant of a binary system, assuming the first
+            /// component is the solute and the second component is the solvent.
+            ///
+            /// Parameters
+            /// ----------
+            /// eos : Eos
+            ///     The equation of state to use.
+            /// temperature : SINumber
+            ///     Temperature.
+            ///
+            /// Returns
+            /// -------
+            /// SIArray1
+            #[staticmethod]
+            fn henrys_law_constant_binary(eos: $py_eos, temperature: PySINumber) -> PyResult<PySINumber> {
+                Ok(State::henrys_law_constant_binary(&eos.0, temperature.try_into()?)?.into())
+            }
+
             /// Return derivative of logarithmic fugacity coefficient w.r.t. temperature.
             ///
             /// Returns

--- a/feos-core/src/state/residual_properties.rs
+++ b/feos-core/src/state/residual_properties.rs
@@ -384,6 +384,16 @@ impl<E: Residual> State<E> {
             .collect())
     }
 
+    /// Henry's law constant $H_{i,s}=\lim_{x_i\to 0}\frac{y_ip}{x_i}=p_s^\mathrm{sat}\frac{\varphi_i^{\infty,\mathrm{L}}}{\varphi_i^{\infty,\mathrm{V}}}$ for a binary system
+    ///
+    /// The solute (i) is the first component and the solvent (s) the second component.
+    pub fn henrys_law_constant_binary(
+        eos: &Arc<E>,
+        temperature: Temperature,
+    ) -> EosResult<Pressure> {
+        Ok(Self::henrys_law_constant(eos, temperature, &arr1(&[0.0, 1.0]))?.get(0))
+    }
+
     /// Partial derivative of the logarithm of the fugacity coefficient w.r.t. temperature: $\left(\frac{\partial\ln\varphi_i}{\partial T}\right)_{p,N_i}$
     pub fn dln_phi_dt(&self) -> <f64 as Div<Temperature<Array1<f64>>>>::Output {
         let vi = self.partial_molar_volume();

--- a/feos-core/src/state/residual_properties.rs
+++ b/feos-core/src/state/residual_properties.rs
@@ -327,7 +327,7 @@ impl<E: Residual> State<E> {
 
     /// Henry's law constant $H_{i,s}=\lim_{x_i\to 0}\frac{y_ip}{x_i}=p_s^\mathrm{sat}\frac{\varphi_i^{\infty,\mathrm{L}}}{\varphi_i^{\infty,\mathrm{V}}}$
     ///
-    /// The composition of the (possibly mixed) solvent is determined by the state. All components for which the composition is 0 are treated as solutes.
+    /// The composition of the (possibly mixed) solvent is determined by the molefracs. All components for which the composition is 0 are treated as solutes.
     pub fn henrys_law_constant(
         eos: &Arc<E>,
         temperature: Temperature,


### PR DESCRIPTION
Adds the calculation of Henry's law constants from an equation of state. Here, $H_{i,s}$ is defined in the way it would be observed, as
$H_{i,s}=\lim_{x_i\to 0}\frac{y_ip}{x_i}=p_s^\mathrm{sat}\frac{\varphi_i^{\infty,\mathrm{L}}}{\varphi_i^{\infty,\mathrm{V}}}$

The function treats all components with $x_i=0$ as solutes and returns only the Henry's law constants of those components.

In some sense, this would be an effective Henry's law constant that already contains the corrections for the non-ideality of the vapor phase and the pressure dependence of the liquid phase. Because this mainly serves as a tool to compare to experimental results or simplified modelling approaches, I don't see an issue.

```python
params = PcSaftParameters.from_json(["water", "nitrogen", "methanol", "carbon dioxide"], "esper2023.json", "rehner2023_binary.json")
eos = EquationOfState.pcsaft(params)

H = State.henrys_law_constant(eos, 300*KELVIN, np.array([0.6, 0.0, 0.4, 0.0]))
H
```
```
[2681433846.773456, 41766375.30479376] Pa
```
For the simple case of a binary system, a helper function can be used:
```python
params = PcSaftParameters.from_json(["nitrogen", "water"], "../../../Code/feos/feos/parameters/pcsaft/esper2023.json", "../../../Code/feos/feos/parameters/pcsaft/rehner2023_binary.json")
eos = EquationOfState.pcsaft(params)
State.henrys_law_constant_binary(eos, 300*KELVIN)
```
$47.744~\mathrm{GPa}$