### PR TITLE
Allow DFTProfile to be Clone again

### DIFF
--- a/crates/feos-dft/src/adsorption/pore.rs
+++ b/crates/feos-dft/src/adsorption/pore.rs
@@ -85,6 +85,7 @@ pub trait PoreSpecification<D: Dimension> {
 }
 
 /// Density profile and properties of a confined system in arbitrary dimensions.
+#[derive(Clone)]
 pub struct PoreProfile<D: Dimension, F> {
     pub profile: DFTProfile<D, F>,
     pub grand_potential: Option<Energy>,

--- a/crates/feos-dft/src/convolver/periodic_convolver.rs
+++ b/crates/feos-dft/src/convolver/periodic_convolver.rs
@@ -35,7 +35,7 @@ where
         angle: Angle,
         weight_functions: &[WeightFunctionInfo<T>],
         lanczos: Option<i32>,
-    ) -> Box<dyn Convolver<T, D>> {
+    ) -> Arc<dyn Convolver<T, D>> {
         let f = |k: &mut Array<f64, D::Larger>| {
             let k_y =
                 (&k.index_axis(Axis(0), 1) - &k.index_axis(Axis(0), 0) * angle.cos()) / angle.sin();
@@ -49,7 +49,7 @@ where
         angles: [Angle; 3],
         weight_functions: &[WeightFunctionInfo<T>],
         lanczos: Option<i32>,
-    ) -> Box<dyn Convolver<T, D>> {
+    ) -> Arc<dyn Convolver<T, D>> {
         let f = |k: &mut Array<f64, D::Larger>| {
             let [alpha, beta, gamma] = angles;
             let [k_u, k_v, k_w] = [0, 1, 2].map(|i| k.index_axis(Axis(0), i));
@@ -72,7 +72,7 @@ where
         non_orthogonal_correction: F,
         weight_functions: &[WeightFunctionInfo<T>],
         lanczos: Option<i32>,
-    ) -> Box<dyn Convolver<T, D>> {
+    ) -> Arc<dyn Convolver<T, D>> {
         // initialize the Fourier transform
         let mut planner = FftPlanner::new();
         let mut forward_transforms = Vec::with_capacity(axes.len());
@@ -174,7 +174,7 @@ where
             });
         }
 
