### PR TITLE
Add tests that check the polar contributions with respect to reordering components

### DIFF
--- a/crates/feos/src/pcsaft/eos/polar.rs
+++ b/crates/feos/src/pcsaft/eos/polar.rs
@@ -530,7 +530,7 @@ mod tests {
         let s = StateHD::new(t, v, arr1(&n));
         let d = parameters.hs_diameter(t);
         let a = Quadrupole.helmholtz_energy(&parameters, &s, &d);
-        assert_relative_eq!(a, -0.327493924806138, epsilon = 1e-10);
+        assert_relative_eq!(a, -0.2748017468669352, epsilon = 1e-10);
     }
 
     #[test]


### PR DESCRIPTION
Confirms the bug in #292. Should we just update the value in the test that checks against a hardcoded helmholtz energy? It's impossible to backtrack where that value is from, but having it is a good check for future changes to the code.