### PR TITLE
Add property methods to `PySaftVRQMieParameters` object

### DIFF
--- a/src/saftvrqmie/parameters.rs
+++ b/src/saftvrqmie/parameters.rs
@@ -42,6 +42,8 @@ impl std::fmt::Display for SaftVRQMieRecord {
         write!(f, "SaftVRQMieRecord(m={}", self.m)?;
         write!(f, ", sigma={}", self.sigma)?;
         write!(f, ", epsilon_k={}", self.epsilon_k)?;
+        write!(f, ", lr={}", self.lr)?;
+        write!(f, ", la={}", self.la)?;
         if let Some(n) = &self.viscosity {
             write!(f, ", viscosity={:?}", n)?;
         }
@@ -181,7 +183,7 @@ impl Parameter for SaftVRQMieParameters {
                 return Err(
                     ParameterError::IncompatibleParameters(
                         format!(
-                            "Segment number `m` for component {} is not one. Chain-contributions are currently not supported.", 
+                            "Segment number `m` for component {} is not one. Chain-contributions are currently not supported.",
                             i
                         )
                     )
@@ -232,7 +234,7 @@ impl Parameter for SaftVRQMieParameters {
                     return Err(
                         ParameterError::IncompatibleParameters(
                             format!(
-                                "cannot combine Feynman-Hibbs orders 1 and 2. Component {} has order {} and component {} has order {}.", 
+                                "cannot combine Feynman-Hibbs orders 1 and 2. Component {} has order {} and component {} has order {}.",
                                 i, fh[i], j, fh[j]
                             )
                         )
@@ -424,6 +426,8 @@ impl std::fmt::Display for SaftVRQMieParameters {
         write!(f, "\n\tm={}", self.m)?;
         write!(f, "\n\tsigma={}", self.sigma)?;
         write!(f, "\n\tepsilon_k={}", self.epsilon_k)?;
+        write!(f, "\n\tlr={}", self.lr)?;
+        write!(f, "\n\tla={}", self.la)?;
 
         if !self.k_ij.iter().all(|k| k.is_zero()) {
             write!(f, "\n\tk_ij=\n{}", self.k_ij)?;

--- a/src/saftvrqmie/python.rs
+++ b/src/saftvrqmie/python.rs
@@ -259,14 +259,14 @@ impl PySaftVRQMieParameters {
         let quantum_d = Array2::from_shape_fn((n, n), |(i, j)| -> f64 {
             self.0.quantum_d_ij(i, j, t.to_reduced())
         });
-        Ok(PySIArray2::from(quantum_d / ANGSTROM / ANGSTROM))
+        Ok(PySIArray2::from(quantum_d / (ANGSTROM * ANGSTROM)))
     }
 
     /// Calculate de Boer parameter.
     ///
     /// Returns
     /// -------
-    /// PySIArray1
+    /// np.ndarray
     #[getter]
     fn de_boer<'py>(&self, py: Python<'py>) -> PyResult<&'py PyArray1<f64>> {
         let n = self.0.m.len();


### PR DESCRIPTION
Adds methods to get some useful properties in Python:
 - de Boer parameter
 - effective sigma and epsilon values
 - prefactor `D` of FH correction
 - hard sphere diameter