### PR TITLE
Implement DFT at fixed moles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Breaking]
+### Added
+- Added `PoreSpecification` enum to specify the state of the fluid in the pore (currently chemical potential or moles). [#371](https://github.com/feos-org/feos/pull/371)
+
 ### Changed
 - Changed data type of initial temperatures or pressure for phase equilibrium calculations (`TemperatureOrPressure::Other`) from `D` to `f64`. [#369](https://github.com/feos-org/feos/pull/369)
+- Reworked DFT solution algorithms slightly for the cases in which additional specifications are given. [#371](https://github.com/feos-org/feos/pull/371)
+
+### Removed
+- Removed the `DFTSpecification` trait in favor of only using the `DFTSpecification` enum (renamed from `DFTSpecifications`). [#371](https://github.com/feos-org/feos/pull/371)
 
 ## [Unreleased]
 

--- a/crates/feos-dft/src/adsorption/mod.rs
+++ b/crates/feos-dft/src/adsorption/mod.rs
@@ -17,7 +17,7 @@ mod fea_potential;
 mod pore;
 mod pore2d;
 pub use external_potential::{ExternalPotential, FluidParameters};
-pub use pore::{HenryCoefficient, Pore1D, PoreProfile, PoreProfile1D, PoreSpecification};
+pub use pore::{HenryCoefficient, Pore, Pore1D, PoreProfile, PoreProfile1D, PoreSpecification};
 pub use pore2d::{Pore2D, PoreProfile2D};
 
 #[cfg(feature = "rayon")]
@@ -54,7 +54,7 @@ where
     }
 
     /// Calculate an adsorption isotherm (starting at low pressure)
-    pub fn adsorption_isotherm<S: PoreSpecification<D>, X: Composition<f64, Dyn> + Clone>(
+    pub fn adsorption_isotherm<S: Pore<D>, X: Composition<f64, Dyn> + Clone>(
         functional: &F,
         temperature: Temperature,
         pressure: &Pressure<Array1<f64>>,
@@ -74,7 +74,7 @@ where
     }
 
     /// Calculate an desorption isotherm (starting at high pressure)
-    pub fn desorption_isotherm<S: PoreSpecification<D>, X: Composition<f64, Dyn> + Clone>(
+    pub fn desorption_isotherm<S: Pore<D>, X: Composition<f64, Dyn> + Clone>(
         functional: &F,
         temperature: Temperature,
         pressure: &Pressure<Array1<f64>>,
@@ -99,7 +99,7 @@ where
     }
 
     /// Calculate an equilibrium isotherm
-    pub fn equilibrium_isotherm<S: PoreSpecification<D>, X: Composition<f64, Dyn> + Clone>(
+    pub fn equilibrium_isotherm<S: Pore<D>, X: Composition<f64, Dyn> + Clone>(
         functional: &F,
         temperature: Temperature,
         pressure: &Pressure<Array1<f64>>,
@@ -182,7 +182,7 @@ where
         }
     }
 
-    fn isotherm<S: PoreSpecification<D>, X: Composition<f64, Dyn> + Clone>(
+    fn isotherm<S: Pore<D>, X: Composition<f64, Dyn> + Clone>(
         functional: &F,
         temperature: Temperature,
         pressure: &Pressure<Array1<f64>>,
@@ -210,7 +210,10 @@ where
                 _ => unreachable!(),
             };
         }
-        let profile = pore.initialize(&bulk, None, None)?.solve(solver)?.profile;
+        let profile = pore
+            .initialize(&bulk, None, None, PoreSpecification::ChemicalPotential)?
+            .solve(solver)?
+            .profile;
         let external_potential = Some(&profile.external_potential);
         let mut old_density = Some(&profile.density);
 
@@ -229,8 +232,18 @@ where
                     .clone();
             }
 
-            let p = pore.initialize(&bulk, old_density, external_potential)?;
-            let p2 = pore.initialize(&bulk, None, external_potential)?;
+            let p = pore.initialize(
+                &bulk,
+                old_density,
+                external_potential,
+                PoreSpecification::ChemicalPotential,
+            )?;
+            let p2 = pore.initialize(
+                &bulk,
+                None,
+                external_potential,
+                PoreSpecification::ChemicalPotential,
+            )?;
             profiles.push(p.solve(solver).or_else(|_| p2.solve(solver)));
 
             old_density = if let Some(Ok(l)) = profiles.last() {
@@ -245,7 +258,7 @@ where
 
     /// Calculate the phase transition from an empty to a filled pore.
     #[expect(clippy::too_many_arguments)]
-    pub fn phase_equilibrium<S: PoreSpecification<D>, X: Composition<f64, Dyn> + Clone>(
+    pub fn phase_equilibrium<S: Pore<D>, X: Composition<f64, Dyn> + Clone>(
         functional: &F,
         temperature: Temperature,
         p_min: Pressure,
@@ -261,8 +274,17 @@ where
         let bulk_init = State::new_npt(functional, temperature, p_max, x.clone(), Some(Liquid))?;
         let liquid_bulk = State::new_npt(functional, temperature, p_max, x.clone(), Some(Vapor))?;
 
-        let mut vapor = pore.initialize(&vapor_bulk, None, None)?.solve(solver)?;
-        let mut liquid = pore.initialize(&bulk_init, None, None)?.solve(solver)?;
+        let mut vapor = pore
+            .initialize(
+                &vapor_bulk,
+                None,
+                None,
+                PoreSpecification::ChemicalPotential,
+            )?
+            .solve(solver)?;
+        let mut liquid = pore
+            .initialize(&bulk_init, None, None, PoreSpecification::ChemicalPotential)?
+            .solve(solver)?;
 
         // calculate initial value for bulk density
         let n_dp_drho_v = (vapor.profile.moles() * vapor_bulk.dp_drho(Contributions::Total)).sum();

--- a/crates/feos-dft/src/adsorption/pore.rs
+++ b/crates/feos-dft/src/adsorption/pore.rs
@@ -1,4 +1,3 @@
-use crate::WeightFunctionInfo;
 use crate::adsorption::{ExternalPotential, FluidParameters};
 use crate::convolver::ConvolverFFT;
 use crate::functional::{HelmholtzEnergyFunctional, HelmholtzEnergyFunctionalDyn, MoleculeShape};
@@ -6,6 +5,7 @@ use crate::functional_contribution::FunctionalContribution;
 use crate::geometry::{Axis, Geometry, Grid};
 use crate::profile::{DFTProfile, MAX_POTENTIAL};
 use crate::solver::DFTSolver;
+use crate::{DFTSpecification, WeightFunctionInfo};
 use feos_core::{Contributions, FeosResult, ReferenceSystem, ResidualDyn, State, StateHD};
 use nalgebra::{DVector, dvector};
 use ndarray::prelude::*;
@@ -13,8 +13,8 @@ use ndarray::{Axis as Axis_nd, RemoveAxis};
 use num_dual::linalg::LU;
 use num_dual::{Dual64, DualNum};
 use quantity::{
-    _Moles, _Pressure, Density, Dimensionless, Energy, KELVIN, Length, MolarEnergy, Quantity, RGAS,
-    Temperature, Volume,
+    _Moles, _Pressure, Density, Dimensionless, Energy, KELVIN, Length, MolarEnergy, Moles,
+    Quantity, RGAS, Temperature, Volume,
 };
 use rustdct::DctNum;
 use std::ops::Sub;
@@ -52,14 +52,25 @@ impl Pore1D {
     }
 }
 
+/// Different ways that the thermodynamic state of the fluid in the pore
+/// can be specified.
+#[derive(Clone)]
+pub enum PoreSpecification {
+    /// Specify the chemical potential (via the bulk state).
+    ChemicalPotential,
+    /// Specify the amount of moles of every component.
+    Moles(Moles<Array1<f64>>),
+}
+
 /// Trait for the generic implementation of adsorption applications.
-pub trait PoreSpecification<D: Dimension> {
+pub trait Pore<D: Dimension> {
     /// Initialize a new single pore.
     fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
         &self,
         bulk: &State<F>,
         density: Option<&Density<Array<f64, D::Larger>>>,
         external_potential: Option<&Array<f64, D::Larger>>,
+        specification: PoreSpecification,
     ) -> FeosResult<PoreProfile<D, F>>;
 
     /// Return the pore volume using Helium at 298 K as reference.
@@ -68,7 +79,7 @@ pub trait PoreSpecification<D: Dimension> {
         D::Larger: Dimension<Smaller = D>,
     {
         let bulk = State::new_pure(&&Helium, 298.0 * KELVIN, Density::from_reduced(1.0))?;
-        let pore = self.initialize(&bulk, None, None)?;
+        let pore = self.initialize(&bulk, None, None, PoreSpecification::ChemicalPotential)?;
         let pot = Dimensionless::from_reduced(
             pore.profile
                 .external_potential
@@ -96,6 +107,27 @@ where
     D::Smaller: Dimension<Larger = D>,
     <D::Larger as Dimension>::Larger: Dimension<Smaller = D::Larger>,
 {
+    pub fn new(
+        grid: Grid,
+        bulk: &State<F>,
+        external_potential: Option<Array<f64, D::Larger>>,
+        density: Option<&Density<Array<f64, D::Larger>>>,
+        specification: PoreSpecification,
+    ) -> Self {
+        let mut profile = DFTProfile::new(grid, bulk, external_potential, density, Some(1));
+
+        // fix the number of particles
+        if let PoreSpecification::Moles(moles) = specification {
+            profile.specification = DFTSpecification::Moles(moles.to_reduced())
+        }
+
+        Self {
+            profile,
+            grand_potential: None,
+            interfacial_tension: None,
+        }
+    }
+
     pub fn solve_inplace(&mut self, solver: Option<&DFTSolver>, debug: bool) -> FeosResult<()> {
         // Solve the profile
         self.profile.solve(solver, debug)?;
@@ -180,12 +212,13 @@ where
     }
 }
 
-impl PoreSpecification<Ix1> for Pore1D {
+impl Pore<Ix1> for Pore1D {
     fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
         &self,
         bulk: &State<F>,
         density: Option<&Density<Array2<f64>>>,
         external_potential: Option<&Array2<f64>>,
+        specification: PoreSpecification,
     ) -> FeosResult<PoreProfile1D<F>> {
         let dft: &F = &bulk.eos;
         let n_grid = self.n_grid.unwrap_or(DEFAULT_GRID_POINTS);
@@ -223,11 +256,13 @@ impl PoreSpecification<Ix1> for Pore1D {
         // initialize grid
         let grid = Grid::new_1d(axis);
 
-        Ok(PoreProfile {
-            profile: DFTProfile::new(grid, bulk, Some(external_potential), density, Some(1)),
-            grand_potential: None,
-            interfacial_tension: None,
-        })
+        Ok(PoreProfile::new(
+            grid,
+            bulk,
+            Some(external_potential),
+            density,
+            specification,
+        ))
     }
 }
 

--- a/crates/feos-dft/src/adsorption/pore2d.rs
+++ b/crates/feos-dft/src/adsorption/pore2d.rs
@@ -1,5 +1,5 @@
-use super::{FluidParameters, PoreProfile, PoreSpecification};
-use crate::{Axis, DFTProfile, Grid, HelmholtzEnergyFunctional};
+use super::{FluidParameters, Pore, PoreProfile};
+use crate::{Axis, Grid, HelmholtzEnergyFunctional, adsorption::pore::PoreSpecification};
 use feos_core::{FeosResult, State};
 use ndarray::{Array3, Ix2};
 use quantity::{Angle, Density, Length};
@@ -22,22 +22,25 @@ impl Pore2D {
     }
 }
 
-impl PoreSpecification<Ix2> for Pore2D {
+impl Pore<Ix2> for Pore2D {
     fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
         &self,
         bulk: &State<F>,
         density: Option<&Density<Array3<f64>>>,
         external_potential: Option<&Array3<f64>>,
+        specification: PoreSpecification,
     ) -> FeosResult<PoreProfile<Ix2, F>> {
         // generate grid
         let x = Axis::new_cartesian(self.n_grid[0], self.system_size[0], None);
         let y = Axis::new_cartesian(self.n_grid[1], self.system_size[1], None);
         let grid = Grid::Periodical2(x, y, self.angle);
 
-        Ok(PoreProfile {
-            profile: DFTProfile::new(grid, bulk, external_potential.cloned(), density, Some(1)),
-            grand_potential: None,
-            interfacial_tension: None,
-        })
+        Ok(PoreProfile::new(
+            grid,
+            bulk,
+            external_potential.cloned(),
+            density,
+            specification,
+        ))
     }
 }

--- a/crates/feos-dft/src/adsorption/pore3d.rs
+++ b/crates/feos-dft/src/adsorption/pore3d.rs
@@ -1,8 +1,8 @@
-use super::pore::{PoreProfile, PoreSpecification};
-use crate::adsorption::FluidParameters;
+use super::pore::{PoreProfile, Pore};
+use crate::adsorption::{FluidParameters, PoreSpecification};
 use crate::functional::HelmholtzEnergyFunctional;
 use crate::geometry::{Axis, Grid};
-use crate::profile::{CUTOFF_RADIUS, DFTProfile, MAX_POTENTIAL};
+use crate::profile::{CUTOFF_RADIUS, MAX_POTENTIAL};
 use feos_core::{FeosError, FeosResult, ReferenceSystem, State};
 use ndarray::Zip;
 use ndarray::prelude::*;
@@ -48,12 +48,13 @@ impl Pore3D {
 /// Density profile and properties of a 3D confined system.
 pub type PoreProfile3D<F> = PoreProfile<Ix3, F>;
 
-impl PoreSpecification<Ix3> for Pore3D {
+impl Pore<Ix3> for Pore3D {
     fn initialize<F: HelmholtzEnergyFunctional + FluidParameters>(
         &self,
         bulk: &State<F>,
         density: Option<&Density<Array4<f64>>>,
         external_potential: Option<&Array4<f64>>,
+        specification: PoreSpecification,
     ) -> FeosResult<PoreProfile3D<F>> {
         let dft: &F = &bulk.eos;
 
@@ -94,11 +95,13 @@ impl PoreSpecification<Ix3> for Pore3D {
         )?;
         let grid = Grid::Periodical3(x, y, z, self.angles.unwrap_or([90.0 * DEGREES; 3]));
 
-        Ok(PoreProfile {
-            profile: DFTProfile::new(grid, bulk, Some(external_potential), density, Some(1)),
-            grand_potential: None,
-            interfacial_tension: None,
-        })
+        Ok(PoreProfile::new(
+            grid,
+            bulk,
+            Some(external_potential),
+            density,
+            specification,
+        ))
     }
 }
 

--- a/crates/feos-dft/src/interface/mod.rs
+++ b/crates/feos-dft/src/interface/mod.rs
@@ -2,12 +2,11 @@
 use crate::functional::HelmholtzEnergyFunctional;
 use crate::geometry::{Axis, Grid};
 use crate::pdgt::PdgtFunctionalProperties;
-use crate::profile::{DFTProfile, DFTSpecifications};
+use crate::profile::DFTProfile;
 use crate::solver::DFTSolver;
 use feos_core::{Contributions, FeosError, FeosResult, PhaseEquilibrium, ReferenceSystem};
 use ndarray::{Array1, Array2, Axis as Axis_nd, Ix1, s};
 use quantity::{Area, Density, Length, Moles, SurfaceTension, Temperature};
-use std::sync::Arc;
 
 mod surface_tension_diagram;
 pub use surface_tension_diagram::SurfaceTensionDiagram;
@@ -95,9 +94,7 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
 
         // specify specification
         if fix_equimolar_surface {
-            profile.profile.specification = Arc::new(DFTSpecifications::total_moles_from_profile(
-                &profile.profile,
-            ));
+            profile.profile.fix_total_moles();
         }
 
         profile
@@ -145,9 +142,7 @@ impl<F: HelmholtzEnergyFunctional> PlanarInterface<F> {
 
         // specify specification
         if fix_equimolar_surface {
-            profile.profile.specification = Arc::new(DFTSpecifications::total_moles_from_profile(
-                &profile.profile,
-            ));
+            profile.profile.fix_total_moles();
         }
 
         Ok(profile)

--- a/crates/feos-dft/src/lib.rs
+++ b/crates/feos-dft/src/lib.rs
@@ -19,6 +19,6 @@ pub use functional::{HelmholtzEnergyFunctional, HelmholtzEnergyFunctionalDyn, Mo
 pub use functional_contribution::FunctionalContribution;
 pub use geometry::{Axis, Geometry, Grid};
 pub use pdgt::PdgtFunctionalProperties;
-pub use profile::{DFTProfile, DFTSpecification, DFTSpecifications};
+pub use profile::{DFTProfile, DFTSpecification};
 pub use solver::{DFTSolver, DFTSolverLog};
 pub use weight_functions::{WeightFunction, WeightFunctionInfo, WeightFunctionShape};

--- a/crates/feos-dft/src/profile/mod.rs
+++ b/crates/feos-dft/src/profile/mod.rs
@@ -22,19 +22,10 @@ pub(crate) const CUTOFF_RADIUS: f64 = 14.0;
 /// General specifications for the chemical potential in a DFT calculation.
 ///
 /// In the most basic case, the chemical potential is specified in a DFT calculation,
-/// for more general systems, this trait provides the possibility to declare additional
+/// for more general systems, this enum provides the possibility to declare additional
 /// equations for the calculation of the chemical potential during the iteration.
-pub trait DFTSpecification<D: Dimension, F>: Send + Sync {
-    fn calculate_bulk_density(
-        &self,
-        profile: &DFTProfile<D, F>,
-        bulk_density: &Array1<f64>,
-        z: &Array1<f64>,
-    ) -> FeosResult<Array1<f64>>;
-}
-
-/// Common specifications for the grand potentials in a DFT calculation.
-pub enum DFTSpecifications {
+#[derive(Clone)]
+pub enum DFTSpecification {
     /// DFT with specified chemical potential.
     ChemicalPotential,
     /// DFT with specified number of particles.
@@ -42,57 +33,21 @@ pub enum DFTSpecifications {
     /// The solution is still a grand canonical density profile, but the chemical
     /// potentials are iterated together with the density profile to obtain a result
     /// with the specified number of particles.
-    Moles { moles: Array1<f64> },
+    Moles(Array1<f64>),
     /// DFT with specified total number of moles.
-    TotalMoles { total_moles: f64 },
+    TotalMoles(f64),
 }
 
-impl DFTSpecifications {
-    /// Calculate the number of particles from the profile.
-    ///
-    /// Call this after initializing the density profile to keep the number of
-    /// particles constant in systems, where the number itself is difficult to obtain.
-    pub fn moles_from_profile<D: Dimension, F: HelmholtzEnergyFunctional>(
-        profile: &DFTProfile<D, F>,
-    ) -> Self
-    where
-        D::Larger: Dimension<Smaller = D>,
-    {
-        let rho = profile.density.to_reduced();
-        Self::Moles {
-            moles: profile.integrate_reduced_comp(&rho),
-        }
-    }
-
-    /// Calculate the number of particles from the profile.
-    ///
-    /// Call this after initializing the density profile to keep the total number of
-    /// particles constant in systems, e.g. to fix the equimolar dividing surface.
-    pub fn total_moles_from_profile<D: Dimension, F: HelmholtzEnergyFunctional>(
-        profile: &DFTProfile<D, F>,
-    ) -> Self
-    where
-        D::Larger: Dimension<Smaller = D>,
-    {
-        let rho = profile.density.to_reduced();
-        let moles = profile.integrate_reduced_comp(&rho).sum();
-        Self::TotalMoles { total_moles: moles }
-    }
-}
-
-impl<D: Dimension, F: HelmholtzEnergyFunctional> DFTSpecification<D, F> for DFTSpecifications {
+impl DFTSpecification {
     fn calculate_bulk_density(
         &self,
-        _profile: &DFTProfile<D, F>,
         bulk_density: &Array1<f64>,
         z: &Array1<f64>,
     ) -> FeosResult<Array1<f64>> {
         Ok(match self {
             Self::ChemicalPotential => bulk_density.clone(),
-            Self::Moles { moles } => moles / z,
-            Self::TotalMoles { total_moles } => {
-                bulk_density * *total_moles / (bulk_density * z).sum()
-            }
+            Self::Moles(moles) => moles / z,
+            Self::TotalMoles(total_moles) => bulk_density * *total_moles / (bulk_density * z).sum(),
         })
     }
 }
@@ -104,7 +59,7 @@ pub struct DFTProfile<D: Dimension, F> {
     pub convolver: Arc<dyn Convolver<f64, D>>,
     pub temperature: Temperature,
     pub density: Density<Array<f64, D::Larger>>,
-    pub specification: Arc<dyn DFTSpecification<D, F>>,
+    pub specification: DFTSpecification,
     pub external_potential: Array<f64, D::Larger>,
     pub bulk: State<F>,
     pub solver_log: Option<DFTSolverLog>,
@@ -246,12 +201,27 @@ where
             convolver,
             temperature: bulk.temperature,
             density,
-            specification: Arc::new(DFTSpecifications::ChemicalPotential),
+            specification: DFTSpecification::ChemicalPotential,
             external_potential,
             bulk: bulk.clone(),
             solver_log: None,
             lanczos,
         }
+    }
+
+    /// Set a constraint to fix the number of particles of every component based on
+    /// the current density profile.
+    pub fn fix_moles(&mut self) {
+        let moles = self.integrate_reduced_comp(&self.density.to_reduced());
+        self.specification = DFTSpecification::Moles(moles);
+    }
+
+    /// Set a constraint to fix the total number of particles based on
+    /// the current density profile.
+    pub fn fix_total_moles(&mut self) {
+        let rho = self.density.to_reduced();
+        let moles = self.integrate_reduced_comp(&rho).sum();
+        self.specification = DFTSpecification::TotalMoles(moles);
     }
 }
 
@@ -374,7 +344,7 @@ where
         // Read from profile
         let density = self.density.to_reduced();
         let partial_density = self.bulk.partial_density().into_reduced();
-        let bulk_density = self
+        let mut bulk_density = self
             .bulk
             .eos
             .component_index()
@@ -383,7 +353,7 @@ where
             .collect();
 
         let (res, res_bulk, res_norm, _, _) =
-            self.euler_lagrange_equation(&density, &bulk_density, log)?;
+            self.euler_lagrange_equation(&density, &mut bulk_density, log)?;
         Ok((res, res_bulk, res_norm))
     }
 
@@ -391,7 +361,7 @@ where
     pub(crate) fn euler_lagrange_equation(
         &self,
         density: &Array<f64, D::Larger>,
-        bulk_density: &Array1<f64>,
+        bulk_density: &mut Array1<f64>,
         log: bool,
     ) -> FeosResult<(
         Array<f64, D::Larger>,
@@ -436,6 +406,14 @@ where
             .bond_integrals(temperature, &exp_dfdrho, self.convolver.as_ref());
         let mut rho_projected = &exp_dfdrho * bonds;
 
+        // calculate bulk density based on the given specification
+        let res_bulk = &*bulk_density
+            - self.specification.calculate_bulk_density(
+                bulk_density,
+                &self.integrate_reduced_comp(&rho_projected),
+            )?;
+        *bulk_density -= &res_bulk;
+
         // multiply bulk density
         rho_projected
             .outer_iter_mut()
@@ -457,18 +435,9 @@ where
             .filter(|&(_, &p)| p + f64::EPSILON >= MAX_POTENTIAL)
             .for_each(|(r, _)| *r = 0.0);
 
-        // additional residuals for the calculation of the bulk densities
-        let z = self.integrate_reduced_comp(&rho_projected);
-        let res_bulk = bulk_density
-            - self
-                .specification
-                .calculate_bulk_density(self, bulk_density, &z)?;
-
         // calculate the norm of the residual
-        let res_norm = ((density - &rho_projected).mapv(|x| x * x).sum()
-            + res_bulk.mapv(|x| x * x).sum())
-        .sqrt()
-            / ((res.len() + res_bulk.len()) as f64).sqrt();
+        let res_norm =
+            (density - &rho_projected).mapv(|x| x * x).sum().sqrt() / (res.len() as f64).sqrt();
 
         if res_norm.is_finite() {
             Ok((res, res_bulk, res_norm, exp_dfdrho, rho_projected))
@@ -501,7 +470,6 @@ where
             .enumerate()
             .for_each(|(i, r)| partial_density.set(component_index[i], Density::from_reduced(r)));
         self.bulk = State::new_density(&self.bulk.eos, self.bulk.temperature, partial_density)?;
-
         Ok(())
     }
 }

--- a/crates/feos-dft/src/profile/properties.rs
+++ b/crates/feos-dft/src/profile/properties.rs
@@ -299,7 +299,7 @@ where
     fn density_derivative(&self, lhs: &Array<f64, D::Larger>) -> FeosResult<Array<f64, D::Larger>> {
         let rho = self.density.to_reduced();
         let partial_density = self.bulk.partial_density().into_reduced();
-        let rho_bulk = self
+        let mut rho_bulk = self
             .bulk
             .eos
             .component_index()
@@ -308,7 +308,7 @@ where
             .collect();
 
         let second_partial_derivatives = self.second_partial_derivatives(&rho)?;
-        let (_, _, _, exp_dfdrho, _) = self.euler_lagrange_equation(&rho, &rho_bulk, false)?;
+        let (_, _, _, exp_dfdrho, _) = self.euler_lagrange_equation(&rho, &mut rho_bulk, false)?;
 
         let rhs = |x: &_| {
             let delta_functional_derivative =

--- a/crates/feos-dft/src/solver.rs
+++ b/crates/feos-dft/src/solver.rs
@@ -266,8 +266,8 @@ where
 
         for k in 0..picard.max_iter {
             // calculate residual
-            let (res, res_bulk, res_norm, _, _) =
-                self.euler_lagrange_equation(&*rho, &*rho_bulk, picard.log)?;
+            let (res, _, res_norm, _, _) =
+                self.euler_lagrange_equation(&*rho, rho_bulk, picard.log)?;
             log.add_residual(solver, k, res_norm);
 
             // check for convergence
@@ -284,10 +284,8 @@ where
             // update solution
             if picard.log {
                 *rho *= &(&res * damping_coefficient).mapv(f64::exp);
-                *rho_bulk *= &(&res_bulk * damping_coefficient).mapv(f64::exp);
             } else {
                 *rho += &(&res * damping_coefficient);
-                *rho_bulk += &(&res_bulk * damping_coefficient);
             }
         }
         Ok((false, picard.max_iter))
@@ -297,7 +295,7 @@ where
         &self,
         rho: &Array<f64, D::Larger>,
         delta_rho: &Array<f64, D::Larger>,
-        rho_bulk: &Array1<f64>,
+        rho_bulk: &mut Array1<f64>,
         res0: f64,
         logarithm: bool,
     ) -> FeosResult<f64> {
@@ -384,8 +382,8 @@ where
             let m = resm.len() + 1;
 
             // calculate residual
-            let (res, res_bulk, res_norm, _, _) =
-                self.euler_lagrange_equation(&*rho, &*rho_bulk, anderson.log)?;
+            let (res, _, res_norm, _, _) =
+                self.euler_lagrange_equation(&*rho, rho_bulk, anderson.log)?;
             log.add_residual(solver, k, res_norm);
 
             // check for convergence
@@ -394,19 +392,19 @@ where
             }
 
             // save residual and x value
-            resm.push_back((res, res_bulk, res_norm));
+            resm.push_back((res, res_norm));
             if anderson.log {
-                rhom.push_back((rho.mapv(f64::ln), rho_bulk.mapv(f64::ln)));
+                rhom.push_back(rho.mapv(f64::ln));
             } else {
-                rhom.push_back((rho.clone(), rho_bulk.clone()));
+                rhom.push_back(rho.clone());
             }
 
             // calculate alpha
             r = DMatrix::from_fn(m + 1, m + 1, |i, j| match (i == m, j == m) {
                 (false, false) => {
-                    let (resi, resi_bulk, _) = &resm[i];
-                    let (resj, resj_bulk, _) = &resm[j];
-                    (resi * resj).sum() + (resi_bulk * resj_bulk).sum()
+                    let (resi, _) = &resm[i];
+                    let (resj, _) = &resm[j];
+                    (resi * resj).sum()
                 }
                 (true, true) => 0.0,
                 _ => 1.0,
@@ -418,20 +416,15 @@ where
 
             // update solution
             rho.fill(0.0);
-            rho_bulk.fill(0.0);
             for i in 0..m {
-                let (rhoi, rhoi_bulk) = &rhom[i];
-                let (resi, resi_bulk, _) = &resm[i];
+                let rhoi = &rhom[i];
+                let (resi, _) = &resm[i];
                 *rho += &(alpha[i] * (rhoi + &(anderson.damping_coefficient * resi)));
-                *rho_bulk +=
-                    &(alpha[i] * (rhoi_bulk + &(anderson.damping_coefficient * resi_bulk)));
             }
             if anderson.log {
                 rho.mapv_inplace(f64::exp);
-                rho_bulk.mapv_inplace(f64::exp);
             } else {
                 rho.mapv_inplace(f64::abs);
-                rho_bulk.mapv_inplace(f64::abs);
             }
         }
         Ok((false, anderson.max_iter))
@@ -476,7 +469,6 @@ where
             let lhs = if newton.log { &*rho * res } else { res };
             *rho += &Self::gmres(rhs, &lhs, newton.max_iter_gmres, newton.tol * 1e-2, log)?;
             rho.mapv_inplace(f64::abs);
-            rho_bulk.mapv_inplace(f64::abs);
         }
 
         Ok((false, newton.max_iter))

--- a/crates/feos/benches/dft_pore.rs
+++ b/crates/feos/benches/dft_pore.rs
@@ -3,7 +3,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use feos::core::parameter::IdentifierOption;
 use feos::core::{PhaseEquilibrium, State};
-use feos::dft::adsorption::{ExternalPotential, Pore1D, PoreSpecification};
+use feos::dft::adsorption::{
+    ExternalPotential, Pore, Pore1D, PoreSpecification::ChemicalPotential,
+};
 use feos::dft::{DFTSolver, Geometry};
 use feos::gc_pcsaft::{GcPcSaftFunctional, GcPcSaftParameters};
 use feos::hard_sphere::{FMTFunctional, FMTVersion};
@@ -24,7 +26,11 @@ fn fmt(c: &mut Criterion) {
     );
     let bulk = State::new_pure(&func, KELVIN, 0.75 / NAV / ANGSTROM.powi::<3>()).unwrap();
     group.bench_function("liquid", |b| {
-        b.iter(|| pore.initialize(&bulk, None, None).unwrap().solve(None))
+        b.iter(|| {
+            pore.initialize(&bulk, None, None, ChemicalPotential)
+                .unwrap()
+                .solve(None)
+        })
     });
 }
 
@@ -52,11 +58,19 @@ fn pcsaft(c: &mut Criterion) {
     let vle = PhaseEquilibrium::pure(&func, 300.0 * KELVIN, None, Default::default()).unwrap();
     let bulk = vle.liquid();
     group.bench_function("butane_liquid", |b| {
-        b.iter(|| pore.initialize(bulk, None, None).unwrap().solve(None))
+        b.iter(|| {
+            pore.initialize(bulk, None, None, ChemicalPotential)
+                .unwrap()
+                .solve(None)
+        })
     });
     let bulk = State::new_pure(&func, 300.0 * KELVIN, vle.vapor().density * 0.2).unwrap();
     group.bench_function("butane_vapor", |b| {
-        b.iter(|| pore.initialize(&bulk, None, None).unwrap().solve(None))
+        b.iter(|| {
+            pore.initialize(&bulk, None, None, ChemicalPotential)
+                .unwrap()
+                .solve(None)
+        })
     });
 
     let parameters = PcSaftParameters::from_json(
@@ -72,12 +86,20 @@ fn pcsaft(c: &mut Criterion) {
             .unwrap();
     let bulk = vle.liquid();
     group.bench_function("butane_pentane_liquid", |b| {
-        b.iter(|| pore.initialize(bulk, None, None).unwrap().solve(None))
+        b.iter(|| {
+            pore.initialize(bulk, None, None, ChemicalPotential)
+                .unwrap()
+                .solve(None)
+        })
     });
     let bulk =
         State::new_density(&func, 300.0 * KELVIN, vle.vapor().partial_density() * 0.2).unwrap();
     group.bench_function("butane_pentane_vapor", |b| {
-        b.iter(|| pore.initialize(&bulk, None, None).unwrap().solve(None))
+        b.iter(|| {
+            pore.initialize(&bulk, None, None, ChemicalPotential)
+                .unwrap()
+                .solve(None)
+        })
     });
 }
 
@@ -112,7 +134,7 @@ fn gc_pcsaft(c: &mut Criterion) {
         .anderson_mixing(None, None, None, None, None);
     group.bench_function("butane_liquid", |b| {
         b.iter(|| {
-            pore.initialize(bulk, None, None)
+            pore.initialize(bulk, None, None, ChemicalPotential)
                 .unwrap()
                 .solve(Some(&solver))
         })

--- a/crates/feos/tests/gc_pcsaft/dft.rs
+++ b/crates/feos/tests/gc_pcsaft/dft.rs
@@ -4,7 +4,7 @@ use approx::assert_relative_eq;
 use feos::gc_pcsaft::{GcPcSaft, GcPcSaftFunctional, GcPcSaftParameters};
 use feos_core::parameter::{ChemicalRecord, Identifier, IdentifierOption, SegmentRecord};
 use feos_core::{PhaseEquilibrium, State, Verbosity};
-use feos_dft::adsorption::{ExternalPotential, Pore1D, PoreSpecification};
+use feos_dft::adsorption::{ExternalPotential, Pore, Pore1D, PoreSpecification};
 use feos_dft::interface::PlanarInterface;
 use feos_dft::{DFTSolver, Geometry};
 use nalgebra::dvector;
@@ -228,7 +228,7 @@ fn test_dft_assoc() -> Result<(), Box<dyn Error>> {
         None,
         None,
     )
-    .initialize(&bulk, None, None)
+    .initialize(&bulk, None, None, PoreSpecification::ChemicalPotential)
     .unwrap()
     .solve(Some(&solver))?;
     Ok(())

--- a/py-feos/src/dft/adsorption/mod.rs
+++ b/py-feos/src/dft/adsorption/mod.rs
@@ -5,9 +5,9 @@ use crate::error::PyFeosError;
 use crate::ideal_gas::IdealGasModel;
 use crate::residual::ResidualModel;
 use feos_core::EquationOfState;
-use feos_dft::adsorption::{Adsorption, Adsorption1D};
 #[cfg(feature = "rayon")]
 use feos_dft::adsorption::Adsorption3D;
+use feos_dft::adsorption::{Adsorption, Adsorption1D};
 use nalgebra::DMatrix;
 use ndarray::*;
 use numpy::*;
@@ -19,7 +19,7 @@ mod external_potential;
 mod pore;
 
 pub use external_potential::PyExternalPotential;
-pub use pore::{PyPore1D, PyPore2D, PyPoreProfile1D};
+pub use pore::{PyPore1D, PyPore2D, PyPoreProfile1D, PyPoreSpecification};
 #[cfg(feature = "rayon")]
 pub use pore::{PyPore3D, PyPoreProfile3D};
 

--- a/py-feos/src/dft/adsorption/pore.rs
+++ b/py-feos/src/dft/adsorption/pore.rs
@@ -56,6 +56,29 @@ macro_rules! impl_pore_profile {
     };
 }
 
+/// Different ways that the thermodynamic state of the fluid in the pore
+/// can be specified.
+#[pyclass(name = "PoreSpecification", from_py_object)]
+#[derive(Clone)]
+pub struct PyPoreSpecification(PoreSpecification);
+
+#[pymethods]
+impl PyPoreSpecification {
+    /// Specify the chemical potential (via the bulk state).
+    #[classattr]
+    #[expect(non_snake_case)]
+    fn ChemicalPotential() -> Self {
+        Self(PoreSpecification::ChemicalPotential)
+    }
+
+    /// Specify the amount of moles of every component.
+    #[staticmethod]
+    #[expect(non_snake_case)]
+    fn Moles(moles: Moles<Array1<f64>>) -> Self {
+        Self(PoreSpecification::Moles(moles))
+    }
+}
+
 /// Parameters required to specify a 1D pore.
 ///
 /// Parameters
@@ -120,17 +143,23 @@ impl PyPore1D {
     ///     The external potential in the pore. Used to
     ///     save computation time in the case of costly
     ///     evaluations of external potentials.
+    /// specification : PoreSpecification
+    ///     The external constraint that specifies the state
+    ///     in the pore.
     ///
     /// Returns
     /// -------
     /// PoreProfile1D
-    #[pyo3(text_signature = "($self, bulk, density=None, external_potential=None)")]
-    #[pyo3(signature = (bulk, density=None, external_potential=None))]
+    #[pyo3(
+        text_signature = "($self, bulk, density=None, external_potential=None, specification=PoreSpecification.ChemicalPotential)"
+    )]
+    #[pyo3(signature = (bulk, density=None, external_potential=None, specification=PyPoreSpecification::ChemicalPotential()))]
     fn initialize(
         &self,
         bulk: &PyState,
         density: Option<Density<Array2<f64>>>,
         external_potential: Option<&Bound<'_, PyArray2<f64>>>,
+        specification: PyPoreSpecification,
     ) -> PyResult<PyPoreProfile1D> {
         Ok(PyPoreProfile1D(
             self.0
@@ -138,6 +167,7 @@ impl PyPore1D {
                     &bulk.0,
                     density.as_ref(),
                     external_potential.map(|e| e.to_owned_array()).as_ref(),
+                    specification.0,
                 )
                 .map_err(PyFeosError::from)?,
         ))
@@ -210,17 +240,23 @@ impl PyPore2D {
     ///     The external potential in the pore. Used to
     ///     save computation time in the case of costly
     ///     evaluations of external potentials.
+    /// specification : PoreSpecification
+    ///     The external constraint that specifies the state
+    ///     in the pore.
     ///
     /// Returns
     /// -------
     /// PoreProfile2D
-    #[pyo3(text_signature = "($self, bulk, density=None, external_potential=None)")]
-    #[pyo3(signature = (bulk, density=None, external_potential=None))]
+    #[pyo3(
+        text_signature = "($self, bulk, density=None, external_potential=None, specification=PoreSpecification.ChemicalPotential)"
+    )]
+    #[pyo3(signature = (bulk, density=None, external_potential=None, specification=PyPoreSpecification::ChemicalPotential()))]
     fn initialize(
         &self,
         bulk: &PyState,
         density: Option<Density<Array3<f64>>>,
         external_potential: Option<&Bound<'_, PyArray3<f64>>>,
+        specification: PyPoreSpecification,
     ) -> PyResult<PyPoreProfile2D> {
         Ok(PyPoreProfile2D(
             self.0
@@ -228,6 +264,7 @@ impl PyPore2D {
                     &bulk.0,
                     density.as_ref(),
                     external_potential.map(|e| e.to_owned_array()).as_ref(),
+                    specification.0,
                 )
                 .map_err(PyFeosError::from)?,
         ))
@@ -326,17 +363,23 @@ impl PyPore3D {
     ///     The external potential in the pore. Used to
     ///     save computation time in the case of costly
     ///     evaluations of external potentials.
+    /// specification : PoreSpecification
+    ///     The external constraint that specifies the state
+    ///     in the pore.
     ///
     /// Returns
     /// -------
     /// PoreProfile3D
-    #[pyo3(text_signature = "($self, bulk, density=None, external_potential=None)")]
-    #[pyo3(signature = (bulk, density=None, external_potential=None))]
+    #[pyo3(
+        text_signature = "($self, bulk, density=None, external_potential=None, specification=PoreSpecification.ChemicalPotential)"
+    )]
+    #[pyo3(signature = (bulk, density=None, external_potential=None, specification=PyPoreSpecification::ChemicalPotential()))]
     fn initialize(
         &self,
         bulk: &PyState,
         density: Option<Density<Array4<f64>>>,
         external_potential: Option<&Bound<'_, PyArray4<f64>>>,
+        specification: PyPoreSpecification,
     ) -> PyResult<PyPoreProfile3D> {
         Ok(PyPoreProfile3D(
             self.0
@@ -344,6 +387,7 @@ impl PyPore3D {
                     &bulk.0,
                     density.as_ref(),
                     external_potential.map(|e| e.to_owned_array()).as_ref(),
+                    specification.0,
                 )
                 .map_err(PyFeosError::from)?,
         ))

--- a/py-feos/src/dft/mod.rs
+++ b/py-feos/src/dft/mod.rs
@@ -15,7 +15,9 @@ mod profile;
 mod solvation;
 mod solver;
 
-pub(crate) use adsorption::{PyAdsorption1D, PyExternalPotential, PyPore1D, PyPore2D};
+pub(crate) use adsorption::{
+    PyAdsorption1D, PyExternalPotential, PyPore1D, PyPore2D, PyPoreSpecification,
+};
 // 3D pore / adsorption bindings wrap rayon-gated feos_dft types.
 #[cfg(feature = "rayon")]
 pub(crate) use adsorption::{PyAdsorption3D, PyPore3D};
@@ -117,24 +119,3 @@ impl PyHelmholtzEnergyFunctional {
         ))))
     }
 }
-
-// #[pymodule]
-// pub fn dft(m: &Bound<'_, PyModule>) -> PyResult<()> {
-//     m.add_class::<PyFMTVersion>()?;
-//     m.add_class::<PyHelmholtzEnergyFunctional>()?;
-
-//     m.add_class::<PyPlanarInterface>()?;
-//     m.add_class::<PyGeometry>()?;
-//     m.add_class::<PyPore1D>()?;
-//     m.add_class::<PyPore2D>()?;
-//     m.add_class::<PyPore3D>()?;
-//     m.add_class::<PyPairCorrelation>()?;
-//     m.add_class::<PyExternalPotential>()?;
-//     m.add_class::<PyAdsorption1D>()?;
-//     m.add_class::<PyAdsorption3D>()?;
-//     m.add_class::<PySurfaceTensionDiagram>()?;
-//     m.add_class::<PyDFTSolver>()?;
-//     m.add_class::<PySolvationProfile>()?;
-
-//     Ok(())
-// }

--- a/py-feos/src/lib.rs
+++ b/py-feos/src/lib.rs
@@ -203,6 +203,7 @@ fn feos(m: &Bound<'_, PyModule>) -> PyResult<()> {
         // Adsorption
         m.add_class::<dft::PyAdsorption1D>()?;
         m.add_class::<dft::PyExternalPotential>()?;
+        m.add_class::<dft::PyPoreSpecification>()?;
         m.add_class::<dft::PyPore1D>()?;
         m.add_class::<dft::PyPore2D>()?;
 


### PR DESCRIPTION
This was always possible in FeOs, however, this PR changes the solution algorithm for non-chemical potential constraints somewhat (convergence should be identical for all cases with fixed chemical potential) and adds an appropriate interface to use the feature from Python.

Example: Meta- and unstable adsorption in a slit pore by specifying the total amount of adsorbed molecules.
<img width="990" height="443" alt="grafik" src="https://github.com/user-attachments/assets/0d74bbcc-c674-4a4b-a435-eae865149989" />
