### PR TITLE
Index out of bounds in PhaseDiagram.binary_vle() fixed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Fixed `PhaseDiagram.binary_vle()` panicking during search for VLLE (tried to access unallocated element). [#361] (https://github.com/feos-org/feos/pull/362)
 
 ## [0.9.5] - 2026-04-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Fixed `PhaseDiagram.binary_vle()` panicking during search for VLLE (tried to access unallocated element). [#361] ()
 
 ## [0.9.5] - 2026-04-14
 ### Added

--- a/crates/feos-core/src/phase_equilibria/phase_diagram_binary.rs
+++ b/crates/feos-core/src/phase_equilibria/phase_diagram_binary.rs
@@ -257,7 +257,7 @@ fn check_for_vlle<E: Residual + Subset, TP: TemperatureOrPressure>(
             }
             if y[j] < y[i] {
                 // intersection found!
-                let (xj, yj, pj) = if j == n - 2 {
+                let (xj, yj, pj) = if j >= n - 2 {
                     // Use Henry constant of component 2
                     let k_inf = (states[n - 1].liquid().ln_phi() - states[n - 1].vapor().ln_phi())
                         .map(f64::exp)[1];


### PR DESCRIPTION
Index correction that only valid array elements are accessed as described in #361 .