### PR TITLE
Add optional allocators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,12 @@ version = "0.21"
 features = ["extension-module", "abi3", "abi3-py37"]
 optional = true
 
+[target.'cfg(all(any(not(target_family = "unix"), allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+mimalloc = { version = "0.1", default-features = false }
+
+[target.'cfg(all(target_family = "unix", not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+tikv-jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
+
 [dev-dependencies]
 approx = "0.5"
 criterion = "0.5"

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,29 @@
+#[cfg(all(
+    target_family = "unix",
+    not(allocator = "default"),
+    not(allocator = "mimalloc"),
+))]
+use tikv_jemallocator::Jemalloc;
+#[cfg(all(
+    not(debug_assertions),
+    not(allocator = "default"),
+    any(not(target_family = "unix"), allocator = "mimalloc"),
+))]
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+#[cfg(all(
+    not(debug_assertions),
+    not(allocator = "mimalloc"),
+    not(allocator = "default"),
+    target_family = "unix",
+))]
+static ALLOC: Jemalloc = Jemalloc;
+
+#[global_allocator]
+#[cfg(all(
+    not(debug_assertions),
+    not(allocator = "default"),
+    any(not(target_family = "unix"), allocator = "mimalloc"),
+))]
+static ALLOC: MiMalloc = MiMalloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::too_many_arguments)]
 
+mod allocator;
 #[cfg(feature = "dft")]
 mod functional;
 #[cfg(feature = "dft")]


### PR DESCRIPTION
Adds `mimalloc` and `jemalloc` as optional allocators.

Use one of `default`, `mimalloc`, or `jemalloc` as rust flag to select allocator.

Example for `mimalloc`:

`RUSTFLAGS="--cfg allocator=\"mimalloc\"" maturin build`

The same can be used to run benches.