### PR TITLE
Add `release-lto-thin` profile

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
           name: wheel-macos-x86_64
           path: dist
   macos-aarch64:
-    runs-on: macos-13-xlarge
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
           name: wheel-macos-x86_64
           path: dist
   macos-aarch64:
-    runs-on: macos-14
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -53,7 +53,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: aarch64
-          args: --release --out dist
+          args: --profile release-lto --out dist
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ criterion = "0.5"
 
 [profile.release-lto]
 inherits = "release"
-lto = true
+lto = "thin"
 codegen-units = 1
 
 


### PR DESCRIPTION
- Add `release-lto-thin` profile that uses `lto = "thin"`.
- Use this profile to build macos arm64 wheel