### PR TITLE
Reimplement Molarweight trait

### DIFF
--- a/feos-core/src/cubic.rs
+++ b/feos-core/src/cubic.rs
@@ -4,7 +4,7 @@
 //! of state - with a single contribution to the Helmholtz energy - can be implemented.
 //! The implementation closely follows the form of the equations given in
 //! [this wikipedia article](https://en.wikipedia.org/wiki/Cubic_equations_of_state#Peng%E2%80%93Robinson_equation_of_state).
-use crate::equation_of_state::{Components, Residual};
+use crate::equation_of_state::{Components, Molarweight, Residual};
 use crate::parameter::{Identifier, Parameter, ParameterError, PureRecord};
 use crate::state::StateHD;
 use ndarray::{Array1, Array2, ScalarOperand};
@@ -214,7 +214,9 @@ impl Residual for PengRobinson {
             self.residual_helmholtz_energy(state),
         )]
     }
+}
 
+impl Molarweight for PengRobinson {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         &self.parameters.molarweight * (GRAM / MOL)
     }

--- a/feos-core/src/equation_of_state/mod.rs
+++ b/feos-core/src/equation_of_state/mod.rs
@@ -9,7 +9,7 @@ mod ideal_gas;
 mod residual;
 
 pub use ideal_gas::IdealGas;
-pub use residual::{EntropyScaling, NoResidual, Residual};
+pub use residual::{EntropyScaling, Molarweight, NoResidual, Residual};
 
 /// The number of components that the model is initialized for.
 pub trait Components {
@@ -91,7 +91,9 @@ impl<I: IdealGas, R: Residual> Residual for EquationOfState<I, R> {
     ) -> Vec<(String, D)> {
         self.residual.residual_helmholtz_energy_contributions(state)
     }
+}
 
+impl<I, R: Molarweight> Molarweight for EquationOfState<I, R> {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.residual.molar_weight()
     }

--- a/feos-core/src/equation_of_state/residual.rs
+++ b/feos-core/src/equation_of_state/residual.rs
@@ -8,7 +8,14 @@ use quantity::*;
 use std::ops::Div;
 use typenum::Quot;
 
-/// A reisdual Helmholtz energy model.
+/// Molar weight of all components.
+///
+/// Enables calculation of (mass) specific properties.
+pub trait Molarweight {
+    fn molar_weight(&self) -> MolarWeight<Array1<f64>>;
+}
+
+/// A residual Helmholtz energy model.
 pub trait Residual: Components + Send + Sync {
     /// Return the maximum density in Angstrom^-3.
     ///
@@ -17,11 +24,6 @@ pub trait Residual: Components + Send + Sync {
     /// be a mathematical limit for the density (if those exist in the
     /// equation of state anyways).
     fn compute_max_density(&self, moles: &Array1<f64>) -> f64;
-
-    /// Molar weight of all components.
-    ///
-    /// Enables calculation of (mass) specific properties.
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>>;
 
     /// Evaluate the reduced Helmholtz energy of each individual contribution
     /// and return them together with a string representation of the contribution.
@@ -192,9 +194,5 @@ impl Residual for NoResidual {
         _: &StateHD<D>,
     ) -> Vec<(String, D)> {
         vec![]
-    }
-
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
-        panic!("No mass specific properties are available for this model!")
     }
 }

