### PR TITLE
additional check of length of experimental permittivity data > 0

### DIFF
--- a/src/epcsaft/parameters.rs
+++ b/src/epcsaft/parameters.rs
@@ -470,6 +470,23 @@ impl Parameter for ElectrolytePcSaftParameters {
         }
 
         if !modeltypes.is_empty() && modeltypes[0] == 2 {
+            for i in 0..permittivity_records.len() {
+                if permittivity_records[i].is_some() {
+                    if let PermittivityRecord::ExperimentalData { data } =
+                        permittivity_records[i].as_ref().unwrap()
+                    {
+                        // check if length of data is greater than 0
+                        if data.is_empty() {
+                            return Err(ParameterError::IncompatibleParameters(
+                                "Experimental data for permittivity must contain at least one data point.".to_string(),
+                            ));
+                        }
+                    }
+                };
+            }
+        }
+
+        if !modeltypes.is_empty() && modeltypes[0] == 2 {
             // order points in data by increasing temperature
             let mut permittivity_records_clone = permittivity_records.clone();
             permittivity_records_clone

--- a/src/epcsaft/parameters.rs
+++ b/src/epcsaft/parameters.rs
@@ -470,19 +470,17 @@ impl Parameter for ElectrolytePcSaftParameters {
         }
 
         if !modeltypes.is_empty() && modeltypes[0] == 2 {
-            for i in 0..permittivity_records.len() {
-                if permittivity_records[i].is_some() {
-                    if let PermittivityRecord::ExperimentalData { data } =
-                        permittivity_records[i].as_ref().unwrap()
-                    {
-                        // check if length of data is greater than 0
-                        if data.is_empty() {
-                            return Err(ParameterError::IncompatibleParameters(
+            for permittivity_record in &permittivity_records {
+                if let Some(PermittivityRecord::ExperimentalData { data }) =
+                    permittivity_record.as_ref()
+                {
+                    // check if length of data is greater than 0
+                    if data.is_empty() {
+                        return Err(ParameterError::IncompatibleParameters(
                                 "Experimental data for permittivity must contain at least one data point.".to_string(),
                             ));
-                        }
                     }
-                };
+                }
             }
         }
 


### PR DESCRIPTION
added additional check if more than 0 permittivity points have been provided during creation of parameters

change only in `src/epcsaft/parameters.rs`
throws Error incompatible parameters if at least one of the components has 0 data points, but only if the permittivity record is some and not none.