### PR TITLE
Fixed transposed jacobian layout in binary association

### DIFF
--- a/crates/feos-core/src/density_iteration.rs
+++ b/crates/feos-core/src/density_iteration.rs
@@ -148,7 +148,7 @@ where
             let (_, _, d2pdrho2) = eos.p_dpdrho_d2pdrho2(temperature, rho, molefracs);
 
             if rho > 0.85 * maxdensity {
-                let (sp_p, sp_rho) =
+                let (sp_p, sp_rho, _) =
                     _pressure_spinodal(eos, temperature, initial_density, molefracs)?;
                 rho = sp_rho;
                 error = sp_p - pressure;
@@ -166,7 +166,7 @@ where
                     rho = (rho * 1.1).min(maxdensity)
                 }
             } else if error.is_sign_positive() && d2pdrho2.is_sign_positive() {
-                let (sp_p, sp_rho) =
+                let (sp_p, sp_rho, _) =
                     _pressure_spinodal(eos, temperature, initial_density, molefracs)?;
                 rho = sp_rho;
                 error = sp_p - pressure;
@@ -176,7 +176,7 @@ where
                     rho = (rho * 1.1).min(maxdensity)
                 }
             } else if error.is_sign_negative() && d2pdrho2.is_sign_negative() {
-                let (sp_p, sp_rho) =
+                let (sp_p, sp_rho, _) =
                     _pressure_spinodal(eos, temperature, initial_density, molefracs)?;
                 rho = sp_rho;
                 error = sp_p - pressure;
@@ -241,12 +241,42 @@ pub(crate) fn _pressure_spinodal<E: Residual<N>, N: Dim>(
     temperature: f64,
     rho_init: f64,
     molefracs: &OVector<f64, N>,
-) -> FeosResult<(f64, f64)>
+) -> FeosResult<(f64, f64, f64)>
 where
     DefaultAllocator: Allocator<N>,
 {
-    let (p, rho, _) = _pressure_spinodal_curvature(eos, temperature, rho_init, molefracs)?;
-    Ok((p, rho))
+    let maxiter = 30;
+    let tol = 1e-8;
+
+    let maxdensity = eos.compute_max_density(molefracs);
+    let mut rho = rho_init;
+
+    if rho <= 0.0 {
+        return Err(FeosError::InvalidState(
+            String::from("pressure spinodal"),
+            String::from("density"),
+            rho,
+        ));
+    }
+
+    for _ in 0..maxiter {
+        let (p, dpdrho, d2pdrho2) = eos.p_dpdrho_d2pdrho2(temperature, rho, molefracs);
+        if dpdrho.abs() < tol {
+            return Ok((p, rho, d2pdrho2));
+        }
+        let mut delta_rho = -dpdrho / d2pdrho2;
+        // Check failure mode: d2pdrho2 is zero which makes delta_rho infinite.
+        if !delta_rho.is_finite() {
+            return Err(FeosError::NotConverged("pressure_spinodal".to_owned()));
+        }
+        if delta_rho.abs() > 0.05 * maxdensity {
+            delta_rho = 0.05 * maxdensity * delta_rho.signum()
+        }
+        delta_rho = delta_rho.max(-rho * 0.95); // prevent stepping to rho < 0.0
+        delta_rho = delta_rho.min(maxdensity - rho); // prevent stepping to rho > maxdensity
+        rho += delta_rho;
+    }
+    Err(FeosError::NotConverged("pressure_spinodal".to_owned()))
 }
 
 /// Spinodal of the requested branch (liquid or vapor). Returns `(p, rho)`.
@@ -271,7 +301,7 @@ where
             )));
         }
     };
-    let (p, rho, d2pdrho2) = _pressure_spinodal_curvature(eos, temperature, rho_init, molefracs)?;
+    let (p, rho, d2pdrho2) = _pressure_spinodal(eos, temperature, rho_init, molefracs)?;
     let (on_branch, name) = match branch {
         Liquid => (d2pdrho2 > 0.0, "liquid"),
         Vapor => (d2pdrho2 < 0.0, "vapor"),
@@ -284,49 +314,4 @@ where
             "pressure_spinodal: iteration converged to the wrong branch (requested {name} spinodal)"
         )))
     }