--- a/feos-core/src/lib.rs
+++ b/feos-core/src/lib.rs
@@ -33,7 +33,7 @@ pub mod parameter;
 mod phase_equilibria;
 mod state;
 pub use equation_of_state::{
-    Components, EntropyScaling, EquationOfState, IdealGas, NoResidual, Residual,
+    Components, EntropyScaling, EquationOfState, IdealGas, Molarweight, NoResidual, Residual,
 };
 pub use errors::{EosError, EosResult};
 pub use phase_equilibria::{

--- a/feos-core/src/python/phase_equilibria.rs
+++ b/feos-core/src/python/phase_equilibria.rs
@@ -943,21 +943,23 @@ macro_rules! impl_phase_equilibrium {
                 if different_pressures {
                     dict.insert(String::from("pressure vapor"), p_v);
                     dict.insert(String::from("pressure liquid"), p_l);
-                }else {
+                } else {
                     dict.insert(String::from("pressure"), p_v);
                 }
                 dict.insert(String::from("density liquid"), self.0.liquid().density().convert_to(MOL / METER.powi::<P3>()).into_raw_vec_and_offset().0);
                 dict.insert(String::from("density vapor"), self.0.vapor().density().convert_to(MOL / METER.powi::<P3>()).into_raw_vec_and_offset().0);
-                dict.insert(String::from("mass density liquid"), self.0.liquid().mass_density().convert_to(KILOGRAM / METER.powi::<P3>()).into_raw_vec_and_offset().0);
-                dict.insert(String::from("mass density vapor"), self.0.vapor().mass_density().convert_to(KILOGRAM / METER.powi::<P3>()).into_raw_vec_and_offset().0);
                 dict.insert(String::from("molar enthalpy liquid"), self.0.liquid().molar_enthalpy(contributions).convert_to(KILO * JOULE / MOL).into_raw_vec_and_offset().0);
                 dict.insert(String::from("molar enthalpy vapor"), self.0.vapor().molar_enthalpy(contributions).convert_to(KILO * JOULE / MOL).into_raw_vec_and_offset().0);
                 dict.insert(String::from("molar entropy liquid"), self.0.liquid().molar_entropy(contributions).convert_to(KILO * JOULE / KELVIN / MOL).into_raw_vec_and_offset().0);
                 dict.insert(String::from("molar entropy vapor"), self.0.vapor().molar_entropy(contributions).convert_to(KILO * JOULE / KELVIN / MOL).into_raw_vec_and_offset().0);
-                dict.insert(String::from("specific enthalpy liquid"), self.0.liquid().specific_enthalpy(contributions).convert_to(KILO * JOULE / KILOGRAM).into_raw_vec_and_offset().0);
-                dict.insert(String::from("specific enthalpy vapor"), self.0.vapor().specific_enthalpy(contributions).convert_to(KILO * JOULE / KILOGRAM).into_raw_vec_and_offset().0);
-                dict.insert(String::from("specific entropy liquid"), self.0.liquid().specific_entropy(contributions).convert_to(KILO * JOULE / KELVIN / KILOGRAM).into_raw_vec_and_offset().0);
-                dict.insert(String::from("specific entropy vapor"), self.0.vapor().specific_entropy(contributions).convert_to(KILO * JOULE / KELVIN / KILOGRAM).into_raw_vec_and_offset().0);
+                if self.0.states[0].liquid().eos.residual.has_molar_weight() {
+                    dict.insert(String::from("mass density liquid"), self.0.liquid().mass_density().convert_to(KILOGRAM / METER.powi::<P3>()).into_raw_vec_and_offset().0);
+                    dict.insert(String::from("mass density vapor"), self.0.vapor().mass_density().convert_to(KILOGRAM / METER.powi::<P3>()).into_raw_vec_and_offset().0);
+                    dict.insert(String::from("specific enthalpy liquid"), self.0.liquid().specific_enthalpy(contributions).convert_to(KILO * JOULE / KILOGRAM).into_raw_vec_and_offset().0);
+                    dict.insert(String::from("specific enthalpy vapor"), self.0.vapor().specific_enthalpy(contributions).convert_to(KILO * JOULE / KILOGRAM).into_raw_vec_and_offset().0);
+                    dict.insert(String::from("specific entropy liquid"), self.0.liquid().specific_entropy(contributions).convert_to(KILO * JOULE / KELVIN / KILOGRAM).into_raw_vec_and_offset().0);
+                    dict.insert(String::from("specific entropy vapor"), self.0.vapor().specific_entropy(contributions).convert_to(KILO * JOULE / KELVIN / KILOGRAM).into_raw_vec_and_offset().0);
+                }
                 dict
             }
 

--- a/feos-core/src/python/user_defined.rs
+++ b/feos-core/src/python/user_defined.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-use crate::{Components, IdealGas, Residual, StateHD};
+use crate::{Components, IdealGas, Molarweight, Residual, StateHD};
 use ndarray::{Array1, ScalarOperand};
 use num_dual::*;
 use numpy::convert::IntoPyArray;
@@ -203,7 +203,9 @@ macro_rules! impl_residual {
                 ) -> Vec<(String, D)> {
                 vec![("Python".to_string(), self.residual_helmholtz_energy(state))]
             }
+        }
 
