### PR TITLE
Fix the handling of association records in combination with induced association in PC-SAFT

### DIFF
--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -525,7 +525,7 @@ mod tests_pcsaft {
     use super::*;
     use crate::hard_sphere::HardSphereProperties;
     use crate::pcsaft::parameters::utils::water_parameters;
-    use crate::pcsaft::parameters::{PcSaftAssociationRecord, PcSaftBinaryAssociationRecord};
+    use crate::pcsaft::parameters::PcSaftAssociationRecord;
     use crate::pcsaft::PcSaftParameters;
     use approx::assert_relative_eq;
     use feos_core::parameter::{Parameter, ParameterError};
@@ -536,7 +536,7 @@ mod tests_pcsaft {
         na: f64,
         nb: f64,
     ) -> AssociationRecord<PcSaftAssociationRecord> {
-        let pcsaft = PcSaftAssociationRecord::new(kappa_ab, epsilon_k_ab);
+        let pcsaft = PcSaftAssociationRecord::new(Some(kappa_ab), Some(epsilon_k_ab));
         AssociationRecord::new(pcsaft, na, nb, 0.0)
     }
 
@@ -544,8 +544,8 @@ mod tests_pcsaft {
         kappa_ab: f64,
         epsilon_k_ab: f64,
         indices: Option<[usize; 2]>,
-    ) -> BinaryAssociationRecord<PcSaftBinaryAssociationRecord> {
-        let pcsaft = PcSaftBinaryAssociationRecord::new(Some(kappa_ab), Some(epsilon_k_ab));
+    ) -> BinaryAssociationRecord<PcSaftAssociationRecord> {
+        let pcsaft = PcSaftAssociationRecord::new(Some(kappa_ab), Some(epsilon_k_ab));
         BinaryAssociationRecord::new(pcsaft, indices)
     }
 
@@ -568,7 +568,10 @@ mod tests_pcsaft {
             [1234., 1500., 1000., 3333.],
             [1750., 1250., 750., 1500.],
         ]);
-        assert_eq!(assoc.parameters_ab.mapv(|p| p.epsilon_k_ab), epsilon_k_ab);
+        assert_eq!(
+            assoc.parameters_ab.mapv(|p| p.epsilon_k_ab.unwrap()),
+            epsilon_k_ab
+        );
     }
 
     #[test]

