### PR TITLE
Burkhardt2025.json: Update identifiers for two chemical compounds

### DIFF
--- a/parameters/ideal_gas/burkhardt2025.json
+++ b/parameters/ideal_gas/burkhardt2025.json
@@ -11935,9 +11935,9 @@
     },
     {
         "identifier": {
-            "cas": "558-15-6",
-            "name": "",
-            "iupac_name": "",
+            "cas": "1511-62-2",
+            "name": "bromodifluoromethane",
+            "iupac_name": "bromo(difluoro)methane",
             "formula": "CHBrF2",
             "smiles": "FC(F)Br",
             "inchi": "InChI=1S/CHBrF2/c2-1(3)4/h1H/i1D"
@@ -19738,9 +19738,9 @@
     },
     {
         "identifier": {
-            "cas": "6928-45-6",
-            "name": "",
-            "iupac_name": "",
+            "cas": "540-49-8",
+            "name": "1,2-dibromoethylene",
+            "iupac_name": "1,2-dibromoethene",
             "formula": "C2H2Br2",
             "smiles": "BrC=CBr",
             "inchi": "InChI=1S/C2H2Br2/c3-1-2-4/h1-2H/b2-1-/i1D,2D"


### PR DESCRIPTION
There were two chemical compounds with no name, and their CAS numbers seemed to not point to any compounds in the CAS database (https://commonchemistry.cas.org/). by looking at their SMILES strings, an appropiate name, IUPAC name and CAS number was added. 