### PR TITLE
Automatically detect VLLEs in BinaryPhaseDiagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Automatically detect VLLEs in `BinaryPhaseDiagram`. [#341](https://github.com/feos-org/feos/pull/341)
 
 ## [0.9.3] - 2026-01-26
 ### Added


### PR DESCRIPTION
I accidentally pushed this to main already...

The PR improves the calculations of binary VLE phase diagrams by automatically checking for a liquid-liquid split.

One way to do that would be to track the stability of the liquid phase. I tested this approach and it works like a charm, however, it also increases the computation time for every phase diagram a lot. Therefore, the implemented method instead first simply calculates the entire phase diagram and then checks whether the dew line crosses itself at some point which is a clear indication of a liquid/liquid split. If it detects an intersection, a initial guess for the VLLE is interpolated from the phase diagram, which is then used to solve the actual VLLE. The liquid compositions of the VLLE are then used to calculate a new phase diagram that does not penetrate the unstable region.