--- a/src/pcsaft/parameters.rs
+++ b/src/pcsaft/parameters.rs
@@ -248,18 +248,12 @@ impl PcSaftRecord {
         diffusion: Option<[f64; 5]>,
         thermal_conductivity: Option<[f64; 4]>,
     ) -> PcSaftRecord {
-        let association_record =
-            // if let (Some(kappa_ab), Some(epsilon_k_ab)) = (kappa_ab, epsilon_k_ab) {
-                Some(AssociationRecord::new(
-                    PcSaftAssociationRecord::new(kappa_ab, epsilon_k_ab),
-                    na.unwrap_or_default(),
-                    nb.unwrap_or_default(),
-                    nc.unwrap_or_default(),
-                ))
-            // } else {
-                // None
-            // };
-            ;
+        let association_record = Some(AssociationRecord::new(
+            PcSaftAssociationRecord::new(kappa_ab, epsilon_k_ab),
+            na.unwrap_or_default(),
+            nb.unwrap_or_default(),
+            nc.unwrap_or_default(),
+        ));
         Self {
             m,
             sigma,
@@ -378,25 +372,6 @@ impl std::fmt::Display for PcSaftBinaryRecord {
         write!(f, "PcSaftBinaryRecord({})", tokens.join(", "))
     }
 }
-
-// #[derive(Serialize, Deserialize, Clone, Copy, Default)]
-// pub struct PcSaftBinaryAssociationRecord {
-//     /// Cross-association association volume parameter.
-//     #[serde(skip_serializing_if = "Option::is_none")]
-//     pub kappa_ab: Option<f64>,
-//     /// Cross-association energy parameter.
-//     #[serde(skip_serializing_if = "Option::is_none")]
-//     pub epsilon_k_ab: Option<f64>,
-// }
-
-// impl PcSaftBinaryAssociationRecord {
-//     pub fn new(kappa_ab: Option<f64>, epsilon_k_ab: Option<f64>) -> Self {
-//         Self {
-//             kappa_ab,
-//             epsilon_k_ab,
-//         }
-//     }
-// }
 
 /// Parameter set required for the PC-SAFT equation of state and Helmholtz energy functional.
 pub struct PcSaftParameters {

--- a/src/pcsaft/parameters.rs
+++ b/src/pcsaft/parameters.rs
@@ -6,10 +6,10 @@ use conv::ValueInto;
 use feos_core::parameter::{
     FromSegments, FromSegmentsBinary, Parameter, ParameterError, PureRecord,
 };
-use quantity::{JOULE, KB, KELVIN};
 use ndarray::{Array, Array1, Array2};
 use num_dual::DualNum;
 use num_traits::Zero;
+use quantity::{JOULE, KB, KELVIN};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -70,8 +70,8 @@ impl FromSegments<f64> for PcSaftRecord {
             .filter_map(|(s, n)| {
                 s.association_record.as_ref().map(|record| {
                     [
-                        record.parameters.kappa_ab * n,
-                        record.parameters.epsilon_k_ab * n,
+                        record.parameters.kappa_ab.unwrap_or(0.0) * n,
+                        record.parameters.epsilon_k_ab.unwrap_or(0.0) * n,
                         record.na * n,
                         record.nb * n,
                         record.nc * n,
@@ -89,7 +89,7 @@ impl FromSegments<f64> for PcSaftRecord {
             })
             .map(|[kappa_ab, epsilon_k_ab, na, nb, nc]| {
                 AssociationRecord::new(
-                    PcSaftAssociationRecord::new(kappa_ab, epsilon_k_ab),
+                    PcSaftAssociationRecord::new(Some(kappa_ab), Some(epsilon_k_ab)),
                     na,
                     nb,
                     nc,
@@ -249,16 +249,17 @@ impl PcSaftRecord {
         thermal_conductivity: Option<[f64; 4]>,
     ) -> PcSaftRecord {
         let association_record =
-            if let (Some(kappa_ab), Some(epsilon_k_ab)) = (kappa_ab, epsilon_k_ab) {
+            // if let (Some(kappa_ab), Some(epsilon_k_ab)) = (kappa_ab, epsilon_k_ab) {
                 Some(AssociationRecord::new(
                     PcSaftAssociationRecord::new(kappa_ab, epsilon_k_ab),
                     na.unwrap_or_default(),
                     nb.unwrap_or_default(),
                     nc.unwrap_or_default(),
                 ))
-            } else {
-                None
-            };
+            // } else {
+                // None
+            // };
+            ;
         Self {
             m,
             sigma,
@@ -276,13 +277,15 @@ impl PcSaftRecord {
 #[derive(Serialize, Deserialize, Clone, Copy, Default)]
 pub struct PcSaftAssociationRecord {
     /// Association volume parameter
-    pub kappa_ab: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kappa_ab: Option<f64>,
     /// Association energy parameter in units of Kelvin
-    pub epsilon_k_ab: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epsilon_k_ab: Option<f64>,
 }
 
 impl PcSaftAssociationRecord {
-    pub fn new(kappa_ab: f64, epsilon_k_ab: f64) -> Self {
+    pub fn new(kappa_ab: Option<f64>, epsilon_k_ab: Option<f64>) -> Self {
         Self {
             kappa_ab,
             epsilon_k_ab,
@@ -292,8 +295,14 @@ impl PcSaftAssociationRecord {
 
 impl std::fmt::Display for PcSaftAssociationRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PcSaftAssociationRecord(kappa_ab={}", self.kappa_ab)?;
-        write!(f, ", epsilon_k_ab={})", self.epsilon_k_ab)
+        let mut params = vec![];
+        if let Some(kappa_ab) = self.kappa_ab {
+            params.push(format!("kappa_ab={}", kappa_ab));
+        }
+        if let Some(epsilon_k_ab) = self.epsilon_k_ab {
+            params.push(format!("epsilon_k_ab={}", epsilon_k_ab));
+        }
+        write!(f, "PcSaftAssociationRecord({})", params.join(", "))
     }
 }
 
@@ -306,7 +315,7 @@ pub struct PcSaftBinaryRecord {
     pub k_ij: f64,
     /// Binary association parameters
     #[serde(flatten)]
-    association: Option<BinaryAssociationRecord<PcSaftBinaryAssociationRecord>>,
+    association: Option<BinaryAssociationRecord<PcSaftAssociationRecord>>,
 }
 
 impl From<f64> for PcSaftBinaryRecord {
@@ -331,7 +340,7 @@ impl PcSaftBinaryRecord {
             None
         } else {
             Some(BinaryAssociationRecord::new(
-                PcSaftBinaryAssociationRecord::new(kappa_ab, epsilon_k_ab),
+                PcSaftAssociationRecord::new(kappa_ab, epsilon_k_ab),
                 None,
             ))
         };
@@ -370,24 +379,24 @@ impl std::fmt::Display for PcSaftBinaryRecord {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Default)]
-pub struct PcSaftBinaryAssociationRecord {
-    /// Cross-association association volume parameter.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kappa_ab: Option<f64>,
-    /// Cross-association energy parameter.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub epsilon_k_ab: Option<f64>,
-}
+// #[derive(Serialize, Deserialize, Clone, Copy, Default)]
+// pub struct PcSaftBinaryAssociationRecord {
+//     /// Cross-association association volume parameter.
+//     #[serde(skip_serializing_if = "Option::is_none")]
+//     pub kappa_ab: Option<f64>,
+//     /// Cross-association energy parameter.
+//     #[serde(skip_serializing_if = "Option::is_none")]
+//     pub epsilon_k_ab: Option<f64>,
+// }
 
-impl PcSaftBinaryAssociationRecord {
-    pub fn new(kappa_ab: Option<f64>, epsilon_k_ab: Option<f64>) -> Self {
-        Self {
-            kappa_ab,
-            epsilon_k_ab,
-        }
-    }
-}
+// impl PcSaftBinaryAssociationRecord {
+//     pub fn new(kappa_ab: Option<f64>, epsilon_k_ab: Option<f64>) -> Self {
+//         Self {
+//             kappa_ab,
+//             epsilon_k_ab,
+//         }
+//     }
+// }
 
 /// Parameter set required for the PC-SAFT equation of state and Helmholtz energy functional.
 pub struct PcSaftParameters {
@@ -576,7 +585,7 @@ impl HardSphereProperties for PcSaftParameters {
 
 impl AssociationStrength for PcSaftParameters {
     type Record = PcSaftAssociationRecord;
-    type BinaryRecord = PcSaftBinaryAssociationRecord;
+    type BinaryRecord = PcSaftAssociationRecord;
 
     fn association_strength<D: DualNum<f64> + Copy>(
         &self,
@@ -585,26 +594,42 @@ impl AssociationStrength for PcSaftParameters {
         comp_j: usize,
         assoc_ij: Self::Record,
     ) -> D {
-        let si = self.sigma[comp_i];
-        let sj = self.sigma[comp_j];
-        (temperature.recip() * assoc_ij.epsilon_k_ab).exp_m1()
-            * assoc_ij.kappa_ab
-            * (si * sj).powf(1.5)
+        if let (Some(kappa_ab), Some(epsilon_k_ab)) = (assoc_ij.kappa_ab, assoc_ij.epsilon_k_ab) {
+            let si = self.sigma[comp_i];
+            let sj = self.sigma[comp_j];
+            (temperature.recip() * epsilon_k_ab).exp_m1() * kappa_ab * (si * sj).powf(1.5)
+        } else {
+            D::zero()
+        }
     }
 
     fn combining_rule(parameters_i: Self::Record, parameters_j: Self::Record) -> Self::Record {
+        let kappa_ab = if let (Some(kappa_ab_i), Some(kappa_ab_j)) =
+            (parameters_i.kappa_ab, parameters_j.kappa_ab)
+        {
+            Some((kappa_ab_i * kappa_ab_j).sqrt())
+        } else {
+            None
+        };
+        let epsilon_k_ab = if let (Some(epsilon_k_ab_i), Some(epsilon_k_ab_j)) =
+            (parameters_i.epsilon_k_ab, parameters_j.epsilon_k_ab)
+        {
+            Some(0.5 * (epsilon_k_ab_i + epsilon_k_ab_j))
+        } else {
+            None
+        };
         Self::Record {
-            kappa_ab: (parameters_i.kappa_ab * parameters_j.kappa_ab).sqrt(),
-            epsilon_k_ab: 0.5 * (parameters_i.epsilon_k_ab + parameters_j.epsilon_k_ab),
+            kappa_ab,
+            epsilon_k_ab,
         }
     }
 
     fn update_binary(parameters_ij: &mut Self::Record, binary_parameters: Self::BinaryRecord) {
         if let Some(kappa_ab) = binary_parameters.kappa_ab {
-            parameters_ij.kappa_ab = kappa_ab
+            parameters_ij.kappa_ab = Some(kappa_ab)
         }
         if let Some(epsilon_k_ab) = binary_parameters.epsilon_k_ab {
-            parameters_ij.epsilon_k_ab = epsilon_k_ab
+            parameters_ij.epsilon_k_ab = Some(epsilon_k_ab)
         }
     }
 }
@@ -622,7 +647,7 @@ impl PcSaftParameters {
             let component = record.identifier.name.clone();
             let component = component.unwrap_or(format!("Component {}", i + 1));
             let association = record.model_record.association_record.unwrap_or_else(|| {
-                AssociationRecord::new(PcSaftAssociationRecord::new(0.0, 0.0), 0.0, 0.0, 0.0)
+                AssociationRecord::new(PcSaftAssociationRecord::new(None, None), 0.0, 0.0, 0.0)
             });
             write!(
                 o,
@@ -632,10 +657,10 @@ impl PcSaftParameters {
                 record.model_record.m,
                 record.model_record.sigma,
                 record.model_record.epsilon_k,
-                record.model_record.mu.unwrap_or(0.0),
-                record.model_record.q.unwrap_or(0.0),
-                association.parameters.kappa_ab,
-                association.parameters.epsilon_k_ab,
+                format_option(record.model_record.mu),
+                format_option(record.model_record.q),
+                format_option(association.parameters.kappa_ab),
+                format_option(association.parameters.epsilon_k_ab),
                 association.na,
                 association.nb,
                 association.nc
@@ -644,6 +669,14 @@ impl PcSaftParameters {
         }
 
         output
+    }
+}
+
+fn format_option(value: Option<f64>) -> String {
+    if let Some(value) = value {
+        format!("{value}")
+    } else {
+        "-".into()
     }
 }
 

--- a/src/pcsaft/python.rs
+++ b/src/pcsaft/python.rs
@@ -113,12 +113,16 @@ impl PyPcSaftRecord {
 
     #[getter]
     fn get_kappa_ab(&self) -> Option<f64> {
-        self.0.association_record.map(|a| a.parameters.kappa_ab)
+        self.0
+            .association_record
+            .and_then(|a| a.parameters.kappa_ab)
     }
 
     #[getter]
     fn get_epsilon_k_ab(&self) -> Option<f64> {
-        self.0.association_record.map(|a| a.parameters.epsilon_k_ab)
+        self.0
+            .association_record
+            .and_then(|a| a.parameters.epsilon_k_ab)
     }
 
     #[getter]


### PR DESCRIPTION
Thanks to @bbbursik for discovering the bug

## The problem
in the existing code `#[serde(flatten)]` would invalidate the entire association record if `kappa_ab` and `epsilon_k_ab` were not both given. This is a problem for an induced association mixture, where one component has `nb!=0` but no association parameters, because those are only adjusted to pure component properties. The mixture would then not be able to describe the induced association, because the `nb` is essentially eliminated.

## The solution
`kappa_ab` and `epsilon_k_ab` are optional, so `#[serde(flatten)]` will always be able to deserialize the `PcSaftAssocationRecord` struct. Induced association is calculated properly if binary association parameters are present. If there are no binary parameters for a certain combination of molecules, combining rules are NOT used, instead the association energy is set to 0, effectively treating the molecules as non-associating (with each other).