-}
-
-/// Spinodal closest to `rho_init`. Returns `(p, rho, d2p/drho2)`.
-fn _pressure_spinodal_curvature<E: Residual<N>, N: Dim>(
-    eos: &E,
-    temperature: f64,
-    rho_init: f64,
-    molefracs: &OVector<f64, N>,
-) -> FeosResult<(f64, f64, f64)>
-where
-    DefaultAllocator: Allocator<N>,
-{
-    let maxiter = 30;
-    let tol_dpdrho = 1e-10;
-
-    let maxdensity = eos.compute_max_density(molefracs);
-    let mut rho = rho_init;
-
-    if rho <= 0.0 {
-        return Err(FeosError::InvalidState(
-            String::from("pressure spinodal"),
-            String::from("density"),
-            rho,
-        ));
-    }
-
-    for _ in 0..maxiter {
-        let (p, dpdrho, d2pdrho2) = eos.p_dpdrho_d2pdrho2(temperature, rho, molefracs);
-        // Scale tolerance by temperature (unit of derivative).
-        if dpdrho.abs() < tol_dpdrho * temperature {
-            return Ok((p, rho, d2pdrho2));
-        }
-        let mut delta_rho = -dpdrho / d2pdrho2;
-        // Check failure mode: d2pdrho2 is zero which makes delta_rho infinite.
-        if !delta_rho.is_finite() {
-            return Err(FeosError::NotConverged("pressure_spinodal".to_owned()));
-        }
-        if delta_rho.abs() > 0.05 * maxdensity {
-            delta_rho = 0.05 * maxdensity * delta_rho.signum()
-        }
-        delta_rho = delta_rho.max(-rho * 0.95); // prevent stepping to rho < 0.0
-        delta_rho = delta_rho.min(maxdensity - rho); // prevent stepping to rho > maxdensity
-        rho += delta_rho;
-    }
-    Err(FeosError::NotConverged("pressure_spinodal".to_owned()))
 }

--- a/crates/feos-core/src/density_iteration.rs
+++ b/crates/feos-core/src/density_iteration.rs
@@ -119,9 +119,8 @@ where
     }
 
     let maxiter = 50;
-    let mut iterations = 0;
+    let mut converged = false;
     'iteration: for k in 0..maxiter {
-        iterations += 1;
         let (_, mut p, mut dp_drho) = eos.p_dpdrho(temperature, rho, molefracs);
 
         // attempt to correct for poor initial density rho_init
@@ -187,9 +186,9 @@ where
                     rho *= 0.8
                 }
             } else if error.is_sign_negative() && d2pdrho2.is_sign_positive() {
-                let (_, rho_l) = _pressure_spinodal(eos, temperature, 0.8 * maxdensity, molefracs)?;
+                let (_, rho_l) = _pressure_spinodal_branch(eos, temperature, molefracs, Liquid)?;
                 let (sp_v_p, rho_v) =
-                    _pressure_spinodal(eos, temperature, 0.001 * maxdensity, molefracs)?;
+                    _pressure_spinodal_branch(eos, temperature, molefracs, Vapor)?;
                 error = sp_v_p - pressure;
                 if error.is_sign_positive()
                     && (initial_density - rho_v).abs() < (initial_density - rho_l).abs()
@@ -199,9 +198,9 @@ where
                     rho = (rho_l * 1.1).min(maxdensity)
                 }
             } else if error.is_sign_positive() && d2pdrho2.is_sign_negative() {
-                let (_, rho_l) = _pressure_spinodal(eos, temperature, 0.8 * maxdensity, molefracs)?;
+                let (_, rho_l) = _pressure_spinodal_branch(eos, temperature, molefracs, Liquid)?;
                 let (sp_v_p, rho_v) =
-                    _pressure_spinodal(eos, temperature, 0.001 * maxdensity, molefracs)?;
+                    _pressure_spinodal_branch(eos, temperature, molefracs, Vapor)?;
                 error = sp_v_p - pressure;
                 if error.is_sign_negative()
                     && (initial_density - rho_v).abs() > (initial_density - rho_l).abs()
@@ -221,16 +220,22 @@ where
         // Newton step
         rho += delta_rho;
         if error.abs() < f64::max(abstol, rho * reltol) {
+            converged = true;
             break 'iteration;
         }
     }
-    if iterations == maxiter + 1 {
-        Err(FeosError::NotConverged("density_iteration".to_owned()))
-    } else {
+    if converged {
         Ok(rho)
+    } else {
+        Err(FeosError::NotConverged("density_iteration".to_owned()))
     }
 }
 