-        Box::new(Self {
+        Arc::new(Self {
             k_abs,
             weight_functions: fft_weight_functions,
             lanczos_sigma,

--- a/crates/feos-dft/src/interface/mod.rs
+++ b/crates/feos-dft/src/interface/mod.rs
@@ -7,6 +7,7 @@ use crate::solver::DFTSolver;
 use feos_core::{Contributions, FeosError, FeosResult, PhaseEquilibrium, ReferenceSystem};
 use ndarray::{Array1, Array2, Axis as Axis_nd, Ix1, s};
 use quantity::{Area, Density, Length, Moles, SurfaceTension, Temperature};
+use std::sync::Arc;
 
 mod surface_tension_diagram;
 pub use surface_tension_diagram::SurfaceTensionDiagram;
@@ -15,6 +16,7 @@ const RELATIVE_WIDTH: f64 = 6.0;
 const MIN_WIDTH: f64 = 100.0;
 
 /// Density profile and properties of a planar interface.
+#[derive(Clone)]
 pub struct PlanarInterface<F: HelmholtzEnergyFunctional> {
     pub profile: DFTProfile<Ix1, F>,
     pub vle: PhaseEquilibrium<F, 2>,
@@ -93,7 +95,7 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
 
         // specify specification
         if fix_equimolar_surface {
-            profile.profile.specification = Box::new(DFTSpecifications::total_moles_from_profile(
+            profile.profile.specification = Arc::new(DFTSpecifications::total_moles_from_profile(
                 &profile.profile,
             ));
         }
@@ -143,7 +145,7 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
 
         // specify specification
         if fix_equimolar_surface {
-            profile.profile.specification = Box::new(DFTSpecifications::total_moles_from_profile(
+            profile.profile.specification = Arc::new(DFTSpecifications::total_moles_from_profile(
                 &profile.profile,
             ));
         }

--- a/crates/feos-dft/src/profile/mod.rs
+++ b/crates/feos-dft/src/profile/mod.rs
@@ -11,6 +11,7 @@ use ndarray::{
 use num_dual::DualNum;
 use quantity::{_Volume, DEGREES, Density, Length, Moles, Quantity, Temperature, Volume};
 use std::ops::{Add, MulAssign};
+use std::sync::Arc;
 use typenum::Sum;
 
 mod properties;
@@ -97,13 +98,14 @@ impl<D: Dimension, F: HelmholtzEnergyFunctional> DFTSpecification<D, F> for DFTS
     }
 }
 
+#[derive(Clone)]
 /// A one-, two-, or three-dimensional density profile.
 pub struct DFTProfile<D: Dimension, F> {
     pub grid: Grid,
-    pub convolver: Box<dyn Convolver<f64, D>>,
+    pub convolver: Arc<dyn Convolver<f64, D>>,
     pub temperature: Temperature,
     pub density: Density<Array<f64, D::Larger>>,
-    pub specification: Box<dyn DFTSpecification<D, F>>,
+    pub specification: Arc<dyn DFTSpecification<D, F>>,
     pub external_potential: Array<f64, D::Larger>,
     pub bulk: State<F>,
     pub solver_log: Option<DFTSolverLog>,
@@ -245,7 +247,7 @@ where
             convolver,
             temperature: bulk.temperature,
             density,
-            specification: Box::new(DFTSpecifications::ChemicalPotential),
+            specification: Arc::new(DFTSpecifications::ChemicalPotential),
             external_potential,
             bulk: bulk.clone(),
             solver_log: None,

--- a/crates/feos-dft/src/profile/properties.rs
+++ b/crates/feos-dft/src/profile/properties.rs
@@ -11,6 +11,7 @@ use quantity::{
     Density, Energy, Entropy, EntropyDensity, MolarEnergy, Moles, Pressure, Quantity, Temperature,
 };
 use std::ops::{AddAssign, Div};
+use std::sync::Arc;
 
 type DrhoDmu<D: Dimension> =
     <Density<Array<f64, <D::Larger as Dimension>::Larger>> as Div<MolarEnergy>>::Output;
@@ -390,7 +391,7 @@ where
             .into_iter()
             .map(|c| c.weight_functions(t_dual))
             .collect();
-        let convolver: Box<dyn Convolver<_, D>> =
+        let convolver: Arc<dyn Convolver<_, D>> =
             ConvolverFFT::plan(&self.grid, &weight_functions, self.lanczos);
         let (_, mut dfdrho) =
             self.bulk

--- a/py-feos/src/dft/adsorption/mod.rs
+++ b/py-feos/src/dft/adsorption/mod.rs
@@ -223,18 +223,18 @@ macro_rules! impl_adsorption_isotherm {
                 ).map_err(PyFeosError::from)?))
             }
 
-            // #[getter]
-            // fn get_profiles(&self) -> Vec<$py_pore_profile> {
-            //     self.0
-            //         .profiles
-            //         .iter()
-            //         .filter_map(|p| {
-            //             p.as_ref()
-            //                 .ok()
-            //                 .map(|p| $py_pore_profile(p.clone()))
-            //         })
-            //         .collect()
-            // }
+            #[getter]
+            fn get_profiles(&self) -> Vec<$py_pore_profile> {
+                self.0
+                    .profiles
+                    .iter()
+                    .filter_map(|p| {
+                        p.as_ref()
+                            .ok()
+                            .map(|p| $py_pore_profile(p.clone()))
+                    })
+                    .collect()
+            }
 
             #[getter]
             fn get_pressure(&self) -> Pressure<Array1<f64>> {

--- a/py-feos/src/dft/interface/surface_tension_diagram.rs
+++ b/py-feos/src/dft/interface/surface_tension_diagram.rs
@@ -72,14 +72,14 @@ impl PySurfaceTensionDiagram {
         )))
     }
 
-    // #[getter]
-    // fn get_profiles(&self) -> Vec<PyPlanarInterface> {
-    //     self.0
-    //         .profiles
-    //         .iter()
-    //         .map(|p| PyPlanarInterface(p.clone()))
-    //         .collect()
-    // }
+    #[getter]
+    fn get_profiles(&self) -> Vec<PyPlanarInterface> {
+        self.0
+            .profiles
+            .iter()
+            .map(|p| PyPlanarInterface(p.clone()))
+            .collect()
+    }
 
     #[getter]
     pub fn get_vapor(&self) -> PyStateVec {


### PR DESCRIPTION
Ultimately allows to view individual profiles from a `SurfaceTensionDiagram` and `Adsorption` again.