### PR TITLE
Replace the model-specific enums in Python with Strings

### DIFF
--- a/py-feos/src/eos/epcsaft.rs
+++ b/py-feos/src/eos/epcsaft.rs
@@ -3,35 +3,9 @@ use crate::parameter::PyParameters;
 use crate::{ideal_gas::IdealGasModel, residual::ResidualModel};
 use feos::epcsaft::{ElectrolytePcSaft, ElectrolytePcSaftOptions, ElectrolytePcSaftVariants};
 use feos_core::{Components, EquationOfState};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::sync::Arc;
-
-#[derive(Clone, Copy, PartialEq)]
-#[pyclass(name = "ElectrolytePcSaftVariants", eq, eq_int)]
-pub enum PyElectrolytePcSaftVariants {
-    Advanced,
-    Revised,
-}
-
-impl From<ElectrolytePcSaftVariants> for PyElectrolytePcSaftVariants {
-    fn from(value: ElectrolytePcSaftVariants) -> Self {
-        use ElectrolytePcSaftVariants::*;
-        match value {
-            Advanced => Self::Advanced,
-            Revised => Self::Revised,
-        }
-    }
-}
-
-impl From<PyElectrolytePcSaftVariants> for ElectrolytePcSaftVariants {
-    fn from(value: PyElectrolytePcSaftVariants) -> Self {
-        use PyElectrolytePcSaftVariants::*;
-        match value {
-            Advanced => Self::Advanced,
-            Revised => Self::Revised,
-        }
-    }
-}
 
 #[pymethods]
 impl PyEquationOfState {
@@ -45,34 +19,42 @@ impl PyEquationOfState {
     ///     Maximum packing fraction. Defaults to 0.5.
     /// max_iter_cross_assoc : unsigned integer, optional
     ///     Maximum number of iterations for cross association. Defaults to 50.
-    /// tol_cross_assoc : float
+    /// tol_cross_assoc : float, optional
     ///     Tolerance for convergence of cross association. Defaults to 1e-10.
-    /// epcsaft_variant : ElectrolytePcSaftVariants, optional
-    ///     Variant of the ePC-SAFT equation of state. Defaults to 'advanced'
+    /// epcsaft_variant : "advanced" | "revised", optional
+    ///     Variant of the ePC-SAFT equation of state. Defaults to "advanced"
     ///
     /// Returns
     /// -------
     /// EquationOfState
     ///     The ePC-SAFT equation of state that can be used to compute thermodynamic
     ///     states.
-    #[cfg(feature = "epcsaft")]
     #[staticmethod]
     #[pyo3(
-        signature = (parameters, max_eta=0.5, max_iter_cross_assoc=50, tol_cross_assoc=1e-10, epcsaft_variant=PyElectrolytePcSaftVariants::Advanced),
-        text_signature = "(parameters, max_eta=0.5, max_iter_cross_assoc=50, tol_cross_assoc=1e-10, epcsaft_variant)",
+        signature = (parameters, max_eta=0.5, max_iter_cross_assoc=50, tol_cross_assoc=1e-10, epcsaft_variant="advanced"),
+        text_signature = r#"(parameters, max_eta=0.5, max_iter_cross_assoc=50, tol_cross_assoc=1e-10, epcsaft_variant="advanced")"#,
     )]
     pub fn epcsaft(
         parameters: PyParameters,
         max_eta: f64,
         max_iter_cross_assoc: usize,
         tol_cross_assoc: f64,
-        epcsaft_variant: PyElectrolytePcSaftVariants,
+        epcsaft_variant: &str,
     ) -> PyResult<Self> {
+        let epcsaft_variant = match epcsaft_variant {
+            "advanced" => ElectrolytePcSaftVariants::Advanced,
+            "revised" => ElectrolytePcSaftVariants::Revised,
+            _ => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    r#"epcsaft_variant must be "advanced" or "revised""#.to_string(),
+                ))
+            }
+        };
         let options = ElectrolytePcSaftOptions {
             max_eta,
             max_iter_cross_assoc,
             tol_cross_assoc,
-            epcsaft_variant: epcsaft_variant.into(),
+            epcsaft_variant,
         };
         let residual = Arc::new(ResidualModel::ElectrolytePcSaft(
             ElectrolytePcSaft::with_options(Arc::new(parameters.try_convert()?), options),

--- a/py-feos/src/eos/pets.rs
+++ b/py-feos/src/eos/pets.rs
@@ -25,7 +25,6 @@ impl PyEquationOfState {
     /// EquationOfState
     ///     The PeTS equation of state that can be used to compute thermodynamic
     ///     states.
-    #[cfg(feature = "pets")]
     #[staticmethod]
     #[pyo3(signature = (parameters, max_eta=0.5), text_signature = "(parameters, max_eta=0.5)")]
     fn pets(parameters: PyParameters, max_eta: f64) -> PyResult<Self> {
@@ -57,7 +56,6 @@ impl PyHelmholtzEnergyFunctional {
     /// Returns
     /// -------
     /// HelmholtzEnergyFunctional
-    #[cfg(feature = "pets")]
     #[staticmethod]
     #[pyo3(
         signature = (parameters, fmt_version=PyFMTVersion::WhiteBear, max_eta=0.5),

--- a/py-feos/src/eos/saftvrmie.rs
+++ b/py-feos/src/eos/saftvrmie.rs
@@ -25,7 +25,6 @@ impl PyEquationOfState {
     /// EquationOfState
     ///     The SAFT-VR Mie equation of state that can be used to compute thermodynamic
     ///     states.
-    #[cfg(feature = "saftvrmie")]
     #[staticmethod]
     #[pyo3(
         signature = (parameters, max_eta=0.5, max_iter_cross_assoc=50, tol_cross_assoc=1e-10),

--- a/py-feos/src/eos/saftvrqmie.rs
+++ b/py-feos/src/eos/saftvrqmie.rs
@@ -27,7 +27,6 @@ impl PyEquationOfState {
     /// EquationOfState
     ///     The SAFT-VRQ Mie equation of state that can be used to compute thermodynamic
     ///     states.
-    #[cfg(feature = "saftvrqmie")]
     #[staticmethod]
     #[pyo3(
         signature = (parameters, max_eta=0.5, inc_nonadd_term=true),
@@ -66,7 +65,6 @@ impl PyHelmholtzEnergyFunctional {
     /// Returns
     /// -------
     /// HelmholtzEnergyFunctional
-    #[cfg(feature = "saftvrqmie")]
     #[staticmethod]
     #[pyo3(
         signature = (parameters, fmt_version=PyFMTVersion::WhiteBear, max_eta=0.5, inc_nonadd_term=true),

--- a/py-feos/src/eos/uvtheory.rs
+++ b/py-feos/src/eos/uvtheory.rs
@@ -2,38 +2,9 @@ use super::PyEquationOfState;
 use crate::{ideal_gas::IdealGasModel, parameter::PyParameters, residual::ResidualModel};
 use feos::uvtheory::{Perturbation, UVTheory, UVTheoryOptions};
 use feos_core::{Components, EquationOfState};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::sync::Arc;
-
-#[derive(Clone, Copy, PartialEq)]
-#[pyclass(name = "Perturbation", eq, eq_int)]
-pub enum PyPerturbation {
-    BarkerHenderson,
-    WeeksChandlerAndersen,
-    WeeksChandlerAndersenB3,
-}
-
-impl From<Perturbation> for PyPerturbation {
-    fn from(value: Perturbation) -> Self {
-        use Perturbation::*;
-        match value {
-            BarkerHenderson => Self::BarkerHenderson,
-            WeeksChandlerAndersen => Self::WeeksChandlerAndersen,
-            WeeksChandlerAndersenB3 => Self::WeeksChandlerAndersenB3,
-        }
-    }
-}
-
-impl From<PyPerturbation> for Perturbation {
-    fn from(value: PyPerturbation) -> Self {
-        use PyPerturbation::*;
-        match value {
-            BarkerHenderson => Self::BarkerHenderson,
-            WeeksChandlerAndersen => Self::WeeksChandlerAndersen,
-            WeeksChandlerAndersenB3 => Self::WeeksChandlerAndersenB3,
-        }
-    }
-}
 
 #[pymethods]
 impl PyEquationOfState {
@@ -45,28 +16,33 @@ impl PyEquationOfState {
     ///     The parameters of the UV-theory equation of state to use.
     /// max_eta : float, optional
     ///     Maximum packing fraction. Defaults to 0.5.
-    /// perturbation : Perturbation, optional
-    ///     Division type of the Mie potential. Defaults to WCA division.
+    /// perturbation : "BH" | "WCA" | "WCA_B3", optional
+    ///     Division type of the Mie potential. Defaults to "WCA".
     ///
     /// Returns
     /// -------
     /// EquationOfState
     ///     The UV-Theory equation of state that can be used to compute thermodynamic
     ///     states.
-    #[cfg(feature = "uvtheory")]
     #[staticmethod]
     #[pyo3(
-        signature = (parameters, max_eta=0.5, perturbation=PyPerturbation::WeeksChandlerAndersen),
-        text_signature = "(parameters, max_eta=0.5, perturbation)"
+        signature = (parameters, max_eta=0.5, perturbation="WCA"),
+        text_signature = r#"(parameters, max_eta=0.5, perturbation="WCA")"#
     )]
-    fn uvtheory(
-        parameters: PyParameters,
-        max_eta: f64,
-        perturbation: PyPerturbation,
-    ) -> PyResult<Self> {
+    fn uvtheory(parameters: PyParameters, max_eta: f64, perturbation: &str) -> PyResult<Self> {
+        let perturbation = match perturbation {
+            "BH" => Perturbation::BarkerHenderson,
+            "WCA" => Perturbation::WeeksChandlerAndersen,
+            "WCA_B3" => Perturbation::WeeksChandlerAndersenB3,
+            _ => {
+                return Err(PyErr::new::<PyValueError, _>(
+                    r#"perturbation must be "BH", "WCA" or "WCA_B3""#.to_string(),
+                ))
+            }
+        };
         let options = UVTheoryOptions {
             max_eta,
-            perturbation: perturbation.into(),
+            perturbation,
         };
         let residual = Arc::new(ResidualModel::UVTheory(UVTheory::with_options(
             Arc::new(parameters.try_convert()?),


### PR DESCRIPTION
They are not part of the Python module right now anyways and it is difficult to conceive of an appropriate place in the module structure.