+/// Spinodal (dp/drho = 0) closest to `rho_init`. Returns `(p, rho)`.
+///
+/// Which spinodal is found depends on the initial density.
+/// If vapor/liquid branch is required, [`_pressure_spinodal_branch`]
+/// can be used, which verifies the result.
 pub(crate) fn _pressure_spinodal<E: Residual<N>, N: Dim>(
     eos: &E,
     temperature: f64,
@@ -240,8 +245,59 @@ pub(crate) fn _pressure_spinodal<E: Residual<N>, N: Dim>(
 where
     DefaultAllocator: Allocator<N>,
 {
+    let (p, rho, _) = _pressure_spinodal_curvature(eos, temperature, rho_init, molefracs)?;
+    Ok((p, rho))
+}
+
+/// Spinodal of the requested branch (liquid or vapor). Returns `(p, rho)`.
+///
+/// Errors if the iteration converged to the other branch.
+pub(crate) fn _pressure_spinodal_branch<E: Residual<N>, N: Dim>(
+    eos: &E,
+    temperature: f64,
+    molefracs: &OVector<f64, N>,
+    branch: DensityInitialization<f64>,
+) -> FeosResult<(f64, f64)>
+where
+    DefaultAllocator: Allocator<N>,
+{
+    let maxdensity = eos.compute_max_density(molefracs);
+    let rho_init = match branch {
+        Liquid => 0.8 * maxdensity,
+        Vapor => 0.001 * maxdensity,
+        InitialDensity(_) => {
+            return Err(FeosError::Error(String::from(
+                "`_pressure_spinodal_branch`: branch must be Liquid or Vapor",
+            )));
+        }
+    };
+    let (p, rho, d2pdrho2) = _pressure_spinodal_curvature(eos, temperature, rho_init, molefracs)?;
+    let (on_branch, name) = match branch {
+        Liquid => (d2pdrho2 > 0.0, "liquid"),
+        Vapor => (d2pdrho2 < 0.0, "vapor"),
+        InitialDensity(_) => unreachable!(),
+    };
+    if on_branch {
+        Ok((p, rho))
+    } else {
+        Err(FeosError::UndeterminedState(format!(
+            "pressure_spinodal: iteration converged to the wrong branch (requested {name} spinodal)"
+        )))
+    }
+}
+
+/// Spinodal closest to `rho_init`. Returns `(p, rho, d2p/drho2)`.
+fn _pressure_spinodal_curvature<E: Residual<N>, N: Dim>(
+    eos: &E,
+    temperature: f64,
+    rho_init: f64,
+    molefracs: &OVector<f64, N>,
+) -> FeosResult<(f64, f64, f64)>
+where
+    DefaultAllocator: Allocator<N>,
+{
     let maxiter = 30;
-    let abstol = 1e-8;
+    let tol_dpdrho = 1e-10;
 
     let maxdensity = eos.compute_max_density(molefracs);
     let mut rho = rho_init;
@@ -256,18 +312,21 @@ where
 
     for _ in 0..maxiter {
         let (p, dpdrho, d2pdrho2) = eos.p_dpdrho_d2pdrho2(temperature, rho, molefracs);
-
+        // Scale tolerance by temperature (unit of derivative).
+        if dpdrho.abs() < tol_dpdrho * temperature {
+            return Ok((p, rho, d2pdrho2));
+        }
         let mut delta_rho = -dpdrho / d2pdrho2;
+        // Check failure mode: d2pdrho2 is zero which makes delta_rho infinite.
+        if !delta_rho.is_finite() {
+            return Err(FeosError::NotConverged("pressure_spinodal".to_owned()));
+        }
         if delta_rho.abs() > 0.05 * maxdensity {
             delta_rho = 0.05 * maxdensity * delta_rho.signum()
         }
         delta_rho = delta_rho.max(-rho * 0.95); // prevent stepping to rho < 0.0
         delta_rho = delta_rho.min(maxdensity - rho); // prevent stepping to rho > maxdensity
         rho += delta_rho;
-
-        if dpdrho.abs() < abstol {
-            return Ok((p, rho));
-        }
     }
     Err(FeosError::NotConverged("pressure_spinodal".to_owned()))
 }

--- a/crates/feos-core/src/phase_equilibria/vle_pure.rs
+++ b/crates/feos-core/src/phase_equilibria/vle_pure.rs
@@ -1,5 +1,5 @@
 use super::{PhaseEquilibrium, TRIVIAL_REL_DEVIATION};
-use crate::density_iteration::{_density_iteration, _pressure_spinodal};
+use crate::density_iteration::{_density_iteration, _pressure_spinodal_branch};
 use crate::equation_of_state::{Residual, Subset};
 use crate::errors::{FeosError, FeosResult};
 use crate::state::{Contributions, DensityInitialization, State};
@@ -228,10 +228,9 @@ where
     DefaultAllocator: Allocator<N>,
 {
     let x = E::pure_molefracs();
-    let maxdensity = eos.compute_max_density(&x);
     let t = temperature.into_reduced();
-    let (p_l, _) = _pressure_spinodal(eos, t, 0.8 * maxdensity, &x)?;
-    let (p_v, _) = _pressure_spinodal(eos, t, 0.001 * maxdensity, &x)?;
+    let (p_l, _) = _pressure_spinodal_branch(eos, t, &x, DensityInitialization::Liquid)?;
+    let (p_v, _) = _pressure_spinodal_branch(eos, t, &x, DensityInitialization::Vapor)?;
     let p = 0.5 * (0.0_f64.max(p_l) + p_v);
     let rho_l = _density_iteration(eos, t, p, &x, DensityInitialization::Liquid)?;
     let rho_v = _density_iteration(eos, t, p, &x, DensityInitialization::Vapor)?;

--- a/crates/feos/src/pcsaft/eos/pcsaft_binary.rs
+++ b/crates/feos/src/pcsaft/eos/pcsaft_binary.rs
@@ -299,7 +299,7 @@ fn association<D: DualNum<f64> + Copy>(
         );
 
         let [g1, g2] = g.data.0[0];
-        let [[j11, j12], [j21, j22]] = j.data.0;
+        let [[j11, j21], [j12, j22]] = j.data.0;
         let det = j11 * j22 - j12 * j21;
 
         let delta_xa1 = (j22 * g1 - j12 * g2) / det;
@@ -526,9 +526,9 @@ pub mod test {
     };
     use approx::assert_relative_eq;
     use feos_core::parameter::{AssociationRecord, PureRecord};
-    use feos_core::{Contributions::Total, FeosResult, State};
+    use feos_core::{Contributions::Total, DensityInitialization, FeosResult, State};
     use nalgebra::{dvector, vector};
-    use quantity::{KELVIN, KILO, METER, MOL};
+    use quantity::{BAR, KELVIN, KILO, METER, MOL};
 
     pub fn pcsaft_binary() -> FeosResult<(PcSaftBinary<f64, 8>, PcSaft)> {
         let params = [
@@ -560,7 +560,7 @@ pub mod test {
         let (pcsaft, eos) = pcsaft_binary()?;
 
         let temperature = 300.0 * KELVIN;
-        let volume = 2.3 * METER * METER * METER;
+        let volume = 0.3 * METER * METER * METER;
         let moles = dvector![1.3, 2.5] * KILO * MOL;
 
         let state = State::new_nvt(&&eos, temperature, volume, &moles)?;
@@ -589,6 +589,9 @@ pub mod test {
         println!("\nChemical potential:\n{}", mu_feos.get(0));
         println!("{}", mu_ad.get(0));
         assert_relative_eq!(mu_feos.get(0), mu_ad.get(0), max_relative = 1e-14);
+        println!("{}", mu_feos.get(1));
+        println!("{}", mu_ad.get(1));
+        assert_relative_eq!(mu_feos.get(1), mu_ad.get(1), max_relative = 1e-14);
 
         println!("\nPressure:\n{p_feos}");
         println!("{p_ad}");
@@ -602,6 +605,207 @@ pub mod test {
         println!("{h_ad}");
         assert_relative_eq!(h_feos, h_ad, max_relative = 1e-14);
 
+        Ok(())
+    }
+
+    /// Two identical associating components: the chemical potentials must be equal.
+    #[test]
+    fn test_pcsaft_binary_identical_assoc() -> FeosResult<()> {
+        // Pure parameters: parameters/pcsaft/esper2023.json
+        let methanol = [
+            2.25965, 2.83016, 183.58634, 0.0, 0.08716, 2465.13545, 1.0, 1.0,
+        ];
+        let params = [methanol, methanol];
+        let kij = 0.0;
+        let records = params.map(|p| {
+            PureRecord::with_association(
+                Default::default(),
+                0.0,
+                PcSaftRecord::new(p[0], p[1], p[2], p[3], 0.0, None, None, None),
+                vec![AssociationRecord::new(
+                    Some(PcSaftAssociationRecord::new(p[4], p[5])),
+                    p[6],
+                    p[7],
+                    0.0,
+                )],
+            )
+        });
+        let params_generic =
+            PcSaftParameters::new_binary(records, Some(PcSaftBinaryRecord::new(kij)), vec![])?;
+        let eos_generic = PcSaft::new(params_generic);
+        let eos_explicit = PcSaftBinary::new(params, kij);
+
+        let temperature = 330.0 * KELVIN;
+        let volume = 1.0 / 24.0 * METER * METER * METER;
+        let x = [0.7, 0.3];
+
+        let state = State::new_nvt(
+            &&eos_generic,
+            temperature,
+            volume,
+            &dvector![x[0], x[1]] * KILO * MOL,
+        )?;
+        let mu_feos = state.residual_chemical_potential();
+        let a_feos = state.residual_molar_helmholtz_energy();
+        let state = State::new_nvt(
+            &eos_explicit,
+            temperature,
+            volume,
+            vector![x[0], x[1]] * KILO * MOL,
+        )?;
+        let mu_ad = state.residual_chemical_potential();
+        let a_ad = state.residual_molar_helmholtz_energy();
+
+        println!("a     generic {a_feos}  specific {a_ad}");
+        println!(
+            "mu[0] generic {}  specific {}",
+            mu_feos.get(0),
+            mu_ad.get(0)
+        );
+        println!(
+            "mu[1] generic {}  specific {}",
+            mu_feos.get(1),
+            mu_ad.get(1)
+        );
+        assert_relative_eq!(a_feos, a_ad, max_relative = 1e-12);
+        assert_relative_eq!(mu_feos.get(0), mu_feos.get(1), max_relative = 1e-12);
+        assert_relative_eq!(mu_ad.get(0), mu_ad.get(1), max_relative = 1e-12);
+        assert_relative_eq!(mu_feos.get(0), mu_ad.get(0), max_relative = 1e-12);
+        assert_relative_eq!(mu_feos.get(1), mu_ad.get(1), max_relative = 1e-12);
+
+        // second derivatives (pressure derivatives) go through the association Newton too
+        let state_feos = State::new_nvt(
+            &&eos_generic,
+            temperature,
+            volume,
+            &dvector![x[0], x[1]] * KILO * MOL,
+        )?;
+        let p_feos = state_feos.pressure(Total);
+        let p_ad = state.pressure(Total);
+        println!("p     generic {p_feos}  specific {p_ad}");
+        assert_relative_eq!(p_feos, p_ad, max_relative = 1e-12);
+        let dpdv_feos = state_feos.dp_dv(Total);
+        let dpdv_ad = state.dp_dv(Total);
+        println!("dp/dv generic {:?}  specific {:?}", dpdv_feos, dpdv_ad);
+        assert_relative_eq!(dpdv_feos, dpdv_ad, max_relative = 1e-12);
+        let dmu_feos = state_feos.dmu_res_dt();
+        let dmu_ad = state.dmu_res_dt();
+        println!(
+            "dmu/dT generic {} {}  specific {} {}",
+            dmu_feos.get(0),
+            dmu_feos.get(1),
+            dmu_ad.get(0),
+            dmu_ad.get(1)
+        );
+        assert_relative_eq!(dmu_feos.get(0), dmu_ad.get(0), max_relative = 1e-12);
+        assert_relative_eq!(dmu_feos.get(1), dmu_ad.get(1), max_relative = 1e-12);
+        Ok(())
+    }
+
+    /// Two different, strongly associating components (methanol + water) with
+    /// a nonzero k_ij at liquid density, compared against the general PC-SAFT.
+    ///
+    /// Pure parameters: parameters/pcsaft/esper2023.json
+    /// Binary parameter: parameters/pcsaft/rehner2023_binary.json
+    #[test]
+    fn test_pcsaft_binary_methanol_water() -> FeosResult<()> {
+        let methanol = [
+            2.25965, 2.83016, 183.58634, 0.0, 0.08716, 2465.13545, 1.0, 1.0,
+        ];
+        let water = [
+            2.36948, 2.15072, 230.71557, 0.0, 0.35319, 2195.10176, 1.0, 1.0,
+        ];
+        let params = [methanol, water];
+        let kij = -0.0159473671673194;
+        let records = params.map(|p| {
+            PureRecord::with_association(
+                Default::default(),
+                0.0,
+                PcSaftRecord::new(p[0], p[1], p[2], p[3], 0.0, None, None, None),
+                vec![AssociationRecord::new(
+                    Some(PcSaftAssociationRecord::new(p[4], p[5])),
+                    p[6],
+                    p[7],
+                    0.0,
+                )],
+            )
+        });
+        let params_generic =
+            PcSaftParameters::new_binary(records, Some(PcSaftBinaryRecord::new(kij)), vec![])?;
+        let generic = PcSaft::new(params_generic);
+        let specific = PcSaftBinary::new(params, kij);
+
+        let temperature = 320.0 * KELVIN;
+
+        for x1 in [0.1, 0.5, 0.9] {
+            let x = [x1, 1.0 - x1];
+            // liquid at 1 bar according to the general PC-SAFT
+            let state_generic = State::new_npt(
+                &&generic,
+                temperature,
+                BAR,
+                &dvector![x[0], x[1]] * KILO * MOL,
+                Some(DensityInitialization::Liquid),
+            )?;
+            let volume = state_generic.volume()?;
+            let state_specific = State::new_nvt(
+                &specific,
+                temperature,
+                volume,
+                vector![x[0], x[1]] * KILO * MOL,
+            )?;
+
+            let a_generic = state_generic.residual_molar_helmholtz_energy();
+            let a_specific = state_specific.residual_molar_helmholtz_energy();
+            let mu_generic = state_generic.residual_chemical_potential();
+            let mu_specific = state_specific.residual_chemical_potential();
+            let p_generic = state_generic.pressure(Total);
+            let p_specific = state_specific.pressure(Total);
+            let dpdv_generic = state_generic.dp_dv(Total);
+            let dpdv_specific = state_specific.dp_dv(Total);
+            let dmu_generic = state_generic.dmu_res_dt();
+            let dmu_specific = state_specific.dmu_res_dt();
+
+            println!("x1 = {x1}");
+            println!("  a      generic {a_generic}  specific {a_specific}");
+            println!(
+                "  mu[0]  generic {}  specific {}",
+                mu_generic.get(0),
+                mu_specific.get(0)
+            );
+            println!(
+                "  mu[1]  generic {}  specific {}",
+                mu_generic.get(1),
+                mu_specific.get(1)
+            );
+            println!("  p      generic {p_generic}  specific {p_specific}");
+            println!(
+                "  dp/dv  generic {:?}  specific {:?}",
+                dpdv_generic, dpdv_specific
+            );
+            println!(
+                "  dmu/dT generic {} {}  specific {} {}",
+                dmu_generic.get(0),
+                dmu_generic.get(1),
+                dmu_specific.get(0),
+                dmu_specific.get(1)
+            );
+            assert_relative_eq!(a_generic, a_specific, max_relative = 1e-12);
+            assert_relative_eq!(mu_generic.get(0), mu_specific.get(0), max_relative = 1e-12);
+            assert_relative_eq!(mu_generic.get(1), mu_specific.get(1), max_relative = 1e-12);
+            assert_relative_eq!(p_generic, p_specific, max_relative = 1e-9); // requires small tol
+            assert_relative_eq!(dpdv_generic, dpdv_specific, max_relative = 1e-12);
+            assert_relative_eq!(
+                dmu_generic.get(0),
+                dmu_specific.get(0),
+                max_relative = 1e-12
+            );
+            assert_relative_eq!(
+                dmu_generic.get(1),
+                dmu_specific.get(1),
+                max_relative = 1e-12
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
- fixed wrong jacobian layout in binary association (`nalgebra` is col-major) 
- pressure spinodal: fixed inconsistency with iteration returning density including additional step change, changed order of operations slightly.
- density iteration: fixed convergence guard (current version always returns `Ok()` branch)
- add version for spinodal function for a specified phase with verification of that phase
- minor: in spinodal, scaled tolerance of derivative by temperature