### PR TITLE
Ideal gas properties from DFT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,7 @@ typenum = "1.16"
 
 [dependencies.pyo3]
 version = "0.23"
-<<<<<<< HEAD
 features = ["extension-module", "abi3", "abi3-py39"]
-=======
-features = ["extension-module", "abi3", "abi3-py37"]
->>>>>>> 13057cfa (Update to PyO3 v0.23)
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,11 @@ typenum = "1.16"
 
 [dependencies.pyo3]
 version = "0.23"
+<<<<<<< HEAD
 features = ["extension-module", "abi3", "abi3-py39"]
+=======
+features = ["extension-module", "abi3", "abi3-py37"]
+>>>>>>> 13057cfa (Update to PyO3 v0.23)
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ codegen-units = 1
 
 
 [features]
-default = ["python", "pcsaft", "dft"]
+default = []
 dft = ["feos-dft", "petgraph"]
 estimator = []
 association = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ codegen-units = 1
 
 
 [features]
-default = []
+default = ["python", "pcsaft", "dft"]
 dft = ["feos-dft", "petgraph"]
 estimator = []
 association = []

--- a/docs/theory/dft/ideal_gas.md
+++ b/docs/theory/dft/ideal_gas.md
@@ -1,0 +1,32 @@
+# Ideal gas properties
+Classical DFT can be used to rapidly determine the ideal gas limit of fluids in porous media. In an ideal gas, there are no interactions between the fluid molecules and therefore the residual Helmholtz energy $F^\mathrm{res}$ and its derivatives vanish. Note that this is only the case for spherical or heterosegmented molecules ($m_\alpha=1$), as the chain contribution in the homosegmented model contains intramolecular interactions. The ideal gas density profile can then be obtained directly from the [Euler-Lagrange equation](euler_lagrange_equation.md):
+
+$$\rho_\alpha^\mathrm{ig}(\mathbf{r})=\rho_\alpha^\mathrm{b}e^{-\beta V_\alpha^\mathrm{ext}(\mathbf{r})}\prod_{\alpha'}I^\mathrm{ig}_{\alpha\alpha'}(\mathbf{r})$$ (eqn:rho_ideal_gas)
+
+$$I^\mathrm{ig}_{\alpha\alpha'}(\mathbf{r})=\int e^{-\beta V_{\alpha'}^\mathrm{ext}(\mathbf{r'})}\left(\prod_{\alpha''\neq\alpha}I^\mathrm{ig}_{\alpha'\alpha''}(\mathbf{r'})\right)\omega_\mathrm{chain}^{\alpha\alpha'}(\mathbf{r}-\mathbf{r'})\mathrm{d}\mathbf{r'}$$
+
+ Either from the derivatives presented [previously](derivatives.md), or from directly calculating derivatives of eq. {eq}`eqn:euler_lagrange_mu`, the **Henry coefficient** $H_\alpha$ can be calculated, as
+
+ $$H_\alpha(T)=\left(\frac{\partial N_\alpha^\mathrm{ig}}{\partial p_\alpha}\right)_{T,x_k}=\int\left(\frac{\partial\rho_\alpha^\mathrm{ig}(\mathbf{r})}{\partial p_\alpha}\right)_{T,x_k}\mathrm{d}\mathbf{r}=\beta\int e^{-\beta V_\alpha^\mathrm{ext}(\mathbf{r})}\prod_{\alpha'}I^\mathrm{ig}_{\alpha\alpha'}(\mathbf{r})\mathrm{d}\mathbf{r}$$
+
+By construction the Henry coefficients for all segments $\alpha$ of a molecule $i$ are identical. Therefore, the number of adsorbed molecules in an ideal gas state (the Henry regime) can be calculated from
+
+$$N_i^\mathrm{ig}=k_\mathrm{B}T\rho_i^\mathrm{b}H_i(T)$$
+
+The expression can be used in the general equation for the **enthalpy of adsorption** (see [here](enthalpy_of_adsorption.md))
+
+$$0=\sum_j\left(\frac{\partial N_i^\mathrm{ig}}{\partial\mu_j}\right)_T\Delta h_j^\mathrm{ads,ig}+T\left(\frac{\partial N_i^\mathrm{ig}}{\partial T}\right)_{p,x_k}$$
+
+to simplify to
+
+$$0=\rho_i^\mathrm{b}H_i(T)\Delta h_i^\mathrm{ads,ig}+k_\mathrm{B}T^2\rho_i^\mathrm{b}H_i'(T)$$
+
+and finally
+
+$$\Delta h_i^\mathrm{ads,ig}=-k_\mathrm{B}T^2\frac{H_i'(T)}{H_i(T)}$$
+
+For a spherical molecule without bond integrals, the derivative can be evaluated straightforwardly to yield
+
+$$\Delta h_i^\mathrm{ads,ig}=\frac{\int\left(k_\mathrm{B}T-V_i^\mathrm{ext}(\mathbf{r})\right)e^{-\beta V_i^\mathrm{ext}(\mathbf{r})}\mathrm{d}\mathbf{r}}{\int e^{-\beta V_i^\mathrm{ext}(\mathbf{r})}\mathrm{d}\mathbf{r}}$$
+
+Analytical derivatives of the bond integrals can be determined, however, in $\text{FeO}_\text{s}$ automatic differentiation with dual numbers is used to obtain correct derivatives with barely any implementation overhead.

--- a/docs/theory/dft/index.md
+++ b/docs/theory/dft/index.md
@@ -10,6 +10,7 @@ This section explains the implementation of the core expressions from classical 
    solver
    derivatives
    enthalpy_of_adsorption
+   ideal_gas
    pdgt
 ```
 

--- a/feos-derive/src/dft.rs
+++ b/feos-derive/src/dft.rs
@@ -141,7 +141,7 @@ fn impl_helmholtz_energy_functional(
                     #(#contributions,)*
                 }
             }
-            fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
+            fn bond_lengths<N: DualNum<f64> + Copy>(&self, temperature: N) -> UnGraph<(), N> {
                 match self {
                     #(#bond_lengths,)*
                     _ => Graph::with_capacity(0, 0),

--- a/feos-dft/src/adsorption/mod.rs
+++ b/feos-dft/src/adsorption/mod.rs
@@ -16,7 +16,7 @@ mod fea_potential;
 mod pore;
 mod pore2d;
 pub use external_potential::{ExternalPotential, FluidParameters};
-pub use pore::{Pore1D, PoreProfile, PoreProfile1D, PoreSpecification};
+pub use pore::{HenryCoefficient, Pore1D, PoreProfile, PoreProfile1D, PoreSpecification};
 pub use pore2d::{Pore2D, PoreProfile2D};
 
 #[cfg(feature = "rayon")]

--- a/feos-dft/src/adsorption/pore.rs
+++ b/feos-dft/src/adsorption/pore.rs
@@ -156,6 +156,9 @@ where
         &self,
         temperature: N,
     ) -> Array1<N> {
+        if self.profile.dft.m().iter().any(|&m| m != 1.0) {
+            panic!("Henry coefficients can only be calculated for spherical and heterosegmented molecules!")
+        };
         let pot = self.profile.external_potential.mapv(N::from)
             * self.profile.temperature.to_reduced()
             / temperature;

--- a/feos-dft/src/python/adsorption/pore.rs
+++ b/feos-dft/src/python/adsorption/pore.rs
@@ -28,6 +28,7 @@ macro_rules! impl_pore {
         pub struct PyPoreProfile1D(PoreProfile1D<$func>);
 
         impl_1d_profile!(PyPoreProfile1D, [get_r, get_z]);
+        impl_pore_profile!(PyPoreProfile1D);
 
         #[pymethods]
         impl PyPore1D {
@@ -113,29 +114,6 @@ macro_rules! impl_pore {
             }
         }
 
-        #[pymethods]
-        impl PyPoreProfile1D {
-            #[getter]
-            fn get_grand_potential(&self) -> Option<Energy> {
-                self.0.grand_potential
-            }
-
-            #[getter]
-            fn get_interfacial_tension(&self) -> Option<Energy> {
-                self.0.interfacial_tension
-            }
-
-            #[getter]
-            fn get_partial_molar_enthalpy_of_adsorption(&self) -> PyResult<MolarEnergy<Array1<f64>>> {
-                Ok(self.0.partial_molar_enthalpy_of_adsorption()?.into())
-            }
-
-            #[getter]
-            fn get_enthalpy_of_adsorption(&self) -> PyResult<MolarEnergy> {
-                Ok(self.0.enthalpy_of_adsorption()?.into())
-            }
-        }
-
         #[pyclass(name = "Pore2D")]
         pub struct PyPore2D(Pore2D);
 
@@ -143,6 +121,7 @@ macro_rules! impl_pore {
         pub struct PyPoreProfile2D(PoreProfile2D<$func>);
 
         impl_2d_profile!(PyPoreProfile2D, get_x, get_y);
+        impl_pore_profile!(PyPoreProfile2D);
 
         #[pymethods]
         impl PyPore2D {
@@ -198,38 +177,12 @@ macro_rules! impl_pore {
             }
         }
 
-        #[pymethods]
-        impl PyPoreProfile2D {
-            #[getter]
-            fn get_grand_potential(&self) -> Option<Energy> {
-                self.0.grand_potential
-            }
-
-            #[getter]
-            fn get_interfacial_tension(&self) -> Option<Energy> {
-                self.0.interfacial_tension
-            }
-
-            #[getter]
-            fn get_partial_molar_enthalpy_of_adsorption(&self) -> PyResult<MolarEnergy<Array1<f64>>> {
-                Ok(self.0.partial_molar_enthalpy_of_adsorption()?)
-            }
-
-            #[getter]
-            fn get_enthalpy_of_adsorption(&self) -> PyResult<MolarEnergy> {
-                Ok(self.0.enthalpy_of_adsorption()?)
-            }
-        }
-
         /// Parameters required to specify a 3D pore.
         ///
         /// Parameters
         /// ----------
         /// system_size : [SINumber; 3]
         ///     The size of the unit cell.
-        /// angles : [Angle; 3]
-        ///     The angles of the unit cell or `None` if the unit cell
-        ///     is orthorombic
         /// n_grid : [int; 3]
         ///     The number of grid points in each direction.
         /// coordinates : numpy.ndarray[float]
@@ -238,6 +191,9 @@ macro_rules! impl_pore {
         ///     The size parameters of all interaction sites.
         /// epsilon_k_ss : numpy.ndarray[float]
         ///     The energy parameter of all interaction sites.
+        /// angles : [Angle; 3], optional
+        ///     The angles of the unit cell or `None` if the unit cell
+        ///     is orthorombic
         /// potential_cutoff: float, optional
         ///     Maximum value for the external potential.
         /// cutoff_radius: SINumber, optional
@@ -254,6 +210,7 @@ macro_rules! impl_pore {
         pub struct PyPoreProfile3D(PoreProfile3D<$func>);
 
         impl_3d_profile!(PyPoreProfile3D, get_x, get_y, get_z);
+        impl_pore_profile!(PyPoreProfile3D);
 
         #[pymethods]
         impl PyPore3D {
@@ -320,9 +277,14 @@ macro_rules! impl_pore {
                 Ok(self.0.pore_volume()?.into())
             }
         }
+    };
+}
 
+#[macro_export]
+macro_rules! impl_pore_profile {
+    ($py_profile:ty) => {
         #[pymethods]
-        impl PyPoreProfile3D {
+        impl $py_profile {
             #[getter]
             fn get_grand_potential(&self) -> Option<Energy> {
                 self.0.grand_potential
@@ -334,13 +296,25 @@ macro_rules! impl_pore {
             }
 
             #[getter]
-            fn get_partial_molar_enthalpy_of_adsorption(&self) -> PyResult<MolarEnergy<Array1<f64>>> {
+            fn get_partial_molar_enthalpy_of_adsorption(
+                &self,
+            ) -> PyResult<MolarEnergy<Array1<f64>>> {
                 Ok(self.0.partial_molar_enthalpy_of_adsorption()?)
             }
 
             #[getter]
             fn get_enthalpy_of_adsorption(&self) -> PyResult<MolarEnergy> {
                 Ok(self.0.enthalpy_of_adsorption()?)
+            }
+
+            #[getter]
+            fn get_henry_coefficient(&self) -> PyResult<PySIArray1> {
+                Ok(self.0.henry_coefficient()?.into())
+            }
+
+            #[getter]
+            fn get_ideal_gas_enthalpy_of_adsorption(&self) -> PyResult<PySIArray1> {
+                Ok(self.0.ideal_gas_enthalpy_of_adsorption()?.into())
             }
         }
     };

--- a/feos-dft/src/python/adsorption/pore.rs
+++ b/feos-dft/src/python/adsorption/pore.rs
@@ -308,13 +308,13 @@ macro_rules! impl_pore_profile {
             }
 
             #[getter]
-            fn get_henry_coefficient(&self) -> PyResult<PySIArray1> {
-                Ok(self.0.henry_coefficient()?.into())
+            fn get_henry_coefficients(&self) -> HenryCoefficient<Array1<f64>> {
+                self.0.henry_coefficients()
             }
 
             #[getter]
-            fn get_ideal_gas_enthalpy_of_adsorption(&self) -> PyResult<PySIArray1> {
-                Ok(self.0.ideal_gas_enthalpy_of_adsorption()?.into())
+            fn get_ideal_gas_enthalpy_of_adsorption(&self) -> MolarEnergy<Array1<f64>> {
+                self.0.ideal_gas_enthalpy_of_adsorption()
             }
         }
     };

--- a/src/gc_pcsaft/dft/mod.rs
+++ b/src/gc_pcsaft/dft/mod.rs
@@ -110,7 +110,7 @@ impl HelmholtzEnergyFunctional for GcPcSaftFunctional {
         Box::new(contributions.into_iter())
     }
 
-    fn bond_lengths(&self, temperature: f64) -> UnGraph<(), f64> {
+    fn bond_lengths<N: DualNum<f64> + Copy>(&self, temperature: N) -> UnGraph<(), N> {
         // temperature dependent segment diameter
         let d = self.parameters.hs_diameter(temperature);
 
@@ -120,7 +120,7 @@ impl HelmholtzEnergyFunctional for GcPcSaftFunctional {
                 let (i, j) = self.parameters.bonds.edge_endpoints(e).unwrap();
                 let di = d[i.index()];
                 let dj = d[j.index()];
-                0.5 * (di + dj)
+                (di + dj) * 0.5
             },
         )
     }


### PR DESCRIPTION
This adds the calculation of Henry coefficients and ideal gas enthalpies of adsorption, which can be evaluated without iterations straight from the external potential. Note that this is only possible for spherical or heterosegmented molecules, due to an approximation in the chain term in the homosegmented model.