### PR TITLE
fix version of upload-artifact Action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build documentation
         run: sphinx-build docs/ public/ -b html
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: public


### PR DESCRIPTION
Because it is incompatible with download-artifact version for documentation.