+        impl Molarweight for PyResidual {
             fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
                 Python::with_gil(|py| {
                     let py_result = self.0.bind(py).call_method0("molar_weight").unwrap();

--- a/feos-core/src/state/properties.rs
+++ b/feos-core/src/state/properties.rs
@@ -1,5 +1,5 @@
 use super::{Contributions, Derivative::*, PartialDerivative, State};
-use crate::equation_of_state::{IdealGas, Residual};
+use crate::equation_of_state::{IdealGas, Molarweight, Residual};
 use crate::ReferenceSystem;
 use ndarray::Array1;
 use quantity::*;
@@ -74,14 +74,6 @@ impl<E: Residual + IdealGas> State<E> {
         self.temperature * self.ds_dt(contributions) / self.total_moles
     }
 
-    /// Specific isochoric heat capacity: $c_v^{(m)}=\frac{C_v}{m}$
-    pub fn specific_isochoric_heat_capacity(
-        &self,
-        contributions: Contributions,
-    ) -> SpecificEntropy {
-        self.molar_isochoric_heat_capacity(contributions) / self.total_molar_weight()
-    }
-
     /// Partial derivative of the molar isochoric heat capacity w.r.t. temperature: $\left(\frac{\partial c_V}{\partial T}\right)_{V,N_i}$
     pub fn dc_v_dt(
         &self,
@@ -103,11 +95,6 @@ impl<E: Residual + IdealGas> State<E> {
         }
     }
 
-    /// Specific isobaric heat capacity: $c_p^{(m)}=\frac{C_p}{m}$
-    pub fn specific_isobaric_heat_capacity(&self, contributions: Contributions) -> SpecificEntropy {
-        self.molar_isobaric_heat_capacity(contributions) / self.total_molar_weight()
-    }
-
     /// Entropy: $S=-\left(\frac{\partial A}{\partial T}\right)_{V,N_i}$
     pub fn entropy(&self, contributions: Contributions) -> Entropy {
         Entropy::from_reduced(
@@ -118,11 +105,6 @@ impl<E: Residual + IdealGas> State<E> {
     /// Molar entropy: $s=\frac{S}{N}$
     pub fn molar_entropy(&self, contributions: Contributions) -> MolarEntropy {
         self.entropy(contributions) / self.total_moles
-    }
-
-    /// Specific entropy: $s^{(m)}=\frac{S}{m}$
-    pub fn specific_entropy(&self, contributions: Contributions) -> SpecificEntropy {
-        self.molar_entropy(contributions) / self.total_molar_weight()
     }
 
     /// Partial molar entropy: $s_i=\left(\frac{\partial S}{\partial N_i}\right)_{T,p,N_j}$
@@ -160,11 +142,6 @@ impl<E: Residual + IdealGas> State<E> {
         self.enthalpy(contributions) / self.total_moles
     }
 
-    /// Specific enthalpy: $h^{(m)}=\frac{H}{m}$
-    pub fn specific_enthalpy(&self, contributions: Contributions) -> SpecificEnergy {
-        self.molar_enthalpy(contributions) / self.total_molar_weight()
-    }
-
     /// Partial molar enthalpy: $h_i=\left(\frac{\partial H}{\partial N_i}\right)_{T,p,N_j}$
     pub fn partial_molar_enthalpy(&self) -> MolarEnergy<Array1<f64>> {
         let s = self.partial_molar_entropy();
@@ -184,11 +161,6 @@ impl<E: Residual + IdealGas> State<E> {
         self.helmholtz_energy(contributions) / self.total_moles
     }
 
-    /// Specific Helmholtz energy: $a^{(m)}=\frac{A}{m}$
-    pub fn specific_helmholtz_energy(&self, contributions: Contributions) -> SpecificEnergy {
-        self.molar_helmholtz_energy(contributions) / self.total_molar_weight()
-    }
-
     /// Internal energy: $U=A+TS$
     pub fn internal_energy(&self, contributions: Contributions) -> Energy {
         self.temperature * self.entropy(contributions) + self.helmholtz_energy(contributions)
@@ -199,11 +171,6 @@ impl<E: Residual + IdealGas> State<E> {
         self.internal_energy(contributions) / self.total_moles
     }
 
-    /// Specific internal energy: $u^{(m)}=\frac{U}{m}$
-    pub fn specific_internal_energy(&self, contributions: Contributions) -> SpecificEnergy {
-        self.molar_internal_energy(contributions) / self.total_molar_weight()
-    }
-
     /// Gibbs energy: $G=A+pV$
     pub fn gibbs_energy(&self, contributions: Contributions) -> Energy {
         self.pressure(contributions) * self.volume + self.helmholtz_energy(contributions)
@@ -212,11 +179,6 @@ impl<E: Residual + IdealGas> State<E> {
     /// Molar Gibbs energy: $g=\frac{G}{N}$
     pub fn molar_gibbs_energy(&self, contributions: Contributions) -> MolarEnergy {
         self.gibbs_energy(contributions) / self.total_moles
-    }
-
-    /// Specific Gibbs energy: $g^{(m)}=\frac{G}{m}$
-    pub fn specific_gibbs_energy(&self, contributions: Contributions) -> SpecificEnergy {
-        self.molar_gibbs_energy(contributions) / self.total_molar_weight()
     }
 
     /// Joule Thomson coefficient: $\mu_{JT}=\left(\frac{\partial T}{\partial p}\right)_{H,N_i}$
@@ -277,6 +239,46 @@ impl<E: Residual + IdealGas> State<E> {
             }
         }
         res
+    }
+}
+
+impl<E: Residual + Molarweight + IdealGas> State<E> {
+    /// Specific isochoric heat capacity: $c_v^{(m)}=\frac{C_v}{m}$
+    pub fn specific_isochoric_heat_capacity(
+        &self,
+        contributions: Contributions,
+    ) -> SpecificEntropy {
+        self.molar_isochoric_heat_capacity(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific isobaric heat capacity: $c_p^{(m)}=\frac{C_p}{m}$
+    pub fn specific_isobaric_heat_capacity(&self, contributions: Contributions) -> SpecificEntropy {
+        self.molar_isobaric_heat_capacity(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific entropy: $s^{(m)}=\frac{S}{m}$
+    pub fn specific_entropy(&self, contributions: Contributions) -> SpecificEntropy {
+        self.molar_entropy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific enthalpy: $h^{(m)}=\frac{H}{m}$
+    pub fn specific_enthalpy(&self, contributions: Contributions) -> SpecificEnergy {
+        self.molar_enthalpy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific Helmholtz energy: $a^{(m)}=\frac{A}{m}$
+    pub fn specific_helmholtz_energy(&self, contributions: Contributions) -> SpecificEnergy {
+        self.molar_helmholtz_energy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific internal energy: $u^{(m)}=\frac{U}{m}$
+    pub fn specific_internal_energy(&self, contributions: Contributions) -> SpecificEnergy {
+        self.molar_internal_energy(contributions) / self.total_molar_weight()
+    }
+
+    /// Specific Gibbs energy: $g^{(m)}=\frac{G}{m}$
+    pub fn specific_gibbs_energy(&self, contributions: Contributions) -> SpecificEnergy {
+        self.molar_gibbs_energy(contributions) / self.total_molar_weight()
     }
 
     /// Speed of sound: $c=\sqrt{\left(\frac{\partial p}{\partial\rho^{(m)}}\right)_{S,N_i}}$

--- a/feos-core/src/state/residual_properties.rs
+++ b/feos-core/src/state/residual_properties.rs
@@ -1,5 +1,5 @@
 use super::{Contributions, Derivative::*, PartialDerivative, State};
-use crate::equation_of_state::{EntropyScaling, Residual};
+use crate::equation_of_state::{EntropyScaling, Molarweight, Residual};
 use crate::errors::EosResult;
 use crate::phase_equilibria::PhaseEquilibrium;
 use crate::ReferenceSystem;
@@ -484,7 +484,9 @@ impl<E: Residual> State<E> {
     pub fn residual_molar_gibbs_energy(&self) -> MolarEnergy {
         self.residual_gibbs_energy() / self.total_moles
     }
+}
 
+impl<E: Residual + Molarweight> State<E> {
     /// Total molar weight: $MW=\sum_ix_iMW_i$
     pub fn total_molar_weight(&self) -> MolarWeight {
         (self.eos.molar_weight() * Dimensionless::new(&self.molefracs)).sum()

--- a/feos-derive/src/dft.rs
+++ b/feos-derive/src/dft.rs
@@ -100,11 +100,15 @@ fn impl_helmholtz_energy_functional(
     });
 
     let mut molar_weight = Vec::new();
+    let mut has_molar_weight = Vec::new();
     for v in variants.iter() {
         if implement("molar_weight", v, &OPT_IMPLS)? {
             let name = &v.ident;
             molar_weight.push(quote! {
                 Self::#name(functional) => functional.molar_weight()
+            });
+            has_molar_weight.push(quote! {
+                Self::#name(functional) => true
             });
         }
     }
@@ -137,16 +141,28 @@ fn impl_helmholtz_energy_functional(
                     #(#contributions,)*
                 }
             }
+            fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
+                match self {
+                    #(#bond_lengths,)*
+                    _ => Graph::with_capacity(0, 0),
+                }
+            }
+        }
+
+        impl Molarweight for FunctionalVariant {
             fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
                 match self {
                     #(#molar_weight,)*
                     _ => unimplemented!()
                 }
             }
-            fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
+        }
+
+        impl FunctionalVariant {
+            pub fn has_molar_weight(&self) -> bool {
                 match self {
-                    #(#bond_lengths,)*
-                    _ => Graph::with_capacity(0, 0),
+                    #(#has_molar_weight,)*
+                    _ => false,
                 }
             }
         }

--- a/feos-dft/src/adsorption/pore.rs
+++ b/feos-dft/src/adsorption/pore.rs
@@ -12,9 +12,7 @@ use ndarray::Axis as Axis_nd;
 use ndarray::RemoveAxis;
 use num_dual::linalg::LU;
 use num_dual::DualNum;
-use quantity::{
-    Density, Dimensionless, Energy, Length, MolarEnergy, MolarWeight, Temperature, Volume, KELVIN,
-};
+use quantity::{Density, Dimensionless, Energy, Length, MolarEnergy, Temperature, Volume, KELVIN};
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -298,10 +296,6 @@ impl HelmholtzEnergyFunctional for Helium {
 
     fn molecule_shape(&self) -> MoleculeShape {
         MoleculeShape::Spherical(1)
-    }
-
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
-        unreachable!()
     }
 }
 

--- a/src/eos.rs
+++ b/src/eos.rs
@@ -15,11 +15,11 @@ use crate::uvtheory::UVTheory;
 use feos_core::cubic::PengRobinson;
 #[cfg(feature = "python")]
 use feos_core::python::user_defined::PyResidual;
-use quantity::*;
 use feos_core::*;
 use feos_derive::{Components, Residual};
 use ndarray::{Array1, ScalarOperand};
 use num_dual::DualNum;
+use quantity::*;
 
 /// Collection of different [Residual] implementations.
 ///
@@ -29,22 +29,29 @@ use num_dual::DualNum;
 pub enum ResidualModel {
     NoResidual(NoResidual),
     #[cfg(feature = "pcsaft")]
-    #[implement(entropy_scaling)]
+    #[implement(entropy_scaling, molar_weight)]
     PcSaft(PcSaft),
     #[cfg(feature = "epcsaft")]
+    #[implement(molar_weight)]
     ElectrolytePcSaft(ElectrolytePcSaft),
     #[cfg(feature = "gc_pcsaft")]
+    #[implement(molar_weight)]
     GcPcSaft(GcPcSaft),
+    #[implement(molar_weight)]
     PengRobinson(PengRobinson),
     #[cfg(feature = "python")]
+    #[implement(molar_weight)]
     Python(PyResidual),
     #[cfg(feature = "saftvrqmie")]
-    #[implement(entropy_scaling)]
+    #[implement(entropy_scaling, molar_weight)]
     SaftVRQMie(SaftVRQMie),
     #[cfg(feature = "saftvrmie")]
+    #[implement(molar_weight)]
     SaftVRMie(SaftVRMie),
     #[cfg(feature = "pets")]
+    #[implement(molar_weight)]
     Pets(Pets),
     #[cfg(feature = "uvtheory")]
+    #[implement(molar_weight)]
     UVTheory(UVTheory),
 }

--- a/src/epcsaft/eos/mod.rs
+++ b/src/epcsaft/eos/mod.rs
@@ -2,8 +2,8 @@ use crate::association::Association;
 use crate::epcsaft::parameters::ElectrolytePcSaftParameters;
 use crate::hard_sphere::{HardSphere, HardSphereProperties};
 use feos_core::parameter::Parameter;
-use feos_core::StateHD;
 use feos_core::{Components, Residual};
+use feos_core::{Molarweight, StateHD};
 use ndarray::Array1;
 use num_dual::DualNum;
 use quantity::*;
@@ -187,7 +187,9 @@ impl Residual for ElectrolytePcSaft {
         };
         v
     }
+}
 
+impl Molarweight for ElectrolytePcSaft {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/estimator/liquid_density.rs
+++ b/src/estimator/liquid_density.rs
@@ -1,6 +1,7 @@
 use super::{DataSet, EstimatorError};
 use feos_core::{
-    DensityInitialization, PhaseEquilibrium, ReferenceSystem, Residual, SolverOptions, State,
+    DensityInitialization, Molarweight, PhaseEquilibrium, ReferenceSystem, Residual, SolverOptions,
+    State,
 };
 use ndarray::{arr1, Array1};
 use quantity::{MassDensity, Moles, Pressure, Temperature, KILOGRAM, METER};
@@ -47,7 +48,7 @@ impl LiquidDensity {
     }
 }
 
-impl<E: Residual> DataSet<E> for LiquidDensity {
+impl<E: Residual + Molarweight> DataSet<E> for LiquidDensity {
     fn target(&self) -> &Array1<f64> {
         &self.target
     }
@@ -119,7 +120,7 @@ impl EquilibriumLiquidDensity {
     }
 }
 
-impl<E: Residual> DataSet<E> for EquilibriumLiquidDensity {
+impl<E: Residual + Molarweight> DataSet<E> for EquilibriumLiquidDensity {
     fn target(&self) -> &Array1<f64> {
         &self.target
     }

--- a/src/gc_pcsaft/dft/mod.rs
+++ b/src/gc_pcsaft/dft/mod.rs
@@ -3,8 +3,7 @@ use super::record::GcPcSaftAssociationRecord;
 use crate::association::{Association, AssociationStrength};
 use crate::hard_sphere::{FMTContribution, FMTVersion, HardSphereProperties, MonomerShape};
 use feos_core::parameter::ParameterHetero;
-use quantity::{MolarWeight, GRAM, MOL};
-use feos_core::{Components, EosResult};
+use feos_core::{Components, EosResult, Molarweight};
 use feos_derive::FunctionalContribution;
 use feos_dft::adsorption::FluidParameters;
 use feos_dft::{
@@ -13,6 +12,7 @@ use feos_dft::{
 use ndarray::{Array1, ArrayView2, ScalarOperand};
 use num_dual::DualNum;
 use petgraph::graph::UnGraph;
+use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
@@ -110,10 +110,6 @@ impl HelmholtzEnergyFunctional for GcPcSaftFunctional {
         Box::new(contributions.into_iter())
     }
 
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
-        self.parameters.molarweight.clone() * GRAM / MOL
-    }
-
     fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
         // temperature dependent segment diameter
         let d = self.parameters.hs_diameter(temperature);
@@ -127,6 +123,12 @@ impl HelmholtzEnergyFunctional for GcPcSaftFunctional {
                 0.5 * (di + dj)
             },
         )
+    }
+}
+
+impl Molarweight for GcPcSaftFunctional {
+    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
+        self.parameters.molarweight.clone() * GRAM / MOL
     }
 }
 

--- a/src/gc_pcsaft/eos/mod.rs
+++ b/src/gc_pcsaft/eos/mod.rs
@@ -1,7 +1,7 @@
 use crate::association::Association;
 use crate::hard_sphere::{HardSphere, HardSphereProperties};
 use feos_core::parameter::ParameterHetero;
-use feos_core::{Components, Residual};
+use feos_core::{Components, Molarweight, Residual};
 use ndarray::Array1;
 use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
@@ -139,7 +139,9 @@ impl Residual for GcPcSaft {
         }
         v
     }
+}
 
+impl Molarweight for GcPcSaft {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/hard_sphere/dft.rs
+++ b/src/hard_sphere/dft.rs
@@ -7,7 +7,6 @@ use feos_dft::{
 };
 use ndarray::*;
 use num_dual::DualNum;
-use quantity::MolarWeight;
 use std::f64::consts::PI;
 use std::fmt;
 use std::sync::Arc;
@@ -351,10 +350,6 @@ impl HelmholtzEnergyFunctional for FMTFunctional {
 
     fn compute_max_density(&self, moles: &Array1<f64>) -> f64 {
         moles.sum() / (moles * &self.properties.sigma).sum() * 1.2
-    }
-
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
-        panic!("No mass specific properties are available for this model!")
     }
 
     fn molecule_shape(&self) -> MoleculeShape {

--- a/src/pcsaft/dft/mod.rs
+++ b/src/pcsaft/dft/mod.rs
@@ -3,8 +3,7 @@ use crate::association::Association;
 use crate::hard_sphere::{FMTContribution, FMTVersion};
 use crate::pcsaft::eos::PcSaftOptions;
 use feos_core::parameter::Parameter;
-use quantity::{MolarWeight, GRAM, MOL};
-use feos_core::{Components, EosResult};
+use feos_core::{Components, EosResult, Molarweight};
 use feos_derive::FunctionalContribution;
 use feos_dft::adsorption::FluidParameters;
 use feos_dft::solvation::PairPotential;
@@ -14,6 +13,7 @@ use feos_dft::{
 use ndarray::{Array1, Array2, ArrayView2, ScalarOperand};
 use num_dual::DualNum;
 use num_traits::One;
+use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
@@ -126,7 +126,9 @@ impl HelmholtzEnergyFunctional for PcSaftFunctional {
     fn molecule_shape(&self) -> MoleculeShape {
         MoleculeShape::NonSpherical(&self.parameters.m)
     }
+}
 
+impl Molarweight for PcSaftFunctional {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/pcsaft/eos/mod.rs
+++ b/src/pcsaft/eos/mod.rs
@@ -3,7 +3,8 @@ use crate::association::Association;
 use crate::hard_sphere::{HardSphere, HardSphereProperties};
 use feos_core::parameter::Parameter;
 use feos_core::{
-    Components, EntropyScaling, EosError, EosResult, ReferenceSystem, Residual, State, StateHD,
+    Components, EntropyScaling, EosError, EosResult, Molarweight, ReferenceSystem, Residual, State,
+    StateHD,
 };
 use ndarray::Array1;
 use num_dual::DualNum;
@@ -180,7 +181,9 @@ impl Residual for PcSaft {
         }
         v
     }
+}
 
+impl Molarweight for PcSaft {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/pets/dft/mod.rs
+++ b/src/pets/dft/mod.rs
@@ -3,8 +3,7 @@ use super::parameters::PetsParameters;
 use crate::hard_sphere::{FMTContribution, FMTVersion};
 use dispersion::AttractiveFunctional;
 use feos_core::parameter::Parameter;
-use quantity::{MolarWeight, GRAM, MOL};
-use feos_core::{Components, EosResult};
+use feos_core::{Components, EosResult, Molarweight};
 use feos_derive::FunctionalContribution;
 use feos_dft::adsorption::FluidParameters;
 use feos_dft::solvation::PairPotential;
@@ -14,6 +13,7 @@ use feos_dft::{
 use ndarray::{Array1, Array2, ArrayView2, ScalarOperand};
 use num_dual::DualNum;
 use pure_pets_functional::*;
+use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
@@ -111,7 +111,9 @@ impl HelmholtzEnergyFunctional for PetsFunctional {
 
         Box::new(contributions.into_iter())
     }
+}
 
+impl Molarweight for PetsFunctional {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/pets/eos/mod.rs
+++ b/src/pets/eos/mod.rs
@@ -1,9 +1,9 @@
 use super::parameters::PetsParameters;
 use crate::hard_sphere::HardSphere;
 use feos_core::parameter::Parameter;
-use quantity::{MolarWeight, GRAM, MOL};
-use feos_core::{Components, Residual};
+use feos_core::{Components, Molarweight, Residual};
 use ndarray::Array1;
+use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
@@ -89,7 +89,9 @@ impl Residual for Pets {
             ),
         ]
     }
+}
 
+impl Molarweight for Pets {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }
@@ -314,9 +316,9 @@ mod tests {
         argon_krypton_parameters, argon_parameters, krypton_parameters,
     };
     use approx::assert_relative_eq;
-    use quantity::{BAR, KELVIN, METER, PASCAL, RGAS};
     use feos_core::{Contributions, DensityInitialization, PhaseEquilibrium, State, StateHD};
     use ndarray::arr1;
+    use quantity::{BAR, KELVIN, METER, PASCAL, RGAS};
     use typenum::P3;
 
     #[test]

--- a/src/saftvrmie/eos/mod.rs
+++ b/src/saftvrmie/eos/mod.rs
@@ -3,7 +3,7 @@ use crate::hard_sphere::HardSphere;
 use super::SaftVRMieParameters;
 use association::Association;
 use feos_core::parameter::Parameter;
-use feos_core::{Components, Residual, StateHD};
+use feos_core::{Components, Molarweight, Residual, StateHD};
 use ndarray::{Array1, ScalarOperand};
 use num_dual::DualNum;
 use quantity::{MolarWeight, GRAM, MOL};
@@ -83,10 +83,6 @@ impl Residual for SaftVRMie {
                 .sum()
     }
 
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
-        self.parameters.molarweight.clone() * GRAM / MOL
-    }
-
     fn residual_helmholtz_energy_contributions<D: DualNum<f64> + Copy + ScalarOperand>(
         &self,
         state: &StateHD<D>,
@@ -108,5 +104,11 @@ impl Residual for SaftVRMie {
             a.push(("Association".to_string(), assoc.helmholtz_energy(state, &d)));
         }
         a
+    }
+}
+
+impl Molarweight for SaftVRMie {
+    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
+        self.parameters.molarweight.clone() * GRAM / MOL
     }
 }

--- a/src/saftvrqmie/dft/mod.rs
+++ b/src/saftvrqmie/dft/mod.rs
@@ -3,8 +3,7 @@ use crate::saftvrqmie::eos::SaftVRQMieOptions;
 use crate::saftvrqmie::parameters::SaftVRQMieParameters;
 use dispersion::AttractiveFunctional;
 use feos_core::parameter::Parameter;
-use quantity::{MolarWeight, GRAM, MOL};
-use feos_core::{Components, EosResult};
+use feos_core::{Components, EosResult, Molarweight};
 use feos_derive::FunctionalContribution;
 use feos_dft::adsorption::FluidParameters;
 use feos_dft::solvation::PairPotential;
@@ -14,6 +13,7 @@ use feos_dft::{
 use ndarray::{Array, Array1, Array2, ArrayView2, ScalarOperand};
 use non_additive_hs::NonAddHardSphereFunctional;
 use num_dual::DualNum;
+use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
@@ -97,12 +97,14 @@ impl HelmholtzEnergyFunctional for SaftVRQMieFunctional {
         Box::new(contributions.into_iter())
     }
 
-    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
-        self.parameters.molarweight.clone() * GRAM / MOL
-    }
-
     fn molecule_shape(&self) -> MoleculeShape {
         MoleculeShape::NonSpherical(&self.parameters.m)
+    }
+}
+
+impl Molarweight for SaftVRQMieFunctional {
+    fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
+        self.parameters.molarweight.clone() * GRAM / MOL
     }
 }
 

--- a/src/saftvrqmie/eos/mod.rs
+++ b/src/saftvrqmie/eos/mod.rs
@@ -1,7 +1,7 @@
 use super::parameters::SaftVRQMieParameters;
 use feos_core::parameter::{Parameter, ParameterError};
 use feos_core::{
-    Components, EntropyScaling, EosError, EosResult, ReferenceSystem, Residual, State,
+    Components, EntropyScaling, EosError, EosResult, Molarweight, ReferenceSystem, Residual, State,
 };
 use ndarray::{Array1, Array2};
 use num_dual::DualNum;
@@ -184,7 +184,9 @@ impl Residual for SaftVRQMie {
         }
         v
     }
+}
 
+impl Molarweight for SaftVRQMie {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }

--- a/src/uvtheory/eos/mod.rs
+++ b/src/uvtheory/eos/mod.rs
@@ -1,18 +1,17 @@
 #![allow(clippy::excessive_precision)]
 #![allow(clippy::needless_range_loop)]
-
-use self::bh::BarkerHenderson;
-use self::wca::{WeeksChandlerAndersen, WeeksChandlerAndersenB3};
-
 use super::parameters::UVTheoryParameters;
-use feos_core::{parameter::Parameter, Components, Residual};
+use feos_core::parameter::Parameter;
+use feos_core::{Components, Molarweight, Residual};
 use ndarray::Array1;
 use quantity::{MolarWeight, GRAM, MOL};
 use std::f64::consts::FRAC_PI_6;
 use std::sync::Arc;
 
 mod bh;
+use bh::BarkerHenderson;
 mod wca;
+use wca::{WeeksChandlerAndersen, WeeksChandlerAndersenB3};
 
 /// Type of perturbation.
 #[derive(Clone, Copy, PartialEq)]
@@ -118,7 +117,9 @@ impl Residual for UVTheory {
             }
         }
     }
+}
 
+impl Molarweight for UVTheory {
     fn molar_weight(&self) -> MolarWeight<Array1<f64>> {
         self.parameters.molarweight.clone() * GRAM / MOL
     }


### PR DESCRIPTION
## :boom: The `Molarweight` trait makes a comeback :boom:
Analogous to `EntropyScaling`, implementing molar weights for models in Rust becomes optional again. Specific properties can thus only be evaluated if the trait is implemented.

IIRC, the last time around this lead to crashes due to panics within getters? The `StateVec` getters that require a molar weight and the `to_dict` methods will now check first if the given variant provides a molar weight.