### PR TITLE
Update `gauss-quad` to 0.2

### DIFF
--- a/feos-dft/Cargo.toml
+++ b/feos-dft/Cargo.toml
@@ -29,7 +29,7 @@ rustdct = "0.7"
 rustfft = "6.0"
 num-traits = "0.2"
 libm = "0.2"
-gauss-quad = { version = "0.1", optional = true }
+gauss-quad = { version = "0.2", optional = true }
 petgraph = "0.6"
 typenum = "1.16"
 numpy = { version = "0.22", optional = true }

--- a/feos-dft/src/adsorption/fea_potential.rs
+++ b/feos-dft/src/adsorption/fea_potential.rs
@@ -54,8 +54,14 @@ pub fn calculate_fea_potential(
             (nodes, weights)
         }
         Geometry::Spherical | Geometry::Cylindrical => {
-            let nodes = PI + Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[0]).0) * PI;
-            let weights = Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[0]).1) * PI;
+            let (unscaled_nodes, unscaled_weights) = GaussLegendre::new(n_grid[0])
+                .unwrap()
+                .into_iter()
+                .unzip();
+
+            let nodes = PI + Array1::from_vec(unscaled_nodes) * PI;
+            let weights = Array1::from_vec(unscaled_weights) * PI;
+
             (nodes, weights)
         }
     };
@@ -75,11 +81,17 @@ pub fn calculate_fea_potential(
             (nodes, weights)
         }
         Geometry::Spherical => {
+            let (unscaled_nodes, unscaled_weights) = GaussLegendre::new(n_grid[1])
+                .unwrap()
+                .into_iter()
+                .unzip();
+
             let nodes = PI / 2.0
-                + Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[1]).0) * PI / 2.0;
-            let weights = Array1::from_vec(GaussLegendre::nodes_and_weights(n_grid[1]).1) * PI
+                + Array1::from_vec(unscaled_nodes) * PI / 2.0;
+            let weights = Array1::from_vec(unscaled_weights) * PI
                 / 2.0
                 * Array1::from_shape_fn(n_grid[1], |i| nodes[i].sin());
+                
             (nodes, weights)
         }
     };

--- a/feos-dft/src/adsorption/fea_potential.rs
+++ b/feos-dft/src/adsorption/fea_potential.rs
@@ -54,10 +54,8 @@ pub fn calculate_fea_potential(
             (nodes, weights)
         }
         Geometry::Spherical | Geometry::Cylindrical => {
-            let (unscaled_nodes, unscaled_weights) = GaussLegendre::new(n_grid[0])
-                .unwrap()
-                .into_iter()
-                .unzip();
+            let (unscaled_nodes, unscaled_weights) =
+                GaussLegendre::new(n_grid[0]).unwrap().into_iter().unzip();
 
             let nodes = PI + Array1::from_vec(unscaled_nodes) * PI;
             let weights = Array1::from_vec(unscaled_weights) * PI;
@@ -81,17 +79,13 @@ pub fn calculate_fea_potential(
             (nodes, weights)
         }
         Geometry::Spherical => {
-            let (unscaled_nodes, unscaled_weights) = GaussLegendre::new(n_grid[1])
-                .unwrap()
-                .into_iter()
-                .unzip();
+            let (unscaled_nodes, unscaled_weights) =
+                GaussLegendre::new(n_grid[1]).unwrap().into_iter().unzip();
 
-            let nodes = PI / 2.0
-                + Array1::from_vec(unscaled_nodes) * PI / 2.0;
-            let weights = Array1::from_vec(unscaled_weights) * PI
-                / 2.0
+            let nodes = PI / 2.0 + Array1::from_vec(unscaled_nodes) * PI / 2.0;
+            let weights = Array1::from_vec(unscaled_weights) * PI / 2.0
                 * Array1::from_shape_fn(n_grid[1], |i| nodes[i].sin());
-                
+
             (nodes, weights)
         }
     };


### PR DESCRIPTION
Hello!

I saw that yours is a big project that uses the crate [`gauss-quad`](https://github.com/domidre/gauss-quad) that I am one of the maintainers of. We recently released version 0.2 that restructures the API. This PR updates `gauss-quad` as well as the two call sites to the new version so that you don't have to.

The main difference this PR introduces into your code is that it removes one computation of the nodes and weights and makes a previously hidden panic and allocation explicit.

As this is an unsolicited PR i understand completely if it is not something you are interested in.