### PR TITLE
Parameter info

### DIFF
--- a/crates/feos-core/src/cubic.rs
+++ b/crates/feos-core/src/cubic.rs
@@ -73,7 +73,7 @@ impl PengRobinsonParameters {
 /// A simple version of the Peng-Robinson equation of state.
 pub struct PengRobinson {
     /// Parameters
-    parameters: PengRobinsonParameters,
+    pub parameters: PengRobinsonParameters,
     /// Critical temperature in Kelvin
     tc: DVector<f64>,
     a: DVector<f64>,

--- a/crates/feos-derive/src/lib.rs
+++ b/crates/feos-derive/src/lib.rs
@@ -17,8 +17,9 @@ mod residual;
 mod subset;
 
 // possible additional traits to implement
-const OPT_IMPLS: [&str; 5] = [
+const OPT_IMPLS: [&str; 6] = [
     "molar_weight",
+    "parameter_info",
     // "entropy_scaling",
     "functional",
     "bond_lengths",

--- a/crates/feos/src/epcsaft/eos/mod.rs
+++ b/crates/feos/src/epcsaft/eos/mod.rs
@@ -1,5 +1,5 @@
+use super::parameters::{ElectrolytePcSaftParameters, ElectrolytePcSaftPars};
 use crate::association::Association;
-use crate::epcsaft::parameters::{ElectrolytePcSaftParameters, ElectrolytePcSaftPars};
 use crate::hard_sphere::{HardSphere, HardSphereProperties};
 use feos_core::{FeosResult, ResidualDyn, Subset};
 use feos_core::{Molarweight, StateHD};
@@ -51,7 +51,7 @@ pub struct ElectrolytePcSaft {
     pub params: ElectrolytePcSaftPars,
     pub options: ElectrolytePcSaftOptions,
     hard_chain: bool,
-    association: Option<Association<ElectrolytePcSaftPars>>,
+    association: Option<Association>,
     ionic: bool,
     born: bool,
 }
@@ -68,11 +68,8 @@ impl ElectrolytePcSaft {
         let params = ElectrolytePcSaftPars::new(&parameters)?;
         let hard_chain = params.m.iter().any(|m| (m - 1.0).abs() > 1e-15);
 
-        let association = Association::new(
-            &parameters,
-            options.max_iter_cross_assoc,
-            options.tol_cross_assoc,
-        )?;
+        let association = (!parameters.association.is_empty())
+            .then(|| Association::new(options.max_iter_cross_assoc, options.tol_cross_assoc));
 
         let ionic = params.nionic > 0;
         let born = ionic && matches!(options.epcsaft_variant, ElectrolytePcSaftVariants::Advanced);

--- a/crates/feos/src/gc_pcsaft/eos/mod.rs
+++ b/crates/feos/src/gc_pcsaft/eos/mod.rs
@@ -44,7 +44,7 @@ pub struct GcPcSaft {
     parameters: GcPcSaftParameters<f64>,
     params: GcPcSaftEosParameters,
     options: GcPcSaftOptions,
-    association: Option<Association<GcPcSaftEosParameters>>,
+    association: Option<Association>,
     dipole: Option<Dipole>,
 }
 
@@ -55,12 +55,8 @@ impl GcPcSaft {
 
     pub fn with_options(parameters: GcPcSaftParameters<f64>, options: GcPcSaftOptions) -> Self {
         let params = GcPcSaftEosParameters::new(&parameters);
-        let association = Association::new(
-            &parameters,
-            options.max_iter_cross_assoc,
-            options.tol_cross_assoc,
-        )
-        .unwrap();
+        let association = (!parameters.association.is_empty())
+            .then(|| Association::new(options.max_iter_cross_assoc, options.tol_cross_assoc));
         let dipole = if !params.dipole_comp.is_empty() {
             Some(Dipole::new(&params))
         } else {

--- a/crates/feos/src/gc_pcsaft/eos/parameter.rs
+++ b/crates/feos/src/gc_pcsaft/eos/parameter.rs
@@ -140,18 +140,6 @@ impl AssociationStrength for GcPcSaftEosParameters {
             * assoc_ij.kappa_ab
             * (si * sj).powf(1.5)
     }
-
-    fn combining_rule(
-        _: &Self::Pure,
-        _: &Self::Pure,
-        parameters_i: &Self::Record,
-        parameters_j: &Self::Record,
-    ) -> Self::Record {
-        Self::Record {
-            kappa_ab: (parameters_i.kappa_ab * parameters_j.kappa_ab).sqrt(),
-            epsilon_k_ab: 0.5 * (parameters_i.epsilon_k_ab + parameters_j.epsilon_k_ab),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/feos/src/gc_pcsaft/record.rs
+++ b/crates/feos/src/gc_pcsaft/record.rs
@@ -1,4 +1,4 @@
-use feos_core::parameter::GcParameters;
+use feos_core::parameter::{CombiningRule, GcParameters};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -45,6 +45,20 @@ impl GcPcSaftAssociationRecord {
         Self {
             kappa_ab,
             epsilon_k_ab,
+        }
+    }
+}
+
+impl CombiningRule<GcPcSaftRecord> for GcPcSaftAssociationRecord {
+    fn combining_rule(
+        _: &GcPcSaftRecord,
+        _: &GcPcSaftRecord,
+        parameters_i: &Self,
+        parameters_j: &Self,
+    ) -> Self {
+        Self {
+            kappa_ab: (parameters_i.kappa_ab * parameters_j.kappa_ab).sqrt(),
+            epsilon_k_ab: 0.5 * (parameters_i.epsilon_k_ab + parameters_j.epsilon_k_ab),
         }
     }
 }

--- a/crates/feos/src/pcsaft/dft/mod.rs
+++ b/crates/feos/src/pcsaft/dft/mod.rs
@@ -27,8 +27,8 @@ use pure_saft_functional::*;
 
 /// PC-SAFT Helmholtz energy functional.
 pub struct PcSaftFunctional {
-    parameters: PcSaftParameters,
-    association: Option<Association<PcSaftPars>>,
+    pub parameters: PcSaftParameters,
+    association: Option<Association>,
     params: PcSaftPars,
     fmt_version: FMTVersion,
     options: PcSaftOptions,
@@ -49,12 +49,12 @@ impl PcSaftFunctional {
         saft_options: PcSaftOptions,
     ) -> Self {
         let params = PcSaftPars::new(&parameters);
-        let association = Association::new(
-            &parameters,
-            saft_options.max_iter_cross_assoc,
-            saft_options.tol_cross_assoc,
-        )
-        .unwrap();
+        let association = (!parameters.association.is_empty()).then(|| {
+            Association::new(
+                saft_options.max_iter_cross_assoc,
+                saft_options.tol_cross_assoc,
+            )
+        });
         Self {
             parameters,
             association,
@@ -103,7 +103,7 @@ impl HelmholtzEnergyFunctionalDyn for PcSaftFunctional {
     fn contributions<'a>(&'a self) -> impl Iterator<Item = PcSaftFunctionalContribution<'a>> {
         let mut contributions = Vec::with_capacity(4);
 
-        let assoc = AssociationFunctional::new(&self.params, &self.parameters, &self.association);
+        let assoc = AssociationFunctional::new(&self.params, &self.parameters, self.association);
 
         if matches!(
             self.fmt_version,

--- a/crates/feos/src/pcsaft/parameters.rs
+++ b/crates/feos/src/pcsaft/parameters.rs
@@ -1,5 +1,5 @@
 use feos_core::FeosResult;
-use feos_core::parameter::{FromSegments, FromSegmentsBinary, Parameters};
+use feos_core::parameter::{CombiningRule, FromSegments, FromSegmentsBinary, Parameters};
 use nalgebra::{DMatrix, DVector};
 use num_traits::Zero;
 use quantity::{JOULE, KB, KELVIN};
@@ -153,6 +153,22 @@ pub struct PcSaftAssociationRecord {
 
 impl PcSaftAssociationRecord {
     pub fn new(kappa_ab: f64, epsilon_k_ab: f64) -> Self {
+        Self {
+            kappa_ab,
+            epsilon_k_ab,
+        }
+    }
+}
+
+impl CombiningRule<PcSaftRecord> for PcSaftAssociationRecord {
+    fn combining_rule(
+        _: &PcSaftRecord,
+        _: &PcSaftRecord,
+        parameters_i: &Self,
+        parameters_j: &Self,
+    ) -> Self {
+        let kappa_ab = (parameters_i.kappa_ab * parameters_j.kappa_ab).sqrt();
+        let epsilon_k_ab = 0.5 * (parameters_i.epsilon_k_ab + parameters_j.epsilon_k_ab);
         Self {
             kappa_ab,
             epsilon_k_ab,

--- a/crates/feos/src/saftvrmie/mod.rs
+++ b/crates/feos/src/saftvrmie/mod.rs
@@ -5,4 +5,4 @@ mod eos;
 pub(crate) mod parameters;
 
 pub use eos::{SaftVRMie, SaftVRMieOptions};
-pub use parameters::{test_utils, SaftVRMieBinaryRecord, SaftVRMieParameters, SaftVRMieRecord};
+pub use parameters::{SaftVRMieBinaryRecord, SaftVRMieParameters, SaftVRMieRecord, test_utils};

--- a/crates/feos/src/saftvrmie/parameters.rs
+++ b/crates/feos/src/saftvrmie/parameters.rs
@@ -1,5 +1,5 @@
 use crate::hard_sphere::{HardSphereProperties, MonomerShape};
-use feos_core::parameter::{Parameters, PureRecord};
+use feos_core::parameter::{CombiningRule, Parameters, PureRecord};
 use nalgebra::{DMatrix, DVector};
 use num_dual::DualNum;
 use num_traits::Zero;
@@ -56,6 +56,22 @@ pub struct SaftVRMieAssociationRecord {
 
 impl SaftVRMieAssociationRecord {
     pub fn new(rc_ab: f64, epsilon_k_ab: f64) -> Self {
+        Self {
+            rc_ab,
+            epsilon_k_ab,
+        }
+    }
+}
+
+impl CombiningRule<SaftVRMieRecord> for SaftVRMieAssociationRecord {
+    fn combining_rule(
+        pure_i: &SaftVRMieRecord,
+        pure_j: &SaftVRMieRecord,
+        parameters_i: &Self,
+        parameters_j: &Self,
+    ) -> Self {
+        let rc_ab = (parameters_i.rc_ab * pure_i.sigma + parameters_j.rc_ab * pure_j.sigma) * 0.5;
+        let epsilon_k_ab = (parameters_i.epsilon_k_ab * parameters_j.epsilon_k_ab).sqrt();
         Self {
             rc_ab,
             epsilon_k_ab,

--- a/crates/feos/src/uvtheory/eos/mod.rs
+++ b/crates/feos/src/uvtheory/eos/mod.rs
@@ -1,6 +1,4 @@
-use crate::uvtheory::parameters::UVTheoryPars;
-
-use super::parameters::UVTheoryParameters;
+use super::parameters::{UVTheoryParameters, UVTheoryPars};
 use feos_core::{Molarweight, ResidualDyn, Subset};
 use nalgebra::DVector;
 use num_dual::DualNum;
@@ -38,7 +36,7 @@ impl Default for UVTheoryOptions {
 
 /// uv-theory equation of state
 pub struct UVTheory {
-    parameters: UVTheoryParameters,
+    pub parameters: UVTheoryParameters,
     params: UVTheoryPars,
     options: UVTheoryOptions,
 }

--- a/py-feos/src/residual.rs
+++ b/py-feos/src/residual.rs
@@ -5,7 +5,8 @@ use feos_derive::{FunctionalContribution, HelmholtzEnergyFunctionalDyn};
 use feos_derive::{ResidualDyn, Subset};
 #[cfg(feature = "dft")]
 use feos_dft::{FunctionalContribution, HelmholtzEnergyFunctionalDyn};
-use nalgebra::DVector;
+use indexmap::IndexMap;
+use nalgebra::{DMatrix, DVector};
 #[cfg(feature = "dft")]
 use ndarray::Array1;
 use num_dual::DualNum;
@@ -22,37 +23,37 @@ pub enum ResidualModel {
     // Equations of state
     NoResidual(NoResidual),
     #[cfg(feature = "pcsaft")]
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     PcSaft(feos::pcsaft::PcSaft),
 
     #[cfg(feature = "epcsaft")]
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     ElectrolytePcSaft(feos::epcsaft::ElectrolytePcSaft),
 
     #[cfg(feature = "gc_pcsaft")]
     #[implement(molar_weight)]
     GcPcSaft(feos::gc_pcsaft::GcPcSaft),
 
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     PengRobinson(PengRobinson),
 
     #[implement(molar_weight)]
     Python(crate::user_defined::PyResidual),
 
     #[cfg(feature = "saftvrqmie")]
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     SaftVRQMie(feos::saftvrqmie::SaftVRQMie),
 
     #[cfg(feature = "saftvrmie")]
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     SaftVRMie(feos::saftvrmie::SaftVRMie),
 
     #[cfg(feature = "pets")]
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     Pets(feos::pets::Pets),
 
     #[cfg(feature = "uvtheory")]
-    #[implement(molar_weight)]
+    #[implement(molar_weight, parameter_info)]
     UVTheory(feos::uvtheory::UVTheory),
 
     #[cfg(feature = "multiparameter")]
@@ -61,7 +62,13 @@ pub enum ResidualModel {
 
     // Helmholtz energy functionals
     #[cfg(all(feature = "dft", feature = "pcsaft"))]
-    #[implement(molar_weight, functional, fluid_parameters, pair_potential)]
+    #[implement(
+        molar_weight,
+        parameter_info,
+        functional,
+        fluid_parameters,
+        pair_potential
+    )]
     PcSaftFunctional(feos::pcsaft::PcSaftFunctional),
 
     #[cfg(all(feature = "dft", feature = "gc_pcsaft"))]
@@ -69,7 +76,13 @@ pub enum ResidualModel {
     GcPcSaftFunctional(feos::gc_pcsaft::GcPcSaftFunctional),
 
     #[cfg(all(feature = "dft", feature = "pets"))]
-    #[implement(molar_weight, functional, fluid_parameters, pair_potential)]
+    #[implement(
+        molar_weight,
+        parameter_info,
+        functional,
+        fluid_parameters,
+        pair_potential
+    )]
     PetsFunctional(feos::pets::Pets),
 
     #[cfg(feature = "dft")]
@@ -77,7 +90,13 @@ pub enum ResidualModel {
     FmtFunctional(feos::hard_sphere::FMTFunctional),
 
     #[cfg(all(feature = "dft", feature = "saftvrqmie"))]
-    #[implement(molar_weight, functional, fluid_parameters, pair_potential)]
+    #[implement(
+        molar_weight,
+        parameter_info,
+        functional,
+        fluid_parameters,
+        pair_potential
+    )]
     SaftVRQMieFunctional(feos::saftvrqmie::SaftVRQMie),
 }
 


### PR DESCRIPTION
Moves combining rules in association terms to core. With this change, the full matrix of association energies (or parameters in general) can be determined when the parameters are constructed, rather than the equation of state.

To be able to access these parameter from Python, this PR adds `EquationOfState.parameters` that provides a dict with all the different (scalar) parameters for models which inernally store their parameters using the `Parameters` struct.