### PR TITLE
Always use the same lanczos sigma factor within one DFT profile

### DIFF
--- a/feos-dft/src/adsorption/pore.rs
+++ b/feos-dft/src/adsorption/pore.rs
@@ -167,7 +167,8 @@ where
         let weight_functions: Vec<WeightFunctionInfo<N>> = functional_contributions
             .map(|c| c.weight_functions(temperature))
             .collect();
-        let convolver = ConvolverFFT::<_, D>::plan(&self.profile.grid, &weight_functions, None);
+        let convolver =
+            ConvolverFFT::<_, D>::plan(&self.profile.grid, &weight_functions, self.profile.lanczos);
         let bonds = self
             .profile
             .dft
@@ -230,14 +231,11 @@ impl PoreSpecification<Ix1> for Pore1D {
             |e| e.clone(),
         );
 
-        // initialize convolver
+        // initialize grid
         let grid = Grid::new_1d(axis);
-        let t = bulk.temperature.to_reduced();
-        let weight_functions = dft.weight_functions(t);
-        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
         Ok(PoreProfile {
-            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), density),
+            profile: DFTProfile::new(grid, bulk, Some(external_potential), density, Some(1)),
             grand_potential: None,
             interfacial_tension: None,
         })

--- a/feos-dft/src/adsorption/pore2d.rs
+++ b/feos-dft/src/adsorption/pore2d.rs
@@ -1,6 +1,6 @@
 use super::{FluidParameters, PoreProfile, PoreSpecification};
-use crate::{Axis, ConvolverFFT, DFTProfile, Grid, HelmholtzEnergyFunctional, DFT};
-use feos_core::{EosResult, ReferenceSystem, State};
+use crate::{Axis, DFTProfile, Grid, HelmholtzEnergyFunctional, DFT};
+use feos_core::{EosResult, State};
 use ndarray::{Array3, Ix2};
 use quantity::{Angle, Density, Length};
 
@@ -29,22 +29,13 @@ impl PoreSpecification<Ix2> for Pore2D {
         density: Option<&Density<Array3<f64>>>,
         external_potential: Option<&Array3<f64>>,
     ) -> EosResult<PoreProfile<Ix2, F>> {
-        let dft: &F = &bulk.eos;
-
         // generate grid
         let x = Axis::new_cartesian(self.n_grid[0], self.system_size[0], None);
         let y = Axis::new_cartesian(self.n_grid[1], self.system_size[1], None);
-
-        // temperature
-        let t = bulk.temperature.to_reduced();
-
-        // initialize convolver
         let grid = Grid::Periodical2(x, y, self.angle);
-        let weight_functions = dft.weight_functions(t);
-        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
         Ok(PoreProfile {
-            profile: DFTProfile::new(grid, convolver, bulk, external_potential.cloned(), density),
+            profile: DFTProfile::new(grid, bulk, external_potential.cloned(), density, Some(1)),
             grand_potential: None,
             interfacial_tension: None,
         })

--- a/feos-dft/src/adsorption/pore3d.rs
+++ b/feos-dft/src/adsorption/pore3d.rs
@@ -1,6 +1,5 @@
 use super::pore::{PoreProfile, PoreSpecification};
 use crate::adsorption::FluidParameters;
-use crate::convolver::ConvolverFFT;
 use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::{Axis, Grid};
 use crate::profile::{DFTProfile, CUTOFF_RADIUS, MAX_POTENTIAL};
@@ -93,14 +92,10 @@ impl PoreSpecification<Ix3> for Pore3D {
             },
             |e| Ok(e.clone()),
         )?;
-
-        // initialize convolver
         let grid = Grid::Periodical3(x, y, z, self.angles.unwrap_or([90.0 * DEGREES; 3]));
-        let weight_functions = dft.weight_functions(t);
-        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
         Ok(PoreProfile {
-            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), density),
+            profile: DFTProfile::new(grid, bulk, Some(external_potential), density, Some(1)),
             grand_potential: None,
             interfacial_tension: None,
         })

--- a/feos-dft/src/convolver/mod.rs
+++ b/feos-dft/src/convolver/mod.rs
@@ -293,7 +293,7 @@ where
             .zip(result.lanes_mut(Axis_nd(0)))
         {
             self.transform
-                .forward_transform(f, r, vector_index.map_or(true, |ind| ind != 0));
+                .forward_transform(f, r, vector_index != Some(0));
         }
         for (i, transform) in self.cartesian_transforms.iter().enumerate() {
             dim[i + 1] = self.k_abs.shape()[i + 1];
@@ -303,7 +303,7 @@ where
                 .into_iter()
                 .zip(res.lanes_mut(Axis_nd(i + 1)))
             {
-                transform.forward_transform(f, r, vector_index.map_or(true, |ind| ind != i + 1));
+                transform.forward_transform(f, r, vector_index.is_none_or(|ind| ind != i + 1));
             }
             result = res;
         }
@@ -339,8 +339,7 @@ where
             .into_iter()
             .zip(res.lanes_mut(Axis_nd(0)))
         {
-            self.transform
-                .back_transform(f, r, vector_index.map_or(true, |ind| ind != 0));
+            self.transform.back_transform(f, r, vector_index != Some(0));
         }
         for (i, transform) in self.cartesian_transforms.iter().enumerate() {
             dim[i + 1] = result.shape()[i + 1];
@@ -350,7 +349,7 @@ where
                 .into_iter()
                 .zip(res2.lanes_mut(Axis_nd(i + 1)))
             {
-                transform.back_transform(f, r, vector_index.map_or(true, |ind| ind != i + 1));
+                transform.back_transform(f, r, vector_index.is_none_or(|ind| ind != i + 1));
             }
             res = res2;
         }

--- a/feos-dft/src/interface/mod.rs
+++ b/feos-dft/src/interface/mod.rs
@@ -1,5 +1,4 @@
 //! Density profiles at planar interfaces and interfacial tensions.
-use crate::convolver::ConvolverFFT;
 use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::{Axis, Grid};
 use crate::profile::{DFTProfile, DFTSpecifications};
@@ -64,18 +63,11 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
 
 impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
     pub fn new(vle: &PhaseEquilibrium<DFT<F>, 2>, n_grid: usize, l_grid: Length) -> Self {
-        let dft = &vle.vapor().eos;
-
         // generate grid
         let grid = Grid::Cartesian1(Axis::new_cartesian(n_grid, l_grid, None));
 
-        // initialize convolver
-        let t = vle.vapor().temperature.to_reduced();
-        let weight_functions = dft.weight_functions(t);
-        let convolver = ConvolverFFT::plan(&grid, &weight_functions, None);
-
         Self {
-            profile: DFTProfile::new(grid, convolver, vle.vapor(), None, None),
+            profile: DFTProfile::new(grid, vle.vapor(), None, None, None),
             vle: vle.clone(),
             surface_tension: None,
             equimolar_radius: None,

--- a/feos-dft/src/profile/properties.rs
+++ b/feos-dft/src/profile/properties.rs
@@ -113,7 +113,7 @@ where
         let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
             .map(|c| c.weight_functions(temperature_dual))
             .collect();
-        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
+        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, self.lanczos);
 
         let density = self.density.to_reduced();
 
@@ -196,7 +196,7 @@ where
         let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
             .map(|c| c.weight_functions(temperature_dual))
             .collect();
-        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
+        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, self.lanczos);
 
         let density = self.density.to_reduced();
 
@@ -239,7 +239,7 @@ where
         let weight_functions: Vec<WeightFunctionInfo<Dual64>> = functional_contributions
             .map(|c| c.weight_functions(temperature_dual))
             .collect();
-        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, None);
+        let convolver = ConvolverFFT::plan(&self.grid, &weight_functions, self.lanczos);
 
         let density = self.density.to_reduced();
 
@@ -358,7 +358,7 @@ where
             .map(|c| c.weight_functions(t_dual))
             .collect();
         let convolver: Arc<dyn Convolver<_, D>> =
-            ConvolverFFT::plan(&self.grid, &weight_functions, None);
+            ConvolverFFT::plan(&self.grid, &weight_functions, self.lanczos);
         let (_, mut dfdrho) = self
             .dft
             .functional_derivative(t_dual, &rho_dual, &convolver)?;

--- a/feos-dft/src/solvation/pair_correlation.rs
+++ b/feos-dft/src/solvation/pair_correlation.rs
@@ -1,5 +1,4 @@
 //! Functionalities for the calculation of pair correlation functions.
-use crate::convolver::ConvolverFFT;
 use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::profile::MAX_POTENTIAL;
 use crate::solver::DFTSolver;
@@ -49,14 +48,10 @@ impl<F: HelmholtzEnergyFunctional + PairPotential> PairCorrelation<F> {
                 *x = MAX_POTENTIAL
             }
         });
-
-        // initialize convolver
         let grid = Grid::Spherical(axis);
-        let weight_functions = dft.weight_functions(t);
-        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
         Self {
-            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), None),
+            profile: DFTProfile::new(grid, bulk, Some(external_potential), None, Some(1)),
             pair_correlation_function: None,
             self_solvation_free_energy: None,
             structure_factor: None,

--- a/feos-dft/src/solvation/solvation_profile.rs
+++ b/feos-dft/src/solvation/solvation_profile.rs
@@ -1,5 +1,4 @@
 use crate::adsorption::FluidParameters;
-use crate::convolver::ConvolverFFT;
 use crate::functional::{HelmholtzEnergyFunctional, DFT};
 use crate::geometry::{Axis, Grid};
 use crate::profile::{DFTProfile, CUTOFF_RADIUS, MAX_POTENTIAL};
@@ -103,13 +102,10 @@ impl<F: HelmholtzEnergyFunctional + FluidParameters> SolvationProfile<F> {
             t,
         )?;
 
-        // initialize convolver
         let grid = Grid::Cartesian3(x, y, z);
-        let weight_functions = dft.weight_functions(t);
-        let convolver = ConvolverFFT::plan(&grid, &weight_functions, Some(1));
 
         Ok(Self {
-            profile: DFTProfile::new(grid, convolver, bulk, Some(external_potential), None),
+            profile: DFTProfile::new(grid, bulk, Some(external_potential), None, Some(1)),
             grand_potential: None,
             solvation_free_energy: None,
         })


### PR DESCRIPTION
Previously, a default of `None` was used, when derivatives were